### PR TITLE
Travis ci fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,8 @@ if(NOT MSVC)
         -pedantic \
         -fsized-deallocation \
         -fdiagnostics-color=always \
-        -Wunreachable-code"
+        -Wunreachable-code \
+	-std=c++14"
     )
     if (NOT CMAKE_COMPILER_IS_GNUCXX)
         # -Wshadow is buggy and broken in GCC, so do not enable it.

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -39,16 +39,15 @@ endif()
 include(ExternalProject)
 
 set(BOOST_URL
-    https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2)
+    https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.bz2)
 set(BOOST_SHA256
-    7f6130bc3cf65f56a618888ce9d5ea704fa10b462be126ad053e80e553d6d8b7)
+    8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406)
 
 set(
   MTXCLIENT_URL
-  https://github.com/Nheko-Reborn/mtxclient/archive/5dc567a4a494a2152658c6586e0d7637ecba85b4.tar.gz
-  )
+  https://github.com/Nheko-Reborn/mtxclient/archive/49226a29626ff6c801931e48a12d7669e8ebcb23.tar.gz)
 set(MTXCLIENT_HASH
-  afea7b9681657233f6e833cccd161af66e320654be0c6bcffba855420e37f415)
+  1538e7aa83b56e8ab5cca3598ba03a668937089698b8bd7495d6e65607e52d10)
 set(
   TWEENY_URL
   https://github.com/mobius3/tweeny/archive/b94ce07cfb02a0eb8ac8aaf66137dabdaea857cf.tar.gz

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -45,9 +45,9 @@ set(BOOST_SHA256
 
 set(
   MTXCLIENT_URL
-  https://github.com/Nheko-Reborn/mtxclient/archive/49226a29626ff6c801931e48a12d7669e8ebcb23.tar.gz)
+  https://github.com/Nheko-Reborn/mtxclient/archive/3edf66b9854b496f9fe992660b0d3d66fd8af594.tar.gz)
 set(MTXCLIENT_HASH
-  1538e7aa83b56e8ab5cca3598ba03a668937089698b8bd7495d6e65607e52d10)
+  00ce1669fda6362181e887d4a71e69b214b8431c5a2dba054a8095449348718b)
 set(
   TWEENY_URL
   https://github.com/mobius3/tweeny/archive/b94ce07cfb02a0eb8ac8aaf66137dabdaea857cf.tar.gz

--- a/deps/cmake/Boost.cmake
+++ b/deps/cmake/Boost.cmake
@@ -16,7 +16,7 @@ ExternalProject_Add(
   CONFIGURE_COMMAND ${DEPS_BUILD_DIR}/boost/bootstrap.sh
     --with-libraries=random,thread,system,iostreams,atomic,chrono,date_time,regex
     --prefix=${DEPS_INSTALL_DIR}
-  BUILD_COMMAND ${DEPS_BUILD_DIR}/boost/b2 -d0 cxxstd=14 variant=release link=static threading=multi --layout=system
+  BUILD_COMMAND ${DEPS_BUILD_DIR}/boost/b2 -d0 cxxstd=14 variant=release link=shared runtime-link=shared threading=multi --layout=system
   INSTALL_COMMAND ${DEPS_BUILD_DIR}/boost/b2 -d0 install
 )
 


### PR DESCRIPTION
Update Travis CI Build to 1.69.0 and link mtxclient as a shared library.