### PR TITLE
Removed RPATH from compiled binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,6 +456,8 @@ if(EXTERNAL_PROJECT_DEPS)
     add_dependencies(nheko ${EXTERNAL_PROJECT_DEPS})
 endif()
 
+set_target_properties(nheko PROPERTIES SKIP_BUILD_RPATH TRUE)
+
 if(UNIX AND NOT APPLE)
     install (TARGETS nheko RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
     install (FILES "resources/nheko-16.png" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/16x16/apps" RENAME "nheko.png")


### PR DESCRIPTION
Rpath is not needed to run installed binaries. Most of GNU/Linux distributions strictly forbid it.

See also:

 * https://lintian.debian.org/tags/binary-or-shlib-defines-rpath.html
 * https://wiki.debian.org/RpathIssue
 * https://docs.fedoraproject.org/en-US/packaging-guidelines/#_beware_of_rpath