### PR TITLE
Add .well-known support

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -46,10 +46,10 @@ set(BOOST_SHA256
 
 set(
   MTXCLIENT_URL
-  https://github.com/Nheko-Reborn/mtxclient/archive/8c6e9ba8fc18ed9dd69d014eebd1ebff08701d6d.tar.gz
+  https://github.com/Nheko-Reborn/mtxclient/archive/32065798a2efa205052fcd2f470c52326a46d0b9.tar.gz
   )
 set(MTXCLIENT_HASH
-  b31ec18b9d7d74db1a17b930bfa570fa1cede56cc49b43948b7d86c396f2f3d3)
+  3ddc6a482b5f388533bbaa69c44f1621d65a4e38fcb6cafaff83330975ea7e2b)
 set(
   TWEENY_URL
   https://github.com/mobius3/tweeny/archive/b94ce07cfb02a0eb8ac8aaf66137dabdaea857cf.tar.gz

--- a/resources/langs/nheko_de.ts
+++ b/resources/langs/nheko_de.ts
@@ -4,38 +4,108 @@
 <context>
     <name>AudioItem</name>
     <message>
-        <location filename="../../src/timeline/widgets/AudioItem.cc" line="+125"/>
+        <location filename="../../src/timeline/widgets/AudioItem.cpp" line="+117"/>
         <source>Save File</source>
         <translation>Datei speichern</translation>
     </message>
 </context>
 <context>
-    <name>DateSeparator</name>
+    <name>ChatPage</name>
     <message>
-        <location filename="../../src/timeline/TimelineView.cc" line="+54"/>
-        <source>Today</source>
-        <translation>Heute</translation>
+        <location filename="../../src/ChatPage.cpp" line="+309"/>
+        <source>Failed to upload image. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+45"/>
+        <source>Failed to upload file. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+43"/>
+        <source>Failed to upload audio. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+42"/>
+        <source>Failed to upload video. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+376"/>
+        <source>Failed to restore OLM account. Please login again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Failed to restore save data. Please login again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+169"/>
+        <source>Failed to setup encryption keys. Server response: %1 %2. Please try again later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+51"/>
+        <location line="+153"/>
+        <source>Please try to login again: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-45"/>
+        <source>Room creation failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Failed to leave room: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommunitiesListItem</name>
+    <message>
+        <location filename="../../src/CommunitiesListItem.cpp" line="+130"/>
+        <source>All rooms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Favourite rooms</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
-        <source>Yesterday</source>
-        <translation>Gestern</translation>
+        <source>Low priority rooms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+2"/>
+        <source> (tag)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source> (community)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>EditModal</name>
     <message>
-        <location filename="../../src/dialogs/RoomSettings.cpp" line="+34"/>
-        <source>APPLY</source>
-        <translation>EINSETZEN</translation>
+        <location filename="../../src/dialogs/RoomSettings.cpp" line="+58"/>
+        <source>Apply</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>CANCEL</source>
-        <translation>ABBRECHEN</translation>
+        <location line="+1"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+10"/>
         <source>Name</source>
         <translation>Titel</translation>
     </message>
@@ -48,7 +118,7 @@
 <context>
     <name>FileItem</name>
     <message>
-        <location filename="../../src/timeline/widgets/FileItem.cc" line="+111"/>
+        <location filename="../../src/timeline/widgets/FileItem.cpp" line="+106"/>
         <source>Save File</source>
         <translation>Datei speichern</translation>
     </message>
@@ -56,15 +126,23 @@
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/timeline/widgets/ImageItem.cc" line="+229"/>
+        <location filename="../../src/timeline/widgets/ImageItem.cpp" line="+238"/>
         <source>Save image</source>
         <translation>Bild speichern</translation>
     </message>
 </context>
 <context>
+    <name>InviteeItem</name>
+    <message>
+        <location filename="../../src/InviteeItem.cpp" line="+17"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoginPage</name>
     <message>
-        <location filename="../../src/LoginPage.cc" line="+79"/>
+        <location filename="../../src/LoginPage.cpp" line="+79"/>
         <source>Matrix ID</source>
         <translation>Matrix-ID</translation>
     </message>
@@ -79,56 +157,63 @@
         <translation>Passwort</translation>
     </message>
     <message>
+        <location line="+4"/>
+        <source>Device name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+19"/>
         <source>LOGIN</source>
         <translation>ANMELDEN</translation>
     </message>
     <message>
-        <location line="+128"/>
+        <location line="+83"/>
+        <source>Autodiscovery failed. Received malformed response.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Autodiscovery failed. Unknown error when requesting .well-known.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>The required endpoints were not found. Possibly not a Matrix server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Received malformed response. Make sure the homeserver domain is valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>An unknown error occured. Make sure the homeserver domain is valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+60"/>
         <source>Empty password</source>
         <translation>Leeres Passwort</translation>
     </message>
 </context>
 <context>
-    <name>MatrixClient</name>
-    <message>
-        <location filename="../../src/MatrixClient.cc" line="+164"/>
-        <source>Wrong username or password</source>
-        <translation>Falscher Benutzername oder Passwort</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Login endpoint was not found on the server</source>
-        <translation>Login-Endpunkt wurde auf dem Server nicht gefunden</translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>An unknown error occured. Please try again.</source>
-        <translation>Ein unbekannter Fehler trat auf. Bitte erneut versuchen.</translation>
-    </message>
-    <message>
-        <location line="+23"/>
-        <source>Malformed response. Possibly not a Matrix server</source>
-        <translation>Ungewöhnliche Antwort. Vielleicht kein Matrix-Server</translation>
-    </message>
-</context>
-<context>
     <name>MemberList</name>
     <message>
-        <location filename="../../src/dialogs/MemberList.cpp" line="+79"/>
+        <location filename="../../src/dialogs/MemberList.cpp" line="+96"/>
         <source>Room members</source>
         <translation>Teilnehmerliste</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <source>SHOW MORE</source>
-        <translation>MEHR ZEIGEN</translation>
+        <location line="+33"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>QuickSwitcher</name>
     <message>
-        <location filename="../../src/QuickSwitcher.cc" line="+70"/>
+        <location filename="../../src/QuickSwitcher.cpp" line="+71"/>
         <source>Search for a room...</source>
         <translation>Raum suchen...</translation>
     </message>
@@ -136,7 +221,7 @@
 <context>
     <name>RegisterPage</name>
     <message>
-        <location filename="../../src/RegisterPage.cc" line="+76"/>
+        <location filename="../../src/RegisterPage.cpp" line="+77"/>
         <source>Username</source>
         <translation>Benutzername</translation>
     </message>
@@ -156,12 +241,12 @@
         <translation>Heimserver</translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+16"/>
         <source>REGISTER</source>
         <translation>REGISTRIEREN</translation>
     </message>
     <message>
-        <location line="+76"/>
+        <location line="+93"/>
         <source>Invalid username</source>
         <translation>Ungültiger Benutzername</translation>
     </message>
@@ -182,14 +267,22 @@
     </message>
 </context>
 <context>
+    <name>ReplyPopup</name>
+    <message>
+        <location filename="../../src/popups/ReplyPopup.cpp" line="+45"/>
+        <source>Logout</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>RoomInfoListItem</name>
     <message>
-        <location filename="../../src/RoomInfoListItem.cc" line="+78"/>
+        <location filename="../../src/RoomInfoListItem.cpp" line="+92"/>
         <source>Leave room</source>
         <translation>Raum verlassen</translation>
     </message>
     <message>
-        <location line="+153"/>
+        <location line="+174"/>
         <source>Accept</source>
         <translation>Akzeptieren </translation>
     </message>
@@ -202,7 +295,12 @@
 <context>
     <name>SideBarActions</name>
     <message>
-        <location filename="../../src/SideBarActions.cc" line="+36"/>
+        <location filename="../../src/SideBarActions.cpp" line="+38"/>
+        <source>User settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <source>Create new room</source>
         <translation>Neuen Raum erstellen</translation>
     </message>
@@ -211,16 +309,65 @@
         <source>Join a room</source>
         <translation>Raum betreten</translation>
     </message>
+    <message>
+        <location line="+16"/>
+        <source>Start a new chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>Room directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StatusIndicator</name>
+    <message>
+        <location filename="../../src/timeline/TimelineItem.cpp" line="+106"/>
+        <source>Encrypted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Delivered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Seen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Sent</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TextInputWidget</name>
     <message>
-        <location filename="../../src/TextInputWidget.cc" line="+445"/>
+        <location filename="../../src/TextInputWidget.cpp" line="+506"/>
+        <source>Send a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location filename="../../src/TextInputWidget.h" line="+168"/>
         <source>Write a message...</source>
         <translation>Schreibe eine Nachricht...</translation>
     </message>
     <message>
-        <location line="+108"/>
+        <location line="+31"/>
+        <source>Send a message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Emoji</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+75"/>
         <source>Select a file</source>
         <translation>Datei auswählen</translation>
     </message>
@@ -229,11 +376,47 @@
         <source>All Files (*)</source>
         <translation>Alle Dateien (*)</translation>
     </message>
+    <message>
+        <location filename="../../src/TextInputWidget.h" line="-5"/>
+        <source>Connection lost. Nheko is trying to re-connect...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TimelineItem</name>
+    <message>
+        <location filename="../../src/timeline/TimelineItem.cpp" line="+85"/>
+        <source>Message redaction failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Reply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TimelineView</name>
+    <message>
+        <location filename="../../src/timeline/TimelineView.cpp" line="+245"/>
+        <source>Encryption is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TopRoomBar</name>
     <message>
-        <location filename="../../src/TopRoomBar.cc" line="+87"/>
+        <location filename="../../src/TopRoomBar.cpp" line="+79"/>
+        <source>Room options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+28"/>
         <source>Invite users</source>
         <translation>Benutzer einladen</translation>
     </message>
@@ -256,7 +439,7 @@
 <context>
     <name>TrayIcon</name>
     <message>
-        <location filename="../../src/TrayIcon.cc" line="+116"/>
+        <location filename="../../src/TrayIcon.cpp" line="+120"/>
         <source>Show</source>
         <translation>Zeigen</translation>
     </message>
@@ -269,7 +452,7 @@
 <context>
     <name>TypingDisplay</name>
     <message>
-        <location filename="../../src/TypingDisplay.cc" line="+26"/>
+        <location filename="../../src/TypingDisplay.cpp" line="+45"/>
         <source> is typing</source>
         <translation> tippt</translation>
     </message>
@@ -280,14 +463,17 @@
     </message>
 </context>
 <context>
+    <name>UserInfoWidget</name>
+    <message>
+        <location filename="../../src/UserInfoWidget.cpp" line="+87"/>
+        <source>Logout</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>UserSettingsPage</name>
     <message>
-        <location filename="../../src/UserSettingsPage.cc" line="+121"/>
-        <source>User Settings</source>
-        <translation>Benutzereinstellungen</translation>
-    </message>
-    <message>
-        <location line="+15"/>
+        <location filename="../../src/UserSettingsPage.cpp" line="+156"/>
         <source>Minimize to tray</source>
         <translation>Ins Benachrichtigungsfeld minimieren</translation>
     </message>
@@ -297,12 +483,7 @@
         <translation>Im Benachrichtigungsfeld starten</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <source>Re-order rooms based on activity</source>
-        <translation>Räume nach Aktivität sortieren</translation>
-    </message>
-    <message>
-        <location line="+9"/>
+        <location line="+11"/>
         <source>Group&apos;s sidebar</source>
         <translation>Gruppen-Seitenleiste</translation>
     </message>
@@ -318,19 +499,115 @@
     </message>
     <message>
         <location line="+9"/>
+        <source>Desktop notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Scale factor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Font Family</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+17"/>
         <source>Theme</source>
         <translation>Erscheinungsbild</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+27"/>
+        <source>Device ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Device Fingerprint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Session Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>IMPORT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>EXPORT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>ENCRYPTION</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>GENERAL</source>
         <translation>ALLGEMEINES</translation>
+    </message>
+    <message>
+        <location line="+150"/>
+        <source>Open Sessions File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <location line="+18"/>
+        <location line="+9"/>
+        <location line="+2"/>
+        <location line="+2"/>
+        <location line="+19"/>
+        <location line="+10"/>
+        <location line="+18"/>
+        <location line="+2"/>
+        <location line="+2"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-73"/>
+        <location line="+32"/>
+        <source>File Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-31"/>
+        <source>Enter the passphrase to decrypt the file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+32"/>
+        <source>The password cannot be empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-8"/>
+        <source>Enter passphrase to encrypt your session keys:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>File to save the exported session keys</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WelcomePage</name>
     <message>
-        <location filename="../../src/WelcomePage.cc" line="+44"/>
+        <location filename="../../src/WelcomePage.cpp" line="+46"/>
         <source>Welcome to nheko! The desktop client for the Matrix protocol.</source>
         <translation>Willkommen bei nheko, dem Desktop-Client für das Matrix-Protokoll.</translation>
     </message>
@@ -340,12 +617,12 @@
         <translation>Genieße deinen Aufenthalt!</translation>
     </message>
     <message>
-        <location line="+19"/>
+        <location line="+23"/>
         <source>REGISTER</source>
         <translation>REGISTRIEREN</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+5"/>
         <source>LOGIN</source>
         <translation>ANMELDEN</translation>
     </message>
@@ -353,12 +630,17 @@
 <context>
     <name>dialogs::CreateRoom</name>
     <message>
-        <location filename="../../src/dialogs/CreateRoom.cc" line="+32"/>
-        <source>CANCEL</source>
-        <translation>ABBRECHEN</translation>
+        <location filename="../../src/dialogs/CreateRoom.cpp" line="+36"/>
+        <source>Create room</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+2"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Abbrechen</translation>
+    </message>
+    <message>
+        <location line="+10"/>
         <source>Name</source>
         <translation>Titel</translation>
     </message>
@@ -378,12 +660,12 @@
         <translation>Raumsichtbarkeit</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+8"/>
         <source>Room Preset</source>
         <translation>Raumvorlage</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+9"/>
         <source>Direct Chat</source>
         <translation>Direkter Chat</translation>
     </message>
@@ -391,12 +673,12 @@
 <context>
     <name>dialogs::InviteUsers</name>
     <message>
-        <location filename="../../src/dialogs/InviteUsers.cc" line="+36"/>
-        <source>CANCEL</source>
-        <translation>ABBRECHEN</translation>
+        <location filename="../../src/dialogs/InviteUsers.cpp" line="+41"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+8"/>
         <source>User ID to invite</source>
         <translation>Benutzer-ID, die eingeladen werden soll</translation>
     </message>
@@ -404,12 +686,17 @@
 <context>
     <name>dialogs::JoinRoom</name>
     <message>
-        <location filename="../../src/dialogs/JoinRoom.cc" line="+30"/>
-        <source>CANCEL</source>
-        <translation>ABBRECHEN</translation>
+        <location filename="../../src/dialogs/JoinRoom.cpp" line="+30"/>
+        <source>Join</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+2"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Abbrechen</translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <source>Room ID or alias</source>
         <translation>Raum-ID oder -Alias</translation>
     </message>
@@ -417,12 +704,12 @@
 <context>
     <name>dialogs::LeaveRoom</name>
     <message>
-        <location filename="../../src/dialogs/LeaveRoom.cc" line="+29"/>
-        <source>CANCEL</source>
-        <translation>ABBRECHEN</translation>
+        <location filename="../../src/dialogs/LeaveRoom.cpp" line="+31"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+8"/>
         <source>Are you sure you want to leave?</source>
         <translation>Willst du wirklich den Raum verlassen?</translation>
     </message>
@@ -430,12 +717,12 @@
 <context>
     <name>dialogs::Logout</name>
     <message>
-        <location filename="../../src/dialogs/Logout.cc" line="+47"/>
-        <source>CANCEL</source>
-        <translation>ABBRECHEN</translation>
+        <location filename="../../src/dialogs/Logout.cpp" line="+47"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+8"/>
         <source>Logout. Are you sure?</source>
         <translation>Willst du dich wirklich abmelden?</translation>
     </message>
@@ -443,7 +730,7 @@
 <context>
     <name>dialogs::PreviewUploadOverlay</name>
     <message>
-        <location filename="../../src/dialogs/PreviewUploadOverlay.cc" line="+41"/>
+        <location filename="../../src/dialogs/PreviewUploadOverlay.cpp" line="+42"/>
         <source>Upload</source>
         <translation>Hochladen</translation>
     </message>
@@ -453,7 +740,7 @@
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+84"/>
         <source>Media type: %1
 Media size: %2
 </source>
@@ -465,14 +752,14 @@ Medien-Größe: %2
 <context>
     <name>dialogs::ReCaptcha</name>
     <message>
-        <location filename="../../src/dialogs/ReCaptcha.cpp" line="+34"/>
-        <source>CONFIRM</source>
-        <translation>BESTÄTIGEN</translation>
+        <location filename="../../src/dialogs/ReCaptcha.cpp" line="+31"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>CANCEL</source>
-        <translation>ABBRECHEN</translation>
+        <location line="+1"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+11"/>
@@ -483,20 +770,40 @@ Medien-Größe: %2
 <context>
     <name>dialogs::ReadReceipts</name>
     <message>
-        <location filename="../../src/dialogs/ReadReceipts.cc" line="+98"/>
+        <location filename="../../src/dialogs/ReadReceipts.cpp" line="+119"/>
         <source>Read receipts</source>
         <translation>Lesebestätigungen</translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dialogs::RoomSettings</name>
     <message>
-        <location filename="../../src/dialogs/RoomSettings.cpp" line="+147"/>
-        <source>CANCEL</source>
-        <translation>ABBRECHEN</translation>
+        <location filename="../../src/dialogs/RoomSettings.cpp" line="+113"/>
+        <source>Settings</source>
+        <translation type="unfinished">Einstellungen</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+3"/>
+        <source>Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Internal ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Notifications</source>
         <translation>Benachrichtigungen</translation>
     </message>
@@ -516,7 +823,7 @@ Medien-Größe: %2
         <translation>Alle Nachrichten</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+7"/>
         <source>Room access</source>
         <translation>Raumzugang</translation>
     </message>
@@ -535,11 +842,115 @@ Medien-Größe: %2
         <source>Invited users</source>
         <translation>Nur Eingeladene</translation>
     </message>
+    <message>
+        <location line="+50"/>
+        <source>Encryption</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>End-to-End Encryption</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Encryption is currently experimental and things might break unexpectedly. &lt;br&gt;Please take note that it can&apos;t be disabled afterwards.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <source>Respond to key requests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Whether or not the client should respond automatically with the session keys
+ upon request. Use with caution, this is a temporary measure to test the
+ E2E implementation until device verification is completed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+53"/>
+        <source>%n member(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+70"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+69"/>
+        <source>Failed to enable encryption: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+149"/>
+        <source>Select an avatar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>All Files (*)</source>
+        <translation type="unfinished">Alle Dateien (*)</translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The selected media is not an image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Error while reading media: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <location line="+20"/>
+        <source>Failed to upload image: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dialogs::UserProfile</name>
+    <message>
+        <location filename="../../src/dialogs/UserProfile.cpp" line="+63"/>
+        <source>Ban the user from the room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Ignore messages from this user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Kick the user from the room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Start a conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+57"/>
+        <source>Devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>emoji::Panel</name>
     <message>
-        <location filename="../../src/emoji/Panel.cc" line="+125"/>
+        <location filename="../../src/emoji/Panel.cpp" line="+125"/>
         <source>Smileys &amp; People</source>
         <translation>Smileys &amp; Personen</translation>
     </message>

--- a/resources/langs/nheko_el.ts
+++ b/resources/langs/nheko_el.ts
@@ -4,38 +4,108 @@
 <context>
     <name>AudioItem</name>
     <message>
-        <location filename="../../src/timeline/widgets/AudioItem.cc" line="+125"/>
+        <location filename="../../src/timeline/widgets/AudioItem.cpp" line="+117"/>
         <source>Save File</source>
         <translation>Αποθήκευση</translation>
     </message>
 </context>
 <context>
-    <name>DateSeparator</name>
+    <name>ChatPage</name>
     <message>
-        <location filename="../../src/timeline/TimelineView.cc" line="+54"/>
-        <source>Today</source>
-        <translation>Σήμερα</translation>
+        <location filename="../../src/ChatPage.cpp" line="+309"/>
+        <source>Failed to upload image. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+45"/>
+        <source>Failed to upload file. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+43"/>
+        <source>Failed to upload audio. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+42"/>
+        <source>Failed to upload video. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+376"/>
+        <source>Failed to restore OLM account. Please login again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Failed to restore save data. Please login again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+169"/>
+        <source>Failed to setup encryption keys. Server response: %1 %2. Please try again later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+51"/>
+        <location line="+153"/>
+        <source>Please try to login again: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-45"/>
+        <source>Room creation failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Failed to leave room: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommunitiesListItem</name>
+    <message>
+        <location filename="../../src/CommunitiesListItem.cpp" line="+130"/>
+        <source>All rooms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Favourite rooms</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
-        <source>Yesterday</source>
-        <translation>Χθές</translation>
+        <source>Low priority rooms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+2"/>
+        <source> (tag)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source> (community)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>EditModal</name>
     <message>
-        <location filename="../../src/dialogs/RoomSettings.cpp" line="+34"/>
-        <source>APPLY</source>
+        <location filename="../../src/dialogs/RoomSettings.cpp" line="+58"/>
+        <source>Apply</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>CANCEL</source>
-        <translation type="unfinished">ΑΚΥΡΟ</translation>
+        <location line="+1"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Άκυρο</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+10"/>
         <source>Name</source>
         <translation type="unfinished">Όνομα</translation>
     </message>
@@ -48,7 +118,7 @@
 <context>
     <name>FileItem</name>
     <message>
-        <location filename="../../src/timeline/widgets/FileItem.cc" line="+111"/>
+        <location filename="../../src/timeline/widgets/FileItem.cpp" line="+106"/>
         <source>Save File</source>
         <translation>Αποθήκευση</translation>
     </message>
@@ -56,15 +126,23 @@
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/timeline/widgets/ImageItem.cc" line="+229"/>
+        <location filename="../../src/timeline/widgets/ImageItem.cpp" line="+238"/>
         <source>Save image</source>
         <translation>Αποθήκευση Εικόνας</translation>
     </message>
 </context>
 <context>
+    <name>InviteeItem</name>
+    <message>
+        <location filename="../../src/InviteeItem.cpp" line="+17"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoginPage</name>
     <message>
-        <location filename="../../src/LoginPage.cc" line="+79"/>
+        <location filename="../../src/LoginPage.cpp" line="+79"/>
         <source>Matrix ID</source>
         <translation>Matrix ID</translation>
     </message>
@@ -79,56 +157,63 @@
         <translation>Κωδικός</translation>
     </message>
     <message>
+        <location line="+4"/>
+        <source>Device name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+19"/>
         <source>LOGIN</source>
         <translation>ΕΙΣΟΔΟΣ</translation>
     </message>
     <message>
-        <location line="+128"/>
+        <location line="+83"/>
+        <source>Autodiscovery failed. Received malformed response.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Autodiscovery failed. Unknown error when requesting .well-known.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>The required endpoints were not found. Possibly not a Matrix server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Received malformed response. Make sure the homeserver domain is valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>An unknown error occured. Make sure the homeserver domain is valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+60"/>
         <source>Empty password</source>
         <translation>Κενός κωδικός</translation>
     </message>
 </context>
 <context>
-    <name>MatrixClient</name>
-    <message>
-        <location filename="../../src/MatrixClient.cc" line="+164"/>
-        <source>Wrong username or password</source>
-        <translation>Λανθασμένο όνμα χρήστη ή κωδικός</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Login endpoint was not found on the server</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>An unknown error occured. Please try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+23"/>
-        <source>Malformed response. Possibly not a Matrix server</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>MemberList</name>
     <message>
-        <location filename="../../src/dialogs/MemberList.cpp" line="+79"/>
+        <location filename="../../src/dialogs/MemberList.cpp" line="+96"/>
         <source>Room members</source>
         <translation>Μέλη</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <source>SHOW MORE</source>
-        <translation>ΠΕΡΙΣΣΟΤΕΡΑ</translation>
+        <location line="+33"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>QuickSwitcher</name>
     <message>
-        <location filename="../../src/QuickSwitcher.cc" line="+70"/>
+        <location filename="../../src/QuickSwitcher.cpp" line="+71"/>
         <source>Search for a room...</source>
         <translation>Αναζήτηση συνομιλίας...</translation>
     </message>
@@ -136,7 +221,7 @@
 <context>
     <name>RegisterPage</name>
     <message>
-        <location filename="../../src/RegisterPage.cc" line="+76"/>
+        <location filename="../../src/RegisterPage.cpp" line="+77"/>
         <source>Username</source>
         <translation>Όνομα χρήστη</translation>
     </message>
@@ -156,12 +241,12 @@
         <translation>Διακομιστής</translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+16"/>
         <source>REGISTER</source>
         <translation>ΕΓΓΡΑΦΗ</translation>
     </message>
     <message>
-        <location line="+76"/>
+        <location line="+93"/>
         <source>Invalid username</source>
         <translation>Μη έγκυρο όνομα χρήστη</translation>
     </message>
@@ -182,14 +267,22 @@
     </message>
 </context>
 <context>
+    <name>ReplyPopup</name>
+    <message>
+        <location filename="../../src/popups/ReplyPopup.cpp" line="+45"/>
+        <source>Logout</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>RoomInfoListItem</name>
     <message>
-        <location filename="../../src/RoomInfoListItem.cc" line="+78"/>
+        <location filename="../../src/RoomInfoListItem.cpp" line="+92"/>
         <source>Leave room</source>
         <translation>Βγές</translation>
     </message>
     <message>
-        <location line="+153"/>
+        <location line="+174"/>
         <source>Accept</source>
         <translation>Αποδοχή</translation>
     </message>
@@ -202,7 +295,12 @@
 <context>
     <name>SideBarActions</name>
     <message>
-        <location filename="../../src/SideBarActions.cc" line="+36"/>
+        <location filename="../../src/SideBarActions.cpp" line="+38"/>
+        <source>User settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <source>Create new room</source>
         <translation>Νέα συνομιλία</translation>
     </message>
@@ -211,16 +309,65 @@
         <source>Join a room</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+16"/>
+        <source>Start a new chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>Room directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StatusIndicator</name>
+    <message>
+        <location filename="../../src/timeline/TimelineItem.cpp" line="+106"/>
+        <source>Encrypted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Delivered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Seen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Sent</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TextInputWidget</name>
     <message>
-        <location filename="../../src/TextInputWidget.cc" line="+445"/>
+        <location filename="../../src/TextInputWidget.cpp" line="+506"/>
+        <source>Send a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location filename="../../src/TextInputWidget.h" line="+168"/>
         <source>Write a message...</source>
         <translation>Γράψε ένα μήνυμα...</translation>
     </message>
     <message>
-        <location line="+108"/>
+        <location line="+31"/>
+        <source>Send a message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Emoji</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+75"/>
         <source>Select a file</source>
         <translation>Διάλεξε ένα αρχείο</translation>
     </message>
@@ -229,11 +376,47 @@
         <source>All Files (*)</source>
         <translation>Όλα τα αρχεία (*)</translation>
     </message>
+    <message>
+        <location filename="../../src/TextInputWidget.h" line="-5"/>
+        <source>Connection lost. Nheko is trying to re-connect...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TimelineItem</name>
+    <message>
+        <location filename="../../src/timeline/TimelineItem.cpp" line="+85"/>
+        <source>Message redaction failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Reply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TimelineView</name>
+    <message>
+        <location filename="../../src/timeline/TimelineView.cpp" line="+245"/>
+        <source>Encryption is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TopRoomBar</name>
     <message>
-        <location filename="../../src/TopRoomBar.cc" line="+87"/>
+        <location filename="../../src/TopRoomBar.cpp" line="+79"/>
+        <source>Room options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+28"/>
         <source>Invite users</source>
         <translation>Προσκάλεσε χρήστες</translation>
     </message>
@@ -256,7 +439,7 @@
 <context>
     <name>TrayIcon</name>
     <message>
-        <location filename="../../src/TrayIcon.cc" line="+116"/>
+        <location filename="../../src/TrayIcon.cpp" line="+120"/>
         <source>Show</source>
         <translation>Εμφάνιση</translation>
     </message>
@@ -269,7 +452,7 @@
 <context>
     <name>TypingDisplay</name>
     <message>
-        <location filename="../../src/TypingDisplay.cc" line="+26"/>
+        <location filename="../../src/TypingDisplay.cpp" line="+45"/>
         <source> is typing</source>
         <translation> πληκτρολογεί</translation>
     </message>
@@ -280,14 +463,17 @@
     </message>
 </context>
 <context>
+    <name>UserInfoWidget</name>
+    <message>
+        <location filename="../../src/UserInfoWidget.cpp" line="+87"/>
+        <source>Logout</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>UserSettingsPage</name>
     <message>
-        <location filename="../../src/UserSettingsPage.cc" line="+121"/>
-        <source>User Settings</source>
-        <translation>Ρυθμίσεις Χρήστη</translation>
-    </message>
-    <message>
-        <location line="+15"/>
+        <location filename="../../src/UserSettingsPage.cpp" line="+156"/>
         <source>Minimize to tray</source>
         <translation>Ελαχιστοποίηση</translation>
     </message>
@@ -297,12 +483,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <source>Re-order rooms based on activity</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
+        <location line="+11"/>
         <source>Group&apos;s sidebar</source>
         <translation type="unfinished"></translation>
     </message>
@@ -318,19 +499,115 @@
     </message>
     <message>
         <location line="+9"/>
+        <source>Desktop notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Scale factor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Font Family</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+17"/>
         <source>Theme</source>
         <translation>Φόντο</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+27"/>
+        <source>Device ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Device Fingerprint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Session Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>IMPORT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>EXPORT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>ENCRYPTION</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>GENERAL</source>
         <translation>ΓΕΝΙΚΑ</translation>
+    </message>
+    <message>
+        <location line="+150"/>
+        <source>Open Sessions File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <location line="+18"/>
+        <location line="+9"/>
+        <location line="+2"/>
+        <location line="+2"/>
+        <location line="+19"/>
+        <location line="+10"/>
+        <location line="+18"/>
+        <location line="+2"/>
+        <location line="+2"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-73"/>
+        <location line="+32"/>
+        <source>File Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-31"/>
+        <source>Enter the passphrase to decrypt the file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+32"/>
+        <source>The password cannot be empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-8"/>
+        <source>Enter passphrase to encrypt your session keys:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>File to save the exported session keys</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WelcomePage</name>
     <message>
-        <location filename="../../src/WelcomePage.cc" line="+44"/>
+        <location filename="../../src/WelcomePage.cpp" line="+46"/>
         <source>Welcome to nheko! The desktop client for the Matrix protocol.</source>
         <translation>Καλως ήρθες στο nheko!</translation>
     </message>
@@ -340,12 +617,12 @@
         <translation> </translation>
     </message>
     <message>
-        <location line="+19"/>
+        <location line="+23"/>
         <source>REGISTER</source>
         <translation>ΕΓΓΡΑΦΗ</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+5"/>
         <source>LOGIN</source>
         <translation>ΕΙΣΟΔΟΣ</translation>
     </message>
@@ -353,12 +630,17 @@
 <context>
     <name>dialogs::CreateRoom</name>
     <message>
-        <location filename="../../src/dialogs/CreateRoom.cc" line="+32"/>
-        <source>CANCEL</source>
-        <translation>ΑΚΥΡΟ</translation>
+        <location filename="../../src/dialogs/CreateRoom.cpp" line="+36"/>
+        <source>Create room</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+2"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Άκυρο</translation>
+    </message>
+    <message>
+        <location line="+10"/>
         <source>Name</source>
         <translation>Όνομα</translation>
     </message>
@@ -378,12 +660,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+8"/>
         <source>Room Preset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+9"/>
         <source>Direct Chat</source>
         <translation>Άμεση συνομιλία</translation>
     </message>
@@ -391,12 +673,12 @@
 <context>
     <name>dialogs::InviteUsers</name>
     <message>
-        <location filename="../../src/dialogs/InviteUsers.cc" line="+36"/>
-        <source>CANCEL</source>
-        <translation>ΑΚΥΡΟ</translation>
+        <location filename="../../src/dialogs/InviteUsers.cpp" line="+41"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Άκυρο</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+8"/>
         <source>User ID to invite</source>
         <translation>Όνομα χρήστη</translation>
     </message>
@@ -404,12 +686,17 @@
 <context>
     <name>dialogs::JoinRoom</name>
     <message>
-        <location filename="../../src/dialogs/JoinRoom.cc" line="+30"/>
-        <source>CANCEL</source>
-        <translation>ΑΚΥΡΟ</translation>
+        <location filename="../../src/dialogs/JoinRoom.cpp" line="+30"/>
+        <source>Join</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+2"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Άκυρο</translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <source>Room ID or alias</source>
         <translation>ID ή όνομα συνομιλίας</translation>
     </message>
@@ -417,12 +704,12 @@
 <context>
     <name>dialogs::LeaveRoom</name>
     <message>
-        <location filename="../../src/dialogs/LeaveRoom.cc" line="+29"/>
-        <source>CANCEL</source>
-        <translation>ΑΚΥΡΟ</translation>
+        <location filename="../../src/dialogs/LeaveRoom.cpp" line="+31"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Άκυρο</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+8"/>
         <source>Are you sure you want to leave?</source>
         <translation>Είστε σίγουροι οτι θέλετε να κλείσετε τη συνομιλία;</translation>
     </message>
@@ -430,12 +717,12 @@
 <context>
     <name>dialogs::Logout</name>
     <message>
-        <location filename="../../src/dialogs/Logout.cc" line="+47"/>
-        <source>CANCEL</source>
-        <translation>ΑΚΥΡΟ</translation>
+        <location filename="../../src/dialogs/Logout.cpp" line="+47"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Άκυρο</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+8"/>
         <source>Logout. Are you sure?</source>
         <translation>Αποσύνδεση. Είστε σίγουροι;</translation>
     </message>
@@ -443,7 +730,7 @@
 <context>
     <name>dialogs::PreviewUploadOverlay</name>
     <message>
-        <location filename="../../src/dialogs/PreviewUploadOverlay.cc" line="+41"/>
+        <location filename="../../src/dialogs/PreviewUploadOverlay.cpp" line="+42"/>
         <source>Upload</source>
         <translation>Μεταφόρτωση</translation>
     </message>
@@ -453,7 +740,7 @@
         <translation>Άκυρο</translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+84"/>
         <source>Media type: %1
 Media size: %2
 </source>
@@ -463,14 +750,14 @@ Media size: %2
 <context>
     <name>dialogs::ReCaptcha</name>
     <message>
-        <location filename="../../src/dialogs/ReCaptcha.cpp" line="+34"/>
-        <source>CONFIRM</source>
-        <translation>ΕΠΙΒΕΒΑΙΩΣΗ</translation>
+        <location filename="../../src/dialogs/ReCaptcha.cpp" line="+31"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Άκυρο</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>CANCEL</source>
-        <translation>ΑΚΥΡΟ</translation>
+        <location line="+1"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+11"/>
@@ -481,20 +768,40 @@ Media size: %2
 <context>
     <name>dialogs::ReadReceipts</name>
     <message>
-        <location filename="../../src/dialogs/ReadReceipts.cc" line="+98"/>
+        <location filename="../../src/dialogs/ReadReceipts.cpp" line="+119"/>
         <source>Read receipts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>ESC</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dialogs::RoomSettings</name>
     <message>
-        <location filename="../../src/dialogs/RoomSettings.cpp" line="+147"/>
-        <source>CANCEL</source>
-        <translation>ΑΚΥΡΟ</translation>
+        <location filename="../../src/dialogs/RoomSettings.cpp" line="+113"/>
+        <source>Settings</source>
+        <translation type="unfinished">Ρυθμίσεις</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+3"/>
+        <source>Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Internal ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Notifications</source>
         <translation>Ειδοποιήσεις</translation>
     </message>
@@ -514,7 +821,7 @@ Media size: %2
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+7"/>
         <source>Room access</source>
         <translation type="unfinished"></translation>
     </message>
@@ -533,11 +840,115 @@ Media size: %2
         <source>Invited users</source>
         <translation>Μόνο με πρόσκληση</translation>
     </message>
+    <message>
+        <location line="+50"/>
+        <source>Encryption</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>End-to-End Encryption</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Encryption is currently experimental and things might break unexpectedly. &lt;br&gt;Please take note that it can&apos;t be disabled afterwards.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <source>Respond to key requests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Whether or not the client should respond automatically with the session keys
+ upon request. Use with caution, this is a temporary measure to test the
+ E2E implementation until device verification is completed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+53"/>
+        <source>%n member(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+70"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+69"/>
+        <source>Failed to enable encryption: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+149"/>
+        <source>Select an avatar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>All Files (*)</source>
+        <translation type="unfinished">Όλα τα αρχεία (*)</translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The selected media is not an image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Error while reading media: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <location line="+20"/>
+        <source>Failed to upload image: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dialogs::UserProfile</name>
+    <message>
+        <location filename="../../src/dialogs/UserProfile.cpp" line="+63"/>
+        <source>Ban the user from the room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Ignore messages from this user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Kick the user from the room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Start a conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+57"/>
+        <source>Devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>emoji::Panel</name>
     <message>
-        <location filename="../../src/emoji/Panel.cc" line="+125"/>
+        <location filename="../../src/emoji/Panel.cpp" line="+125"/>
         <source>Smileys &amp; People</source>
         <translation>Πρόσωπα</translation>
     </message>

--- a/resources/langs/nheko_en.ts
+++ b/resources/langs/nheko_en.ts
@@ -4,38 +4,108 @@
 <context>
     <name>AudioItem</name>
     <message>
-        <location filename="../../src/timeline/widgets/AudioItem.cc" line="+125"/>
+        <location filename="../../src/timeline/widgets/AudioItem.cpp" line="+117"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>DateSeparator</name>
+    <name>ChatPage</name>
     <message>
-        <location filename="../../src/timeline/TimelineView.cc" line="+54"/>
-        <source>Today</source>
+        <location filename="../../src/ChatPage.cpp" line="+309"/>
+        <source>Failed to upload image. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+45"/>
+        <source>Failed to upload file. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+43"/>
+        <source>Failed to upload audio. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+42"/>
+        <source>Failed to upload video. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+376"/>
+        <source>Failed to restore OLM account. Please login again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Failed to restore save data. Please login again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+169"/>
+        <source>Failed to setup encryption keys. Server response: %1 %2. Please try again later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+51"/>
+        <location line="+153"/>
+        <source>Please try to login again: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-45"/>
+        <source>Room creation failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Failed to leave room: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommunitiesListItem</name>
+    <message>
+        <location filename="../../src/CommunitiesListItem.cpp" line="+130"/>
+        <source>All rooms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Favourite rooms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
-        <source>Yesterday</source>
+        <source>Low priority rooms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+2"/>
+        <source> (tag)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source> (community)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>EditModal</name>
     <message>
-        <location filename="../../src/dialogs/RoomSettings.cpp" line="+34"/>
-        <source>APPLY</source>
+        <location filename="../../src/dialogs/RoomSettings.cpp" line="+58"/>
+        <source>Apply</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>CANCEL</source>
+        <location line="+1"/>
+        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+10"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,7 +118,7 @@
 <context>
     <name>FileItem</name>
     <message>
-        <location filename="../../src/timeline/widgets/FileItem.cc" line="+111"/>
+        <location filename="../../src/timeline/widgets/FileItem.cpp" line="+106"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -56,15 +126,23 @@
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/timeline/widgets/ImageItem.cc" line="+229"/>
+        <location filename="../../src/timeline/widgets/ImageItem.cpp" line="+238"/>
         <source>Save image</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>InviteeItem</name>
+    <message>
+        <location filename="../../src/InviteeItem.cpp" line="+17"/>
+        <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LoginPage</name>
     <message>
-        <location filename="../../src/LoginPage.cc" line="+79"/>
+        <location filename="../../src/LoginPage.cpp" line="+79"/>
         <source>Matrix ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -79,56 +157,63 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+4"/>
+        <source>Device name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+19"/>
         <source>LOGIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
-        <source>Empty password</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MatrixClient</name>
-    <message>
-        <location filename="../../src/MatrixClient.cc" line="+164"/>
-        <source>Wrong username or password</source>
+        <location line="+83"/>
+        <source>Autodiscovery failed. Received malformed response.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Login endpoint was not found on the server</source>
+        <location line="+4"/>
+        <source>Autodiscovery failed. Unknown error when requesting .well-known.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>The required endpoints were not found. Possibly not a Matrix server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+6"/>
-        <source>An unknown error occured. Please try again.</source>
+        <source>Received malformed response. Make sure the homeserver domain is valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <source>Malformed response. Possibly not a Matrix server</source>
+        <location line="+5"/>
+        <source>An unknown error occured. Make sure the homeserver domain is valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+60"/>
+        <source>Empty password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MemberList</name>
     <message>
-        <location filename="../../src/dialogs/MemberList.cpp" line="+79"/>
+        <location filename="../../src/dialogs/MemberList.cpp" line="+96"/>
         <source>Room members</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
-        <source>SHOW MORE</source>
+        <location line="+33"/>
+        <source>ESC</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>QuickSwitcher</name>
     <message>
-        <location filename="../../src/QuickSwitcher.cc" line="+70"/>
+        <location filename="../../src/QuickSwitcher.cpp" line="+71"/>
         <source>Search for a room...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -136,7 +221,7 @@
 <context>
     <name>RegisterPage</name>
     <message>
-        <location filename="../../src/RegisterPage.cc" line="+76"/>
+        <location filename="../../src/RegisterPage.cpp" line="+77"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
@@ -156,12 +241,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+16"/>
         <source>REGISTER</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+76"/>
+        <location line="+93"/>
         <source>Invalid username</source>
         <translation type="unfinished"></translation>
     </message>
@@ -182,14 +267,22 @@
     </message>
 </context>
 <context>
+    <name>ReplyPopup</name>
+    <message>
+        <location filename="../../src/popups/ReplyPopup.cpp" line="+45"/>
+        <source>Logout</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>RoomInfoListItem</name>
     <message>
-        <location filename="../../src/RoomInfoListItem.cc" line="+78"/>
+        <location filename="../../src/RoomInfoListItem.cpp" line="+92"/>
         <source>Leave room</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+153"/>
+        <location line="+174"/>
         <source>Accept</source>
         <translation type="unfinished"></translation>
     </message>
@@ -202,7 +295,12 @@
 <context>
     <name>SideBarActions</name>
     <message>
-        <location filename="../../src/SideBarActions.cc" line="+36"/>
+        <location filename="../../src/SideBarActions.cpp" line="+38"/>
+        <source>User settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <source>Create new room</source>
         <translation type="unfinished"></translation>
     </message>
@@ -211,16 +309,65 @@
         <source>Join a room</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+16"/>
+        <source>Start a new chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>Room directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StatusIndicator</name>
+    <message>
+        <location filename="../../src/timeline/TimelineItem.cpp" line="+106"/>
+        <source>Encrypted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Delivered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Seen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Sent</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TextInputWidget</name>
     <message>
-        <location filename="../../src/TextInputWidget.cc" line="+445"/>
+        <location filename="../../src/TextInputWidget.cpp" line="+506"/>
+        <source>Send a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location filename="../../src/TextInputWidget.h" line="+168"/>
         <source>Write a message...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
+        <location line="+31"/>
+        <source>Send a message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Emoji</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+75"/>
         <source>Select a file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -229,11 +376,47 @@
         <source>All Files (*)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../src/TextInputWidget.h" line="-5"/>
+        <source>Connection lost. Nheko is trying to re-connect...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TimelineItem</name>
+    <message>
+        <location filename="../../src/timeline/TimelineItem.cpp" line="+85"/>
+        <source>Message redaction failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Reply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TimelineView</name>
+    <message>
+        <location filename="../../src/timeline/TimelineView.cpp" line="+245"/>
+        <source>Encryption is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TopRoomBar</name>
     <message>
-        <location filename="../../src/TopRoomBar.cc" line="+87"/>
+        <location filename="../../src/TopRoomBar.cpp" line="+79"/>
+        <source>Room options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+28"/>
         <source>Invite users</source>
         <translation type="unfinished"></translation>
     </message>
@@ -256,7 +439,7 @@
 <context>
     <name>TrayIcon</name>
     <message>
-        <location filename="../../src/TrayIcon.cc" line="+116"/>
+        <location filename="../../src/TrayIcon.cpp" line="+120"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -269,7 +452,7 @@
 <context>
     <name>TypingDisplay</name>
     <message>
-        <location filename="../../src/TypingDisplay.cc" line="+26"/>
+        <location filename="../../src/TypingDisplay.cpp" line="+45"/>
         <source> is typing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -280,14 +463,17 @@
     </message>
 </context>
 <context>
-    <name>UserSettingsPage</name>
+    <name>UserInfoWidget</name>
     <message>
-        <location filename="../../src/UserSettingsPage.cc" line="+121"/>
-        <source>User Settings</source>
+        <location filename="../../src/UserInfoWidget.cpp" line="+87"/>
+        <source>Logout</source>
         <translation type="unfinished"></translation>
     </message>
+</context>
+<context>
+    <name>UserSettingsPage</name>
     <message>
-        <location line="+15"/>
+        <location filename="../../src/UserSettingsPage.cpp" line="+156"/>
         <source>Minimize to tray</source>
         <translation type="unfinished"></translation>
     </message>
@@ -297,12 +483,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <source>Re-order rooms based on activity</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
+        <location line="+11"/>
         <source>Group&apos;s sidebar</source>
         <translation type="unfinished"></translation>
     </message>
@@ -318,19 +499,115 @@
     </message>
     <message>
         <location line="+9"/>
+        <source>Desktop notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Scale factor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Font Family</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+17"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+27"/>
+        <source>Device ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Device Fingerprint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Session Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>IMPORT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>EXPORT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>ENCRYPTION</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>GENERAL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+150"/>
+        <source>Open Sessions File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <location line="+18"/>
+        <location line="+9"/>
+        <location line="+2"/>
+        <location line="+2"/>
+        <location line="+19"/>
+        <location line="+10"/>
+        <location line="+18"/>
+        <location line="+2"/>
+        <location line="+2"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-73"/>
+        <location line="+32"/>
+        <source>File Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-31"/>
+        <source>Enter the passphrase to decrypt the file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+32"/>
+        <source>The password cannot be empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-8"/>
+        <source>Enter passphrase to encrypt your session keys:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>File to save the exported session keys</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WelcomePage</name>
     <message>
-        <location filename="../../src/WelcomePage.cc" line="+44"/>
+        <location filename="../../src/WelcomePage.cpp" line="+46"/>
         <source>Welcome to nheko! The desktop client for the Matrix protocol.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -340,12 +617,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
+        <location line="+23"/>
         <source>REGISTER</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+5"/>
         <source>LOGIN</source>
         <translation type="unfinished"></translation>
     </message>
@@ -353,12 +630,17 @@
 <context>
     <name>dialogs::CreateRoom</name>
     <message>
-        <location filename="../../src/dialogs/CreateRoom.cc" line="+32"/>
-        <source>CANCEL</source>
+        <location filename="../../src/dialogs/CreateRoom.cpp" line="+36"/>
+        <source>Create room</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+2"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -378,12 +660,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+8"/>
         <source>Room Preset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+9"/>
         <source>Direct Chat</source>
         <translation type="unfinished"></translation>
     </message>
@@ -391,12 +673,12 @@
 <context>
     <name>dialogs::InviteUsers</name>
     <message>
-        <location filename="../../src/dialogs/InviteUsers.cc" line="+36"/>
-        <source>CANCEL</source>
+        <location filename="../../src/dialogs/InviteUsers.cpp" line="+41"/>
+        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+8"/>
         <source>User ID to invite</source>
         <translation type="unfinished"></translation>
     </message>
@@ -404,12 +686,17 @@
 <context>
     <name>dialogs::JoinRoom</name>
     <message>
-        <location filename="../../src/dialogs/JoinRoom.cc" line="+30"/>
-        <source>CANCEL</source>
+        <location filename="../../src/dialogs/JoinRoom.cpp" line="+30"/>
+        <source>Join</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+2"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <source>Room ID or alias</source>
         <translation type="unfinished"></translation>
     </message>
@@ -417,12 +704,12 @@
 <context>
     <name>dialogs::LeaveRoom</name>
     <message>
-        <location filename="../../src/dialogs/LeaveRoom.cc" line="+29"/>
-        <source>CANCEL</source>
+        <location filename="../../src/dialogs/LeaveRoom.cpp" line="+31"/>
+        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+8"/>
         <source>Are you sure you want to leave?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -430,12 +717,12 @@
 <context>
     <name>dialogs::Logout</name>
     <message>
-        <location filename="../../src/dialogs/Logout.cc" line="+47"/>
-        <source>CANCEL</source>
+        <location filename="../../src/dialogs/Logout.cpp" line="+47"/>
+        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+8"/>
         <source>Logout. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -443,7 +730,7 @@
 <context>
     <name>dialogs::PreviewUploadOverlay</name>
     <message>
-        <location filename="../../src/dialogs/PreviewUploadOverlay.cc" line="+41"/>
+        <location filename="../../src/dialogs/PreviewUploadOverlay.cpp" line="+42"/>
         <source>Upload</source>
         <translation type="unfinished"></translation>
     </message>
@@ -453,7 +740,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+84"/>
         <source>Media type: %1
 Media size: %2
 </source>
@@ -463,13 +750,13 @@ Media size: %2
 <context>
     <name>dialogs::ReCaptcha</name>
     <message>
-        <location filename="../../src/dialogs/ReCaptcha.cpp" line="+34"/>
-        <source>CONFIRM</source>
+        <location filename="../../src/dialogs/ReCaptcha.cpp" line="+31"/>
+        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>CANCEL</source>
+        <location line="+1"/>
+        <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -481,20 +768,40 @@ Media size: %2
 <context>
     <name>dialogs::ReadReceipts</name>
     <message>
-        <location filename="../../src/dialogs/ReadReceipts.cc" line="+98"/>
+        <location filename="../../src/dialogs/ReadReceipts.cpp" line="+119"/>
         <source>Read receipts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>ESC</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dialogs::RoomSettings</name>
     <message>
-        <location filename="../../src/dialogs/RoomSettings.cpp" line="+147"/>
-        <source>CANCEL</source>
+        <location filename="../../src/dialogs/RoomSettings.cpp" line="+113"/>
+        <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+3"/>
+        <source>Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Internal ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Notifications</source>
         <translation type="unfinished"></translation>
     </message>
@@ -514,7 +821,7 @@ Media size: %2
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+7"/>
         <source>Room access</source>
         <translation type="unfinished"></translation>
     </message>
@@ -533,11 +840,115 @@ Media size: %2
         <source>Invited users</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+50"/>
+        <source>Encryption</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>End-to-End Encryption</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Encryption is currently experimental and things might break unexpectedly. &lt;br&gt;Please take note that it can&apos;t be disabled afterwards.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <source>Respond to key requests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Whether or not the client should respond automatically with the session keys
+ upon request. Use with caution, this is a temporary measure to test the
+ E2E implementation until device verification is completed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+53"/>
+        <source>%n member(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+70"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+69"/>
+        <source>Failed to enable encryption: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+149"/>
+        <source>Select an avatar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>All Files (*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The selected media is not an image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Error while reading media: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <location line="+20"/>
+        <source>Failed to upload image: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dialogs::UserProfile</name>
+    <message>
+        <location filename="../../src/dialogs/UserProfile.cpp" line="+63"/>
+        <source>Ban the user from the room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Ignore messages from this user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Kick the user from the room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Start a conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+57"/>
+        <source>Devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>emoji::Panel</name>
     <message>
-        <location filename="../../src/emoji/Panel.cc" line="+125"/>
+        <location filename="../../src/emoji/Panel.cpp" line="+125"/>
         <source>Smileys &amp; People</source>
         <translation type="unfinished">Smileys &amp; People</translation>
     </message>

--- a/resources/langs/nheko_fr.ts
+++ b/resources/langs/nheko_fr.ts
@@ -4,35 +4,105 @@
 <context>
     <name>AudioItem</name>
     <message>
-        <location filename="../../src/timeline/widgets/AudioItem.cc" line="+125"/>
+        <location filename="../../src/timeline/widgets/AudioItem.cpp" line="+117"/>
         <source>Save File</source>
         <translation>Enregistrer le fichier</translation>
     </message>
 </context>
 <context>
-    <name>DateSeparator</name>
+    <name>ChatPage</name>
     <message>
-        <location filename="../../src/timeline/TimelineView.cc" line="+54"/>
-        <source>Today</source>
-        <translation>Aujourd&apos;hui</translation>
+        <location filename="../../src/ChatPage.cpp" line="+309"/>
+        <source>Failed to upload image. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+45"/>
+        <source>Failed to upload file. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+43"/>
+        <source>Failed to upload audio. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+42"/>
+        <source>Failed to upload video. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+376"/>
+        <source>Failed to restore OLM account. Please login again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Failed to restore save data. Please login again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+169"/>
+        <source>Failed to setup encryption keys. Server response: %1 %2. Please try again later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+51"/>
+        <location line="+153"/>
+        <source>Please try to login again: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-45"/>
+        <source>Room creation failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Failed to leave room: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommunitiesListItem</name>
+    <message>
+        <location filename="../../src/CommunitiesListItem.cpp" line="+130"/>
+        <source>All rooms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Favourite rooms</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
-        <source>Yesterday</source>
-        <translation>Hier</translation>
+        <source>Low priority rooms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+2"/>
+        <source> (tag)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source> (community)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>EditModal</name>
     <message>
-        <location filename="../../src/dialogs/RoomSettings.cpp" line="+36"/>
-        <source>APPLY</source>
-        <translation>APPLIQUER</translation>
+        <location filename="../../src/dialogs/RoomSettings.cpp" line="+58"/>
+        <source>Apply</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>CANCEL</source>
-        <translation>ANNULER</translation>
+        <location line="+1"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuler</translation>
     </message>
     <message>
         <location line="+10"/>
@@ -48,7 +118,7 @@
 <context>
     <name>FileItem</name>
     <message>
-        <location filename="../../src/timeline/widgets/FileItem.cc" line="+111"/>
+        <location filename="../../src/timeline/widgets/FileItem.cpp" line="+106"/>
         <source>Save File</source>
         <translation>Enregistrer le fichier</translation>
     </message>
@@ -56,15 +126,23 @@
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/timeline/widgets/ImageItem.cc" line="+229"/>
+        <location filename="../../src/timeline/widgets/ImageItem.cpp" line="+238"/>
         <source>Save image</source>
         <translation>Enregistrer l&apos;image</translation>
     </message>
 </context>
 <context>
+    <name>InviteeItem</name>
+    <message>
+        <location filename="../../src/InviteeItem.cpp" line="+17"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoginPage</name>
     <message>
-        <location filename="../../src/LoginPage.cc" line="+79"/>
+        <location filename="../../src/LoginPage.cpp" line="+79"/>
         <source>Matrix ID</source>
         <translation>Identifiant Matrix</translation>
     </message>
@@ -79,56 +157,63 @@
         <translation>Mot de passe</translation>
     </message>
     <message>
+        <location line="+4"/>
+        <source>Device name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+19"/>
         <source>LOGIN</source>
         <translation>CONNEXION</translation>
     </message>
     <message>
-        <location line="+128"/>
+        <location line="+83"/>
+        <source>Autodiscovery failed. Received malformed response.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Autodiscovery failed. Unknown error when requesting .well-known.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>The required endpoints were not found. Possibly not a Matrix server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Received malformed response. Make sure the homeserver domain is valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>An unknown error occured. Make sure the homeserver domain is valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+60"/>
         <source>Empty password</source>
         <translation>Mot de passe vide</translation>
     </message>
 </context>
 <context>
-    <name>MatrixClient</name>
-    <message>
-        <location filename="../../src/MatrixClient.cc" line="+164"/>
-        <source>Wrong username or password</source>
-        <translation>Mauvais nom d&apos;utilisateur ou mot de passe</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Login endpoint was not found on the server</source>
-        <translation>L&apos;interface de connexion n&apos;a pas pu être trouvée sur le serveur</translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>An unknown error occured. Please try again.</source>
-        <translation>Une erreur inconnue s&apos;est produite. Veuillez essayer à nouveau.</translation>
-    </message>
-    <message>
-        <location line="+23"/>
-        <source>Malformed response. Possibly not a Matrix server</source>
-        <translation>La réponse du serveur est malformée. Il est possible qu&apos;il ne s&apos;agisse pas d&apos;un serveur Matrix</translation>
-    </message>
-</context>
-<context>
     <name>MemberList</name>
     <message>
-        <location filename="../../src/dialogs/MemberList.cpp" line="+79"/>
+        <location filename="../../src/dialogs/MemberList.cpp" line="+96"/>
         <source>Room members</source>
         <translation>Membres du salon</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <source>SHOW MORE</source>
-        <translation>MONTRER PLUS</translation>
+        <location line="+33"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>QuickSwitcher</name>
     <message>
-        <location filename="../../src/QuickSwitcher.cc" line="+70"/>
+        <location filename="../../src/QuickSwitcher.cpp" line="+71"/>
         <source>Search for a room...</source>
         <translation>Chercher un salon…</translation>
     </message>
@@ -136,7 +221,7 @@
 <context>
     <name>RegisterPage</name>
     <message>
-        <location filename="../../src/RegisterPage.cc" line="+76"/>
+        <location filename="../../src/RegisterPage.cpp" line="+77"/>
         <source>Username</source>
         <translation>Nom d&apos;utilisateur</translation>
     </message>
@@ -157,12 +242,12 @@
         <translation>Serveur Matrix</translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+16"/>
         <source>REGISTER</source>
         <translation>S&apos;ENREGISTRER</translation>
     </message>
     <message>
-        <location line="+76"/>
+        <location line="+93"/>
         <source>Invalid username</source>
         <translation>Nom d&apos;utilisateur invalide</translation>
     </message>
@@ -183,14 +268,22 @@
     </message>
 </context>
 <context>
+    <name>ReplyPopup</name>
+    <message>
+        <location filename="../../src/popups/ReplyPopup.cpp" line="+45"/>
+        <source>Logout</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>RoomInfoListItem</name>
     <message>
-        <location filename="../../src/RoomInfoListItem.cc" line="+78"/>
+        <location filename="../../src/RoomInfoListItem.cpp" line="+92"/>
         <source>Leave room</source>
         <translation>Quitter le salon</translation>
     </message>
     <message>
-        <location line="+153"/>
+        <location line="+174"/>
         <source>Accept</source>
         <translation>Accepter</translation>
     </message>
@@ -203,7 +296,12 @@
 <context>
     <name>SideBarActions</name>
     <message>
-        <location filename="../../src/SideBarActions.cc" line="+36"/>
+        <location filename="../../src/SideBarActions.cpp" line="+38"/>
+        <source>User settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <source>Create new room</source>
         <translation>Créer un nouveau salon</translation>
     </message>
@@ -212,16 +310,65 @@
         <source>Join a room</source>
         <translation>Rejoindre un salon</translation>
     </message>
+    <message>
+        <location line="+16"/>
+        <source>Start a new chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>Room directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StatusIndicator</name>
+    <message>
+        <location filename="../../src/timeline/TimelineItem.cpp" line="+106"/>
+        <source>Encrypted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Delivered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Seen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Sent</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TextInputWidget</name>
     <message>
-        <location filename="../../src/TextInputWidget.cc" line="+445"/>
+        <location filename="../../src/TextInputWidget.cpp" line="+506"/>
+        <source>Send a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location filename="../../src/TextInputWidget.h" line="+168"/>
         <source>Write a message...</source>
         <translation>Écrivez un message...</translation>
     </message>
     <message>
-        <location line="+108"/>
+        <location line="+31"/>
+        <source>Send a message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Emoji</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+75"/>
         <source>Select a file</source>
         <translation>Sélectionnez un fichier</translation>
     </message>
@@ -230,11 +377,47 @@
         <source>All Files (*)</source>
         <translation>Tous les types de fichiers (*)</translation>
     </message>
+    <message>
+        <location filename="../../src/TextInputWidget.h" line="-5"/>
+        <source>Connection lost. Nheko is trying to re-connect...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TimelineItem</name>
+    <message>
+        <location filename="../../src/timeline/TimelineItem.cpp" line="+85"/>
+        <source>Message redaction failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Reply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TimelineView</name>
+    <message>
+        <location filename="../../src/timeline/TimelineView.cpp" line="+245"/>
+        <source>Encryption is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TopRoomBar</name>
     <message>
-        <location filename="../../src/TopRoomBar.cc" line="+87"/>
+        <location filename="../../src/TopRoomBar.cpp" line="+79"/>
+        <source>Room options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+28"/>
         <source>Invite users</source>
         <translation>Inviter des utilisateurs</translation>
     </message>
@@ -257,7 +440,7 @@
 <context>
     <name>TrayIcon</name>
     <message>
-        <location filename="../../src/TrayIcon.cc" line="+116"/>
+        <location filename="../../src/TrayIcon.cpp" line="+120"/>
         <source>Show</source>
         <translation>Montrer</translation>
     </message>
@@ -270,7 +453,7 @@
 <context>
     <name>TypingDisplay</name>
     <message>
-        <location filename="../../src/TypingDisplay.cc" line="+26"/>
+        <location filename="../../src/TypingDisplay.cpp" line="+45"/>
         <source> is typing</source>
         <translation> est en train d&apos;écrire</translation>
     </message>
@@ -281,14 +464,17 @@
     </message>
 </context>
 <context>
+    <name>UserInfoWidget</name>
+    <message>
+        <location filename="../../src/UserInfoWidget.cpp" line="+87"/>
+        <source>Logout</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>UserSettingsPage</name>
     <message>
-        <location filename="../../src/UserSettingsPage.cc" line="+121"/>
-        <source>User Settings</source>
-        <translation>Paramètres utilisateur</translation>
-    </message>
-    <message>
-        <location line="+15"/>
+        <location filename="../../src/UserSettingsPage.cpp" line="+156"/>
         <source>Minimize to tray</source>
         <translation>Réduire à la barre des tâches</translation>
     </message>
@@ -298,12 +484,7 @@
         <translation>Démarrer dans la barre des tâches</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <source>Re-order rooms based on activity</source>
-        <translation>Ré-ordonner les salons en fonction de leur activité</translation>
-    </message>
-    <message>
-        <location line="+9"/>
+        <location line="+11"/>
         <source>Group&apos;s sidebar</source>
         <translation>Barre latérale des groupes</translation>
     </message>
@@ -319,19 +500,115 @@
     </message>
     <message>
         <location line="+9"/>
+        <source>Desktop notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Scale factor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Font Family</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+17"/>
         <source>Theme</source>
         <translation>Thème</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+27"/>
+        <source>Device ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Device Fingerprint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Session Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>IMPORT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>EXPORT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>ENCRYPTION</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>GENERAL</source>
         <translation>GÉNÉRAL</translation>
+    </message>
+    <message>
+        <location line="+150"/>
+        <source>Open Sessions File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <location line="+18"/>
+        <location line="+9"/>
+        <location line="+2"/>
+        <location line="+2"/>
+        <location line="+19"/>
+        <location line="+10"/>
+        <location line="+18"/>
+        <location line="+2"/>
+        <location line="+2"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-73"/>
+        <location line="+32"/>
+        <source>File Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-31"/>
+        <source>Enter the passphrase to decrypt the file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+32"/>
+        <source>The password cannot be empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-8"/>
+        <source>Enter passphrase to encrypt your session keys:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>File to save the exported session keys</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WelcomePage</name>
     <message>
-        <location filename="../../src/WelcomePage.cc" line="+44"/>
+        <location filename="../../src/WelcomePage.cpp" line="+46"/>
         <source>Welcome to nheko! The desktop client for the Matrix protocol.</source>
         <translation>Bienvenue sur nheko ! Le client de bureau pour le protocole Matrix.</translation>
     </message>
@@ -341,12 +618,12 @@
         <translation>Bon séjour !</translation>
     </message>
     <message>
-        <location line="+19"/>
+        <location line="+23"/>
         <source>REGISTER</source>
         <translation>S&apos;ENREGISTRER</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+5"/>
         <source>LOGIN</source>
         <translation>CONNEXION</translation>
     </message>
@@ -354,12 +631,17 @@
 <context>
     <name>dialogs::CreateRoom</name>
     <message>
-        <location filename="../../src/dialogs/CreateRoom.cc" line="+32"/>
-        <source>CANCEL</source>
-        <translation>ANNULER</translation>
+        <location filename="../../src/dialogs/CreateRoom.cpp" line="+36"/>
+        <source>Create room</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+2"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuler</translation>
+    </message>
+    <message>
+        <location line="+10"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
@@ -379,12 +661,12 @@
         <translation>Visibilité du salon</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+8"/>
         <source>Room Preset</source>
         <translation>Préréglage du salon</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+9"/>
         <source>Direct Chat</source>
         <translation>Discussion directe</translation>
     </message>
@@ -392,12 +674,12 @@
 <context>
     <name>dialogs::InviteUsers</name>
     <message>
-        <location filename="../../src/dialogs/InviteUsers.cc" line="+36"/>
-        <source>CANCEL</source>
-        <translation>ANNULER</translation>
+        <location filename="../../src/dialogs/InviteUsers.cpp" line="+41"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuler</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+8"/>
         <source>User ID to invite</source>
         <translation>Identifiant d&apos;utilisateur à inviter</translation>
     </message>
@@ -405,12 +687,17 @@
 <context>
     <name>dialogs::JoinRoom</name>
     <message>
-        <location filename="../../src/dialogs/JoinRoom.cc" line="+30"/>
-        <source>CANCEL</source>
-        <translation>ANNULER</translation>
+        <location filename="../../src/dialogs/JoinRoom.cpp" line="+30"/>
+        <source>Join</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+2"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuler</translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <source>Room ID or alias</source>
         <translation>Identifiant ou alias du salon</translation>
     </message>
@@ -418,12 +705,12 @@
 <context>
     <name>dialogs::LeaveRoom</name>
     <message>
-        <location filename="../../src/dialogs/LeaveRoom.cc" line="+29"/>
-        <source>CANCEL</source>
-        <translation>ANNULER</translation>
+        <location filename="../../src/dialogs/LeaveRoom.cpp" line="+31"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuler</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+8"/>
         <source>Are you sure you want to leave?</source>
         <translation>Êtes-vous sûr·e de vouloir quitter ?</translation>
     </message>
@@ -431,12 +718,12 @@
 <context>
     <name>dialogs::Logout</name>
     <message>
-        <location filename="../../src/dialogs/Logout.cc" line="+47"/>
-        <source>CANCEL</source>
-        <translation>ANNULER</translation>
+        <location filename="../../src/dialogs/Logout.cpp" line="+47"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuler</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+8"/>
         <source>Logout. Are you sure?</source>
         <translation>Déconnexion. Êtes-vous sûr·e ?</translation>
     </message>
@@ -444,7 +731,7 @@
 <context>
     <name>dialogs::PreviewUploadOverlay</name>
     <message>
-        <location filename="../../src/dialogs/PreviewUploadOverlay.cc" line="+41"/>
+        <location filename="../../src/dialogs/PreviewUploadOverlay.cpp" line="+42"/>
         <source>Upload</source>
         <translation>Envoyer</translation>
     </message>
@@ -454,7 +741,7 @@
         <translation>Annuler</translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+84"/>
         <source>Media type: %1
 Media size: %2
 </source>
@@ -466,14 +753,14 @@ Taille du média : %2
 <context>
     <name>dialogs::ReCaptcha</name>
     <message>
-        <location filename="../../src/dialogs/ReCaptcha.cpp" line="+34"/>
-        <source>CONFIRM</source>
-        <translation>CONFIRMER</translation>
+        <location filename="../../src/dialogs/ReCaptcha.cpp" line="+31"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuler</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>CANCEL</source>
-        <translation>ANNULER</translation>
+        <location line="+1"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+11"/>
@@ -484,20 +771,40 @@ Taille du média : %2
 <context>
     <name>dialogs::ReadReceipts</name>
     <message>
-        <location filename="../../src/dialogs/ReadReceipts.cc" line="+98"/>
+        <location filename="../../src/dialogs/ReadReceipts.cpp" line="+119"/>
         <source>Read receipts</source>
         <translation>Accusés de lecture</translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dialogs::RoomSettings</name>
     <message>
-        <location filename="../../src/dialogs/RoomSettings.cpp" line="+144"/>
-        <source>CANCEL</source>
-        <translation>ANNULER</translation>
+        <location filename="../../src/dialogs/RoomSettings.cpp" line="+113"/>
+        <source>Settings</source>
+        <translation type="unfinished">Paramètres</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+3"/>
+        <source>Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Internal ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Notifications</source>
         <translation>Notifications</translation>
     </message>
@@ -517,7 +824,7 @@ Taille du média : %2
         <translation>Tous les messages</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+7"/>
         <source>Room access</source>
         <translation>Accès au salon</translation>
     </message>
@@ -536,11 +843,115 @@ Taille du média : %2
         <source>Invited users</source>
         <translation>Utilisateurs invités</translation>
     </message>
+    <message>
+        <location line="+50"/>
+        <source>Encryption</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>End-to-End Encryption</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Encryption is currently experimental and things might break unexpectedly. &lt;br&gt;Please take note that it can&apos;t be disabled afterwards.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <source>Respond to key requests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Whether or not the client should respond automatically with the session keys
+ upon request. Use with caution, this is a temporary measure to test the
+ E2E implementation until device verification is completed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+53"/>
+        <source>%n member(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+70"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+69"/>
+        <source>Failed to enable encryption: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+149"/>
+        <source>Select an avatar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>All Files (*)</source>
+        <translation type="unfinished">Tous les types de fichiers (*)</translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The selected media is not an image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Error while reading media: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <location line="+20"/>
+        <source>Failed to upload image: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dialogs::UserProfile</name>
+    <message>
+        <location filename="../../src/dialogs/UserProfile.cpp" line="+63"/>
+        <source>Ban the user from the room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Ignore messages from this user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Kick the user from the room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Start a conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+57"/>
+        <source>Devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>emoji::Panel</name>
     <message>
-        <location filename="../../src/emoji/Panel.cc" line="+125"/>
+        <location filename="../../src/emoji/Panel.cpp" line="+125"/>
         <source>Smileys &amp; People</source>
         <translation>Smileys &amp; Personnes</translation>
     </message>

--- a/resources/langs/nheko_nl.ts
+++ b/resources/langs/nheko_nl.ts
@@ -4,38 +4,108 @@
 <context>
     <name>AudioItem</name>
     <message>
-        <location filename="../../src/timeline/widgets/AudioItem.cc" line="+125"/>
+        <location filename="../../src/timeline/widgets/AudioItem.cpp" line="+117"/>
         <source>Save File</source>
         <translation>Bestand opslaan</translation>
     </message>
 </context>
 <context>
-    <name>DateSeparator</name>
+    <name>ChatPage</name>
     <message>
-        <location filename="../../src/timeline/TimelineView.cc" line="+54"/>
-        <source>Today</source>
-        <translation>Vandaag</translation>
+        <location filename="../../src/ChatPage.cpp" line="+309"/>
+        <source>Failed to upload image. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+45"/>
+        <source>Failed to upload file. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+43"/>
+        <source>Failed to upload audio. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+42"/>
+        <source>Failed to upload video. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+376"/>
+        <source>Failed to restore OLM account. Please login again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Failed to restore save data. Please login again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+169"/>
+        <source>Failed to setup encryption keys. Server response: %1 %2. Please try again later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+51"/>
+        <location line="+153"/>
+        <source>Please try to login again: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-45"/>
+        <source>Room creation failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Failed to leave room: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommunitiesListItem</name>
+    <message>
+        <location filename="../../src/CommunitiesListItem.cpp" line="+130"/>
+        <source>All rooms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Favourite rooms</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
-        <source>Yesterday</source>
-        <translation>Gisteren</translation>
+        <source>Low priority rooms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+2"/>
+        <source> (tag)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source> (community)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>EditModal</name>
     <message>
-        <location filename="../../src/dialogs/RoomSettings.cpp" line="+34"/>
-        <source>APPLY</source>
-        <translation>TOEPASSEN</translation>
+        <location filename="../../src/dialogs/RoomSettings.cpp" line="+58"/>
+        <source>Apply</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>CANCEL</source>
-        <translation>ANNULEREN</translation>
+        <location line="+1"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+10"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
@@ -48,7 +118,7 @@
 <context>
     <name>FileItem</name>
     <message>
-        <location filename="../../src/timeline/widgets/FileItem.cc" line="+111"/>
+        <location filename="../../src/timeline/widgets/FileItem.cpp" line="+106"/>
         <source>Save File</source>
         <translation>Bestand opslaan</translation>
     </message>
@@ -56,15 +126,23 @@
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/timeline/widgets/ImageItem.cc" line="+229"/>
+        <location filename="../../src/timeline/widgets/ImageItem.cpp" line="+238"/>
         <source>Save image</source>
         <translation>Afbeelding opslaan</translation>
     </message>
 </context>
 <context>
+    <name>InviteeItem</name>
+    <message>
+        <location filename="../../src/InviteeItem.cpp" line="+17"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LoginPage</name>
     <message>
-        <location filename="../../src/LoginPage.cc" line="+79"/>
+        <location filename="../../src/LoginPage.cpp" line="+79"/>
         <source>Matrix ID</source>
         <translation>Matrix-id</translation>
     </message>
@@ -79,56 +157,63 @@
         <translation>Wachtwoord</translation>
     </message>
     <message>
+        <location line="+4"/>
+        <source>Device name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+19"/>
         <source>LOGIN</source>
         <translation>INLOGGEN</translation>
     </message>
     <message>
-        <location line="+128"/>
+        <location line="+83"/>
+        <source>Autodiscovery failed. Received malformed response.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Autodiscovery failed. Unknown error when requesting .well-known.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>The required endpoints were not found. Possibly not a Matrix server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Received malformed response. Make sure the homeserver domain is valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>An unknown error occured. Make sure the homeserver domain is valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+60"/>
         <source>Empty password</source>
         <translation>Leeg wachtwoord</translation>
     </message>
 </context>
 <context>
-    <name>MatrixClient</name>
-    <message>
-        <location filename="../../src/MatrixClient.cc" line="+164"/>
-        <source>Wrong username or password</source>
-        <translation>Verkeerde gebruikersnaam of wachtwoord</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Login endpoint was not found on the server</source>
-        <translation>Het inlog-endpoint is niet aangetroffen op de server</translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>An unknown error occured. Please try again.</source>
-        <translation>Er is een onbekende fout opgetreden. Probeer het opnieuw.</translation>
-    </message>
-    <message>
-        <location line="+23"/>
-        <source>Malformed response. Possibly not a Matrix server</source>
-        <translation>Onjuist antwoord ontvangen: dit is mogelijk geen Matrix server</translation>
-    </message>
-</context>
-<context>
     <name>MemberList</name>
     <message>
-        <location filename="../../src/dialogs/MemberList.cpp" line="+79"/>
+        <location filename="../../src/dialogs/MemberList.cpp" line="+96"/>
         <source>Room members</source>
         <translation>Kamerleden</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <source>SHOW MORE</source>
-        <translation>MEER TONEN</translation>
+        <location line="+33"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>QuickSwitcher</name>
     <message>
-        <location filename="../../src/QuickSwitcher.cc" line="+70"/>
+        <location filename="../../src/QuickSwitcher.cpp" line="+71"/>
         <source>Search for a room...</source>
         <translation>Zoek een kamer...</translation>
     </message>
@@ -136,7 +221,7 @@
 <context>
     <name>RegisterPage</name>
     <message>
-        <location filename="../../src/RegisterPage.cc" line="+76"/>
+        <location filename="../../src/RegisterPage.cpp" line="+77"/>
         <source>Username</source>
         <translation>Gebruikersnaam</translation>
     </message>
@@ -156,12 +241,12 @@
         <translation>Thuisserver</translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+16"/>
         <source>REGISTER</source>
         <translation>REGISTREREN</translation>
     </message>
     <message>
-        <location line="+76"/>
+        <location line="+93"/>
         <source>Invalid username</source>
         <translation>Ongeldige gebruikersnaam</translation>
     </message>
@@ -182,14 +267,22 @@
     </message>
 </context>
 <context>
+    <name>ReplyPopup</name>
+    <message>
+        <location filename="../../src/popups/ReplyPopup.cpp" line="+45"/>
+        <source>Logout</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>RoomInfoListItem</name>
     <message>
-        <location filename="../../src/RoomInfoListItem.cc" line="+78"/>
+        <location filename="../../src/RoomInfoListItem.cpp" line="+92"/>
         <source>Leave room</source>
         <translation>Kamer verlaten</translation>
     </message>
     <message>
-        <location line="+153"/>
+        <location line="+174"/>
         <source>Accept</source>
         <translation>Accepteren</translation>
     </message>
@@ -202,7 +295,12 @@
 <context>
     <name>SideBarActions</name>
     <message>
-        <location filename="../../src/SideBarActions.cc" line="+36"/>
+        <location filename="../../src/SideBarActions.cpp" line="+38"/>
+        <source>User settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <source>Create new room</source>
         <translation>Nieuwe kamer creëren</translation>
     </message>
@@ -211,16 +309,65 @@
         <source>Join a room</source>
         <translation>Kamer betreden</translation>
     </message>
+    <message>
+        <location line="+16"/>
+        <source>Start a new chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>Room directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StatusIndicator</name>
+    <message>
+        <location filename="../../src/timeline/TimelineItem.cpp" line="+106"/>
+        <source>Encrypted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Delivered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Seen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Sent</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TextInputWidget</name>
     <message>
-        <location filename="../../src/TextInputWidget.cc" line="+445"/>
+        <location filename="../../src/TextInputWidget.cpp" line="+506"/>
+        <source>Send a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location filename="../../src/TextInputWidget.h" line="+168"/>
         <source>Write a message...</source>
         <translation>Typ een bericht...</translation>
     </message>
     <message>
-        <location line="+108"/>
+        <location line="+31"/>
+        <source>Send a message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Emoji</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+75"/>
         <source>Select a file</source>
         <translation>Kies een bestand</translation>
     </message>
@@ -229,11 +376,47 @@
         <source>All Files (*)</source>
         <translation>Alle bestanden (*)</translation>
     </message>
+    <message>
+        <location filename="../../src/TextInputWidget.h" line="-5"/>
+        <source>Connection lost. Nheko is trying to re-connect...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TimelineItem</name>
+    <message>
+        <location filename="../../src/timeline/TimelineItem.cpp" line="+85"/>
+        <source>Message redaction failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Reply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TimelineView</name>
+    <message>
+        <location filename="../../src/timeline/TimelineView.cpp" line="+245"/>
+        <source>Encryption is enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TopRoomBar</name>
     <message>
-        <location filename="../../src/TopRoomBar.cc" line="+87"/>
+        <location filename="../../src/TopRoomBar.cpp" line="+79"/>
+        <source>Room options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+28"/>
         <source>Invite users</source>
         <translation>Gebruikers uitnodigen</translation>
     </message>
@@ -256,7 +439,7 @@
 <context>
     <name>TrayIcon</name>
     <message>
-        <location filename="../../src/TrayIcon.cc" line="+116"/>
+        <location filename="../../src/TrayIcon.cpp" line="+120"/>
         <source>Show</source>
         <translation>Tonen</translation>
     </message>
@@ -269,7 +452,7 @@
 <context>
     <name>TypingDisplay</name>
     <message>
-        <location filename="../../src/TypingDisplay.cc" line="+26"/>
+        <location filename="../../src/TypingDisplay.cpp" line="+45"/>
         <source> is typing</source>
         <translation> is aan het typen</translation>
     </message>
@@ -280,14 +463,17 @@
     </message>
 </context>
 <context>
+    <name>UserInfoWidget</name>
+    <message>
+        <location filename="../../src/UserInfoWidget.cpp" line="+87"/>
+        <source>Logout</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>UserSettingsPage</name>
     <message>
-        <location filename="../../src/UserSettingsPage.cc" line="+121"/>
-        <source>User Settings</source>
-        <translation>Gebruikersinstellingen</translation>
-    </message>
-    <message>
-        <location line="+15"/>
+        <location filename="../../src/UserSettingsPage.cpp" line="+156"/>
         <source>Minimize to tray</source>
         <translation>Minimaliseren naar systeemvak</translation>
     </message>
@@ -297,12 +483,7 @@
         <translation>Geminimaliseerd opstarten</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <source>Re-order rooms based on activity</source>
-        <translation>Kamers herordenen op basis van activiteit</translation>
-    </message>
-    <message>
-        <location line="+9"/>
+        <location line="+11"/>
         <source>Group&apos;s sidebar</source>
         <translation>Zijbalk van groep</translation>
     </message>
@@ -318,19 +499,115 @@
     </message>
     <message>
         <location line="+9"/>
+        <source>Desktop notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Scale factor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Font Family</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+17"/>
         <source>Theme</source>
         <translation>Thema</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+27"/>
+        <source>Device ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Device Fingerprint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Session Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>IMPORT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>EXPORT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>ENCRYPTION</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>GENERAL</source>
         <translation>ALGEMEEN</translation>
+    </message>
+    <message>
+        <location line="+150"/>
+        <source>Open Sessions File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <location line="+18"/>
+        <location line="+9"/>
+        <location line="+2"/>
+        <location line="+2"/>
+        <location line="+19"/>
+        <location line="+10"/>
+        <location line="+18"/>
+        <location line="+2"/>
+        <location line="+2"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-73"/>
+        <location line="+32"/>
+        <source>File Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-31"/>
+        <source>Enter the passphrase to decrypt the file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+32"/>
+        <source>The password cannot be empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-8"/>
+        <source>Enter passphrase to encrypt your session keys:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>File to save the exported session keys</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WelcomePage</name>
     <message>
-        <location filename="../../src/WelcomePage.cc" line="+44"/>
+        <location filename="../../src/WelcomePage.cpp" line="+46"/>
         <source>Welcome to nheko! The desktop client for the Matrix protocol.</source>
         <translation>Welkom bij nheko! Dé computerclient voor het Matrix-protocol.</translation>
     </message>
@@ -340,12 +617,12 @@
         <translation>Geniet van je verblijf!</translation>
     </message>
     <message>
-        <location line="+19"/>
+        <location line="+23"/>
         <source>REGISTER</source>
         <translation>REGISTREREN</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+5"/>
         <source>LOGIN</source>
         <translation>INLOGGEN</translation>
     </message>
@@ -353,12 +630,17 @@
 <context>
     <name>dialogs::CreateRoom</name>
     <message>
-        <location filename="../../src/dialogs/CreateRoom.cc" line="+32"/>
-        <source>CANCEL</source>
-        <translation>ANNULEREN</translation>
+        <location filename="../../src/dialogs/CreateRoom.cpp" line="+36"/>
+        <source>Create room</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+2"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuleren</translation>
+    </message>
+    <message>
+        <location line="+10"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
@@ -378,12 +660,12 @@
         <translation>Kamerzichtbaarheid</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+8"/>
         <source>Room Preset</source>
         <translation>Kamer-voorinstellingen</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+9"/>
         <source>Direct Chat</source>
         <translation>Directe chat</translation>
     </message>
@@ -391,12 +673,12 @@
 <context>
     <name>dialogs::InviteUsers</name>
     <message>
-        <location filename="../../src/dialogs/InviteUsers.cc" line="+36"/>
-        <source>CANCEL</source>
-        <translation>ANNULEREN</translation>
+        <location filename="../../src/dialogs/InviteUsers.cpp" line="+41"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+8"/>
         <source>User ID to invite</source>
         <translation>Uit te nodigen gebruikers-id</translation>
     </message>
@@ -404,12 +686,17 @@
 <context>
     <name>dialogs::JoinRoom</name>
     <message>
-        <location filename="../../src/dialogs/JoinRoom.cc" line="+30"/>
-        <source>CANCEL</source>
-        <translation>ANNULEREN</translation>
+        <location filename="../../src/dialogs/JoinRoom.cpp" line="+30"/>
+        <source>Join</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+2"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuleren</translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <source>Room ID or alias</source>
         <translation>Kamer-id of alias</translation>
     </message>
@@ -417,12 +704,12 @@
 <context>
     <name>dialogs::LeaveRoom</name>
     <message>
-        <location filename="../../src/dialogs/LeaveRoom.cc" line="+29"/>
-        <source>CANCEL</source>
-        <translation>ANNULEREN</translation>
+        <location filename="../../src/dialogs/LeaveRoom.cpp" line="+31"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+8"/>
         <source>Are you sure you want to leave?</source>
         <translation>Weet je zeker dat je wilt vertrekken?</translation>
     </message>
@@ -430,12 +717,12 @@
 <context>
     <name>dialogs::Logout</name>
     <message>
-        <location filename="../../src/dialogs/Logout.cc" line="+47"/>
-        <source>CANCEL</source>
-        <translation>ANNULEREN</translation>
+        <location filename="../../src/dialogs/Logout.cpp" line="+47"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+8"/>
         <source>Logout. Are you sure?</source>
         <translation>Uitloggen. Weet je het zeker?</translation>
     </message>
@@ -443,7 +730,7 @@
 <context>
     <name>dialogs::PreviewUploadOverlay</name>
     <message>
-        <location filename="../../src/dialogs/PreviewUploadOverlay.cc" line="+41"/>
+        <location filename="../../src/dialogs/PreviewUploadOverlay.cpp" line="+42"/>
         <source>Upload</source>
         <translation>Uploaden</translation>
     </message>
@@ -453,7 +740,7 @@
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+84"/>
         <source>Media type: %1
 Media size: %2
 </source>
@@ -465,14 +752,14 @@ Mediagrootte: %2
 <context>
     <name>dialogs::ReCaptcha</name>
     <message>
-        <location filename="../../src/dialogs/ReCaptcha.cpp" line="+34"/>
-        <source>CONFIRM</source>
-        <translation>BEVESTIGEN</translation>
+        <location filename="../../src/dialogs/ReCaptcha.cpp" line="+31"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>CANCEL</source>
-        <translation>ANNULEREN</translation>
+        <location line="+1"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+11"/>
@@ -483,20 +770,40 @@ Mediagrootte: %2
 <context>
     <name>dialogs::ReadReceipts</name>
     <message>
-        <location filename="../../src/dialogs/ReadReceipts.cc" line="+98"/>
+        <location filename="../../src/dialogs/ReadReceipts.cpp" line="+119"/>
         <source>Read receipts</source>
         <translation>Leesbevestigingen</translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dialogs::RoomSettings</name>
     <message>
-        <location filename="../../src/dialogs/RoomSettings.cpp" line="+147"/>
-        <source>CANCEL</source>
-        <translation>ANNULEREN</translation>
+        <location filename="../../src/dialogs/RoomSettings.cpp" line="+113"/>
+        <source>Settings</source>
+        <translation type="unfinished">Instellingen</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+3"/>
+        <source>Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Internal ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Notifications</source>
         <translation>Meldingen</translation>
     </message>
@@ -516,7 +823,7 @@ Mediagrootte: %2
         <translation>Alle berichten</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+7"/>
         <source>Room access</source>
         <translation>Kamertoegang</translation>
     </message>
@@ -535,11 +842,115 @@ Mediagrootte: %2
         <source>Invited users</source>
         <translation>Uitgenodigde gebruikers</translation>
     </message>
+    <message>
+        <location line="+50"/>
+        <source>Encryption</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>End-to-End Encryption</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Encryption is currently experimental and things might break unexpectedly. &lt;br&gt;Please take note that it can&apos;t be disabled afterwards.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <source>Respond to key requests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Whether or not the client should respond automatically with the session keys
+ upon request. Use with caution, this is a temporary measure to test the
+ E2E implementation until device verification is completed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+53"/>
+        <source>%n member(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+70"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+69"/>
+        <source>Failed to enable encryption: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+149"/>
+        <source>Select an avatar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>All Files (*)</source>
+        <translation type="unfinished">Alle bestanden (*)</translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The selected media is not an image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Error while reading media: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <location line="+20"/>
+        <source>Failed to upload image: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dialogs::UserProfile</name>
+    <message>
+        <location filename="../../src/dialogs/UserProfile.cpp" line="+63"/>
+        <source>Ban the user from the room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Ignore messages from this user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Kick the user from the room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Start a conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+57"/>
+        <source>Devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>emoji::Panel</name>
     <message>
-        <location filename="../../src/emoji/Panel.cc" line="+125"/>
+        <location filename="../../src/emoji/Panel.cpp" line="+125"/>
         <source>Smileys &amp; People</source>
         <translation>Smileys en mensen</translation>
     </message>

--- a/resources/langs/nheko_pl.ts
+++ b/resources/langs/nheko_pl.ts
@@ -4,7 +4,7 @@
 <context>
     <name>AudioItem</name>
     <message>
-        <location filename="../../src/timeline/widgets/AudioItem.cpp" line="+118"/>
+        <location filename="../../src/timeline/widgets/AudioItem.cpp" line="+117"/>
         <source>Save File</source>
         <translation>Zapisz plik</translation>
     </message>
@@ -12,7 +12,7 @@
 <context>
     <name>ChatPage</name>
     <message>
-        <location filename="../../src/ChatPage.cpp" line="+303"/>
+        <location filename="../../src/ChatPage.cpp" line="+309"/>
         <source>Failed to upload image. Please try again.</source>
         <translation>Nie udało się wysłać obrazu. Spróbuj ponownie.</translation>
     </message>
@@ -32,7 +32,7 @@
         <translation>Nie udało się wysłać filmu. Spróbuj ponownie.</translation>
     </message>
     <message>
-        <location line="+366"/>
+        <location line="+376"/>
         <source>Failed to restore OLM account. Please login again.</source>
         <translation>Nie udało się przywrócić konta OLM. Spróbuj zalogować się ponownie.</translation>
     </message>
@@ -42,8 +42,13 @@
         <translation>Nie udało się przywrócić zapisanych danych. Spróbuj zalogować się ponownie.</translation>
     </message>
     <message>
-        <location line="+212"/>
-        <location line="+150"/>
+        <location line="+169"/>
+        <source>Failed to setup encryption keys. Server response: %1 %2. Please try again later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+51"/>
+        <location line="+153"/>
         <source>Please try to login again: %1</source>
         <translation>Spróbuj zalogować się ponownie: %1</translation>
     </message>
@@ -59,32 +64,48 @@
     </message>
 </context>
 <context>
-    <name>DateSeparator</name>
+    <name>CommunitiesListItem</name>
     <message>
-        <location filename="../../src/ui/InfoMessage.cpp" line="+68"/>
-        <source>Today</source>
-        <translation>Dzisiaj</translation>
+        <location filename="../../src/CommunitiesListItem.cpp" line="+130"/>
+        <source>All rooms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Favourite rooms</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
-        <source>Yesterday</source>
-        <translation>Wczoraj</translation>
+        <source>Low priority rooms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+2"/>
+        <source> (tag)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source> (community)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>EditModal</name>
     <message>
-        <location filename="../../src/dialogs/RoomSettings.cpp" line="+59"/>
-        <source>APPLY</source>
-        <translation>ZASTOSUJ</translation>
+        <location filename="../../src/dialogs/RoomSettings.cpp" line="+58"/>
+        <source>Apply</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>CANCEL</source>
-        <translation>ANULUJ</translation>
+        <location line="+1"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Anuluj</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+10"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
@@ -97,7 +118,7 @@
 <context>
     <name>FileItem</name>
     <message>
-        <location filename="../../src/timeline/widgets/FileItem.cpp" line="+108"/>
+        <location filename="../../src/timeline/widgets/FileItem.cpp" line="+106"/>
         <source>Save File</source>
         <translation>Zapisz plik</translation>
     </message>
@@ -105,9 +126,17 @@
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/timeline/widgets/ImageItem.cpp" line="+236"/>
+        <location filename="../../src/timeline/widgets/ImageItem.cpp" line="+238"/>
         <source>Save image</source>
         <translation>Zapisz obraz</translation>
+    </message>
+</context>
+<context>
+    <name>InviteeItem</name>
+    <message>
+        <location filename="../../src/InviteeItem.cpp" line="+17"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -138,7 +167,17 @@
         <translation>ZALOGUJ</translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+83"/>
+        <source>Autodiscovery failed. Received malformed response.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Autodiscovery failed. Unknown error when requesting .well-known.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
         <source>The required endpoints were not found. Possibly not a Matrix server.</source>
         <translation>Nie odnaleziono wymaganych punktów końcowych. To może nie być serwer Matriksa.</translation>
     </message>
@@ -161,14 +200,14 @@
 <context>
     <name>MemberList</name>
     <message>
-        <location filename="../../src/dialogs/MemberList.cpp" line="+82"/>
+        <location filename="../../src/dialogs/MemberList.cpp" line="+96"/>
         <source>Room members</source>
         <translation>Członkowie pokoju</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <source>SHOW MORE</source>
-        <translation>POKAŻ WIĘCEJ</translation>
+        <location line="+33"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -202,7 +241,7 @@
         <translation>Serwer domowy</translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+16"/>
         <source>REGISTER</source>
         <translation>ZAREJESTRUJ</translation>
     </message>
@@ -228,14 +267,22 @@
     </message>
 </context>
 <context>
+    <name>ReplyPopup</name>
+    <message>
+        <location filename="../../src/popups/ReplyPopup.cpp" line="+45"/>
+        <source>Logout</source>
+        <translation type="unfinished">Wyloguj</translation>
+    </message>
+</context>
+<context>
     <name>RoomInfoListItem</name>
     <message>
-        <location filename="../../src/RoomInfoListItem.cpp" line="+77"/>
+        <location filename="../../src/RoomInfoListItem.cpp" line="+92"/>
         <source>Leave room</source>
         <translation>Opuść pokój</translation>
     </message>
     <message>
-        <location line="+153"/>
+        <location line="+174"/>
         <source>Accept</source>
         <translation>Akceptuj</translation>
     </message>
@@ -248,7 +295,7 @@
 <context>
     <name>SideBarActions</name>
     <message>
-        <location filename="../../src/SideBarActions.cpp" line="+32"/>
+        <location filename="../../src/SideBarActions.cpp" line="+38"/>
         <source>User settings</source>
         <translation>Ustawienia użytkownika</translation>
     </message>
@@ -276,7 +323,7 @@
 <context>
     <name>StatusIndicator</name>
     <message>
-        <location filename="../../src/timeline/TimelineItem.cpp" line="+126"/>
+        <location filename="../../src/timeline/TimelineItem.cpp" line="+106"/>
         <source>Encrypted</source>
         <translation>Szyfrowana</translation>
     </message>
@@ -299,18 +346,18 @@
 <context>
     <name>TextInputWidget</name>
     <message>
-        <location filename="../../src/TextInputWidget.cpp" line="+452"/>
+        <location filename="../../src/TextInputWidget.cpp" line="+506"/>
         <source>Send a file</source>
         <translation>Wyślij plik</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location filename="../../src/TextInputWidget.h" line="+154"/>
+        <location line="+13"/>
+        <location filename="../../src/TextInputWidget.h" line="+168"/>
         <source>Write a message...</source>
         <translation>Napisz wiadomość…</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+31"/>
         <source>Send a message</source>
         <translation>Wyślij wiadomość</translation>
     </message>
@@ -320,7 +367,7 @@
         <translation>Emoji</translation>
     </message>
     <message>
-        <location line="+77"/>
+        <location line="+75"/>
         <source>Select a file</source>
         <translation>Wybierz plik</translation>
     </message>
@@ -338,9 +385,19 @@
 <context>
     <name>TimelineItem</name>
     <message>
-        <location filename="../../src/timeline/TimelineItem.cpp" line="+76"/>
+        <location filename="../../src/timeline/TimelineItem.cpp" line="+85"/>
         <source>Message redaction failed: %1</source>
         <translation>Redagowanie wiadomości nie powiodło się: %1</translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Reply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -354,7 +411,7 @@
 <context>
     <name>TopRoomBar</name>
     <message>
-        <location filename="../../src/TopRoomBar.cpp" line="+68"/>
+        <location filename="../../src/TopRoomBar.cpp" line="+79"/>
         <source>Room options</source>
         <translation>Ustawienia pokoju</translation>
     </message>
@@ -382,7 +439,7 @@
 <context>
     <name>TrayIcon</name>
     <message>
-        <location filename="../../src/TrayIcon.cpp" line="+116"/>
+        <location filename="../../src/TrayIcon.cpp" line="+120"/>
         <source>Show</source>
         <translation>Pokaż</translation>
     </message>
@@ -395,7 +452,7 @@
 <context>
     <name>TypingDisplay</name>
     <message>
-        <location filename="../../src/TypingDisplay.cpp" line="+49"/>
+        <location filename="../../src/TypingDisplay.cpp" line="+45"/>
         <source> is typing</source>
         <translation> pisze</translation>
     </message>
@@ -408,7 +465,7 @@
 <context>
     <name>UserInfoWidget</name>
     <message>
-        <location filename="../../src/UserInfoWidget.cpp" line="+78"/>
+        <location filename="../../src/UserInfoWidget.cpp" line="+87"/>
         <source>Logout</source>
         <translation>Wyloguj</translation>
     </message>
@@ -416,7 +473,7 @@
 <context>
     <name>UserSettingsPage</name>
     <message>
-        <location filename="../../src/UserSettingsPage.cpp" line="+140"/>
+        <location filename="../../src/UserSettingsPage.cpp" line="+156"/>
         <source>Minimize to tray</source>
         <translation>Zminimalizuj do paska zadań</translation>
     </message>
@@ -426,12 +483,7 @@
         <translation>Rozpocznij na pasku zadań</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <source>Re-order rooms based on activity</source>
-        <translation>Porządkuj pokoje na podstawie aktywności</translation>
-    </message>
-    <message>
-        <location line="+9"/>
+        <location line="+11"/>
         <source>Group&apos;s sidebar</source>
         <translation>Pasek boczny grupy</translation>
     </message>
@@ -452,23 +504,48 @@
     </message>
     <message>
         <location line="+9"/>
-        <source>Scale factor (requires restart)</source>
-        <translation>Czynnik skalowania (wymaga ponownego uruchomienia)</translation>
+        <source>Scale factor</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+11"/>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Font Family</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+17"/>
         <source>Theme</source>
         <translation>Motyw</translation>
     </message>
     <message>
-        <location line="+21"/>
+        <location line="+27"/>
         <source>Device ID</source>
         <translation>ID urządzenia</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Device Fingerprint</source>
         <translation>Odcisk palca urządzenia</translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Session Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>IMPORT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>EXPORT</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+13"/>
@@ -476,15 +553,61 @@
         <translation>SZYFROWANIE</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+4"/>
         <source>GENERAL</source>
         <translation>OGÓLNE</translation>
+    </message>
+    <message>
+        <location line="+150"/>
+        <source>Open Sessions File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <location line="+18"/>
+        <location line="+9"/>
+        <location line="+2"/>
+        <location line="+2"/>
+        <location line="+19"/>
+        <location line="+10"/>
+        <location line="+18"/>
+        <location line="+2"/>
+        <location line="+2"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-73"/>
+        <location line="+32"/>
+        <source>File Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-31"/>
+        <source>Enter the passphrase to decrypt the file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+32"/>
+        <source>The password cannot be empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-8"/>
+        <source>Enter passphrase to encrypt your session keys:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>File to save the exported session keys</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WelcomePage</name>
     <message>
-        <location filename="../../src/WelcomePage.cpp" line="+44"/>
+        <location filename="../../src/WelcomePage.cpp" line="+46"/>
         <source>Welcome to nheko! The desktop client for the Matrix protocol.</source>
         <translation>Witamy w nheko! Desktopowy klient protokołu Matrix.</translation>
     </message>
@@ -494,12 +617,12 @@
         <translation>Udanego pobytu!</translation>
     </message>
     <message>
-        <location line="+19"/>
+        <location line="+23"/>
         <source>REGISTER</source>
         <translation>ZAREJESTRUJ SIĘ</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+5"/>
         <source>LOGIN</source>
         <translation>ZALOGUJ SIĘ</translation>
     </message>
@@ -507,12 +630,17 @@
 <context>
     <name>dialogs::CreateRoom</name>
     <message>
-        <location filename="../../src/dialogs/CreateRoom.cpp" line="+41"/>
-        <source>CANCEL</source>
-        <translation>ANULUJ</translation>
+        <location filename="../../src/dialogs/CreateRoom.cpp" line="+36"/>
+        <source>Create room</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+2"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Anuluj</translation>
+    </message>
+    <message>
+        <location line="+10"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
@@ -545,9 +673,9 @@
 <context>
     <name>dialogs::InviteUsers</name>
     <message>
-        <location filename="../../src/dialogs/InviteUsers.cpp" line="+40"/>
-        <source>CANCEL</source>
-        <translation>ANULUJ</translation>
+        <location filename="../../src/dialogs/InviteUsers.cpp" line="+41"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Anuluj</translation>
     </message>
     <message>
         <location line="+8"/>
@@ -558,12 +686,17 @@
 <context>
     <name>dialogs::JoinRoom</name>
     <message>
-        <location filename="../../src/dialogs/JoinRoom.cpp" line="+34"/>
-        <source>CANCEL</source>
-        <translation>ANULUJ</translation>
+        <location filename="../../src/dialogs/JoinRoom.cpp" line="+30"/>
+        <source>Join</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Anuluj</translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <source>Room ID or alias</source>
         <translation>ID pokoju lub alias</translation>
     </message>
@@ -571,12 +704,12 @@
 <context>
     <name>dialogs::LeaveRoom</name>
     <message>
-        <location filename="../../src/dialogs/LeaveRoom.cpp" line="+33"/>
-        <source>CANCEL</source>
-        <translation>ANULUJ</translation>
+        <location filename="../../src/dialogs/LeaveRoom.cpp" line="+31"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Anuluj</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+8"/>
         <source>Are you sure you want to leave?</source>
         <translation>Czy na pewno chcesz wyjść?</translation>
     </message>
@@ -584,12 +717,12 @@
 <context>
     <name>dialogs::Logout</name>
     <message>
-        <location filename="../../src/dialogs/Logout.cpp" line="+52"/>
-        <source>CANCEL</source>
-        <translation>ANULUJ</translation>
+        <location filename="../../src/dialogs/Logout.cpp" line="+47"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Anuluj</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+8"/>
         <source>Logout. Are you sure?</source>
         <translation>Czy na pewno chcesz wylogować się?</translation>
     </message>
@@ -607,7 +740,7 @@
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location line="+89"/>
+        <location line="+84"/>
         <source>Media type: %1
 Media size: %2
 </source>
@@ -619,14 +752,14 @@ Rozmiar multimediów: %2
 <context>
     <name>dialogs::ReCaptcha</name>
     <message>
-        <location filename="../../src/dialogs/ReCaptcha.cpp" line="+38"/>
-        <source>CONFIRM</source>
-        <translation>POTWIERDŹ</translation>
+        <location filename="../../src/dialogs/ReCaptcha.cpp" line="+31"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Anuluj</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>CANCEL</source>
-        <translation>ANULUJ</translation>
+        <location line="+1"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+11"/>
@@ -637,15 +770,25 @@ Rozmiar multimediów: %2
 <context>
     <name>dialogs::ReadReceipts</name>
     <message>
-        <location filename="../../src/dialogs/ReadReceipts.cpp" line="+104"/>
+        <location filename="../../src/dialogs/ReadReceipts.cpp" line="+119"/>
         <source>Read receipts</source>
         <translation>Potwierdzenia przeczytania</translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dialogs::RoomSettings</name>
     <message>
-        <location filename="../../src/dialogs/RoomSettings.cpp" line="+116"/>
+        <location filename="../../src/dialogs/RoomSettings.cpp" line="+113"/>
         <source>Settings</source>
         <translation>Ustawienia</translation>
     </message>
@@ -655,7 +798,7 @@ Rozmiar multimediów: %2
         <translation>Informacje</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+11"/>
         <source>Internal ID</source>
         <translation>Wewnętrzne ID</translation>
     </message>
@@ -738,12 +881,17 @@ Rozmiar multimediów: %2
         </translation>
     </message>
     <message>
-        <location line="+125"/>
+        <location line="+70"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+69"/>
         <source>Failed to enable encryption: %1</source>
         <translation>Nie udało się włączyć szyfrowania: %1</translation>
     </message>
     <message>
-        <location line="+158"/>
+        <location line="+149"/>
         <source>Select an avatar</source>
         <translation>Wybierz awatar</translation>
     </message>
@@ -772,7 +920,7 @@ Rozmiar multimediów: %2
 <context>
     <name>dialogs::UserProfile</name>
     <message>
-        <location filename="../../src/dialogs/UserProfile.cpp" line="+59"/>
+        <location filename="../../src/dialogs/UserProfile.cpp" line="+63"/>
         <source>Ban the user from the room</source>
         <translation>Zablokuj użytkownika w tym pokoju</translation>
     </message>
@@ -792,9 +940,14 @@ Rozmiar multimediów: %2
         <translation>Rozpocznij rozmowę</translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+57"/>
         <source>Devices</source>
         <translation>Urządzenia</translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/resources/langs/nheko_ru.ts
+++ b/resources/langs/nheko_ru.ts
@@ -12,7 +12,7 @@
 <context>
     <name>ChatPage</name>
     <message>
-        <location filename="../../src/ChatPage.cpp" line="+304"/>
+        <location filename="../../src/ChatPage.cpp" line="+309"/>
         <source>Failed to upload image. Please try again.</source>
         <translation>Не удалось загрузить изображение. Пожалуйста, попробуйте еще раз.</translation>
     </message>
@@ -32,7 +32,7 @@
         <translation>Не удалось загрузить видео. Пожалуйста, попробуйте еще раз.</translation>
     </message>
     <message>
-        <location line="+374"/>
+        <location line="+376"/>
         <source>Failed to restore OLM account. Please login again.</source>
         <translation>Не удалось восстановить учетную запись OLM. Пожалуйста, войдите снова.</translation>
     </message>
@@ -42,13 +42,13 @@
         <translation>Не удалось восстановить сохраненные данные. Пожалуйста, войдите снова.</translation>
     </message>
     <message>
-        <location line="+167"/>
+        <location line="+169"/>
         <source>Failed to setup encryption keys. Server response: %1 %2. Please try again later.</source>
         <translation>Не удалось настроить ключи шифрования. Ответ сервера:%1 %2. Пожалуйста, попробуйте позже.</translation>
     </message>
     <message>
         <location line="+51"/>
-        <location line="+152"/>
+        <location line="+153"/>
         <source>Please try to login again: %1</source>
         <translation>Повторите попытку входа: %1</translation>
     </message>
@@ -126,7 +126,7 @@
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/timeline/widgets/ImageItem.cpp" line="+237"/>
+        <location filename="../../src/timeline/widgets/ImageItem.cpp" line="+238"/>
         <source>Save image</source>
         <translation>Сохранить изображение</translation>
     </message>
@@ -167,7 +167,17 @@
         <translation>ВОЙТИ</translation>
     </message>
     <message>
-        <location line="+84"/>
+        <location line="+83"/>
+        <source>Autodiscovery failed. Received malformed response.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Autodiscovery failed. Unknown error when requesting .well-known.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
         <source>The required endpoints were not found. Possibly not a Matrix server.</source>
         <translation>Необходимые конечные точки не найдены. Возможно, это не сервер Matrix.</translation>
     </message>
@@ -257,6 +267,14 @@
     </message>
 </context>
 <context>
+    <name>ReplyPopup</name>
+    <message>
+        <location filename="../../src/popups/ReplyPopup.cpp" line="+45"/>
+        <source>Logout</source>
+        <translation type="unfinished">Выйти</translation>
+    </message>
+</context>
+<context>
     <name>RoomInfoListItem</name>
     <message>
         <location filename="../../src/RoomInfoListItem.cpp" line="+92"/>
@@ -264,7 +282,7 @@
         <translation>Покинуть комнату</translation>
     </message>
     <message>
-        <location line="+166"/>
+        <location line="+174"/>
         <source>Accept</source>
         <translation>Принять</translation>
     </message>
@@ -305,7 +323,7 @@
 <context>
     <name>StatusIndicator</name>
     <message>
-        <location filename="../../src/timeline/TimelineItem.cpp" line="+105"/>
+        <location filename="../../src/timeline/TimelineItem.cpp" line="+106"/>
         <source>Encrypted</source>
         <translation>Зашифровано</translation>
     </message>
@@ -328,13 +346,13 @@
 <context>
     <name>TextInputWidget</name>
     <message>
-        <location filename="../../src/TextInputWidget.cpp" line="+465"/>
+        <location filename="../../src/TextInputWidget.cpp" line="+506"/>
         <source>Send a file</source>
         <translation>Отправить файл</translation>
     </message>
     <message>
         <location line="+13"/>
-        <location filename="../../src/TextInputWidget.h" line="+153"/>
+        <location filename="../../src/TextInputWidget.h" line="+168"/>
         <source>Write a message...</source>
         <translation>Написать сообщение...</translation>
     </message>
@@ -344,7 +362,12 @@
         <translation>Отправить сообщение</translation>
     </message>
     <message>
-        <location line="+47"/>
+        <location line="+8"/>
+        <source>Emoji</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+75"/>
         <source>Select a file</source>
         <translation>Выберите файл</translation>
     </message>
@@ -362,9 +385,19 @@
 <context>
     <name>TimelineItem</name>
     <message>
-        <location filename="../../src/timeline/TimelineItem.cpp" line="+72"/>
+        <location filename="../../src/timeline/TimelineItem.cpp" line="+85"/>
         <source>Message redaction failed: %1</source>
         <translation>Ошибка редактирования сообщения: %1</translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Reply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -440,7 +473,7 @@
 <context>
     <name>UserSettingsPage</name>
     <message>
-        <location filename="../../src/UserSettingsPage.cpp" line="+147"/>
+        <location filename="../../src/UserSettingsPage.cpp" line="+156"/>
         <source>Minimize to tray</source>
         <translation>Сворачивать в системную панель</translation>
     </message>
@@ -481,11 +514,16 @@
     </message>
     <message>
         <location line="+11"/>
+        <source>Font Family</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+17"/>
         <source>Theme</source>
         <translation>Тема</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+27"/>
         <source>Device ID</source>
         <translation>ID устройства</translation>
     </message>
@@ -520,7 +558,7 @@
         <translation>ГЛАВНОЕ</translation>
     </message>
     <message>
-        <location line="+144"/>
+        <location line="+150"/>
         <source>Open Sessions File</source>
         <translation>Открыть файл сеансов</translation>
     </message>
@@ -532,14 +570,14 @@
         <location line="+2"/>
         <location line="+19"/>
         <location line="+10"/>
-        <location line="+13"/>
+        <location line="+18"/>
         <location line="+2"/>
         <location line="+2"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="-68"/>
+        <location line="-73"/>
         <location line="+32"/>
         <source>File Password</source>
         <translatorcomment>Или введите пароль?</translatorcomment>
@@ -909,6 +947,49 @@ Media size: %2
         <location line="+39"/>
         <source>ESC</source>
         <translation></translation>
+    </message>
+</context>
+<context>
+    <name>emoji::Panel</name>
+    <message>
+        <location filename="../../src/emoji/Panel.cpp" line="+125"/>
+        <source>Smileys &amp; People</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Animals &amp; Nature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Food &amp; Drink</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Activity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Travel &amp; Places</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Flags</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/resources/langs/nheko_zh_CN.ts
+++ b/resources/langs/nheko_zh_CN.ts
@@ -12,7 +12,7 @@
 <context>
     <name>ChatPage</name>
     <message>
-        <location filename="../../src/ChatPage.cpp" line="+304"/>
+        <location filename="../../src/ChatPage.cpp" line="+309"/>
         <source>Failed to upload image. Please try again.</source>
         <translation>上传图像失败。请重试。</translation>
     </message>
@@ -32,7 +32,7 @@
         <translation>上传视频失败。请重试。</translation>
     </message>
     <message>
-        <location line="+371"/>
+        <location line="+376"/>
         <source>Failed to restore OLM account. Please login again.</source>
         <translation>恢复 OLM 账户失败。请重新登录。</translation>
     </message>
@@ -42,13 +42,13 @@
         <translation>恢复保存的数据失败。请重新登录。</translation>
     </message>
     <message>
-        <location line="+167"/>
-        <source>Failed to setup encryption keys. Server response: %s %d. Please try again later.</source>
-        <translation>建立加密密钥失败。 服务器返回：%s %d. 请稍后重试。</translation>
+        <location line="+169"/>
+        <source>Failed to setup encryption keys. Server response: %1 %2. Please try again later.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+51"/>
-        <location line="+150"/>
+        <location line="+153"/>
         <source>Please try to login again: %1</source>
         <translation>请尝试再次登录：%1</translation>
     </message>
@@ -64,32 +64,48 @@
     </message>
 </context>
 <context>
-    <name>DateSeparator</name>
+    <name>CommunitiesListItem</name>
     <message>
-        <location filename="../../src/ui/InfoMessage.cpp" line="+68"/>
-        <source>Today</source>
-        <translation>今天</translation>
+        <location filename="../../src/CommunitiesListItem.cpp" line="+130"/>
+        <source>All rooms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Favourite rooms</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
-        <source>Yesterday</source>
-        <translation>昨天</translation>
+        <source>Low priority rooms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+2"/>
+        <source> (tag)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source> (community)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>EditModal</name>
     <message>
-        <location filename="../../src/dialogs/RoomSettings.cpp" line="+60"/>
-        <source>APPLY</source>
-        <translation>应用</translation>
+        <location filename="../../src/dialogs/RoomSettings.cpp" line="+58"/>
+        <source>Apply</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>CANCEL</source>
-        <translation>取消</translation>
+        <location line="+1"/>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+10"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
@@ -113,6 +129,14 @@
         <location filename="../../src/timeline/widgets/ImageItem.cpp" line="+238"/>
         <source>Save image</source>
         <translation>保存图像</translation>
+    </message>
+</context>
+<context>
+    <name>InviteeItem</name>
+    <message>
+        <location filename="../../src/InviteeItem.cpp" line="+17"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -143,7 +167,17 @@
         <translation>登录</translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+83"/>
+        <source>Autodiscovery failed. Received malformed response.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Autodiscovery failed. Unknown error when requesting .well-known.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
         <source>The required endpoints were not found. Possibly not a Matrix server.</source>
         <translation>没找到要求的终端。可能不是一个 Matrix 服务器。</translation>
     </message>
@@ -166,14 +200,14 @@
 <context>
     <name>MemberList</name>
     <message>
-        <location filename="../../src/dialogs/MemberList.cpp" line="+82"/>
+        <location filename="../../src/dialogs/MemberList.cpp" line="+96"/>
         <source>Room members</source>
         <translation>聊天室成员</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <source>SHOW MORE</source>
-        <translation>显示更多</translation>
+        <location line="+33"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -207,7 +241,7 @@
         <translation>服务器</translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+16"/>
         <source>REGISTER</source>
         <translation>注册</translation>
     </message>
@@ -233,14 +267,22 @@
     </message>
 </context>
 <context>
+    <name>ReplyPopup</name>
+    <message>
+        <location filename="../../src/popups/ReplyPopup.cpp" line="+45"/>
+        <source>Logout</source>
+        <translation type="unfinished">登出</translation>
+    </message>
+</context>
+<context>
     <name>RoomInfoListItem</name>
     <message>
-        <location filename="../../src/RoomInfoListItem.cpp" line="+79"/>
+        <location filename="../../src/RoomInfoListItem.cpp" line="+92"/>
         <source>Leave room</source>
         <translation>离开聊天室</translation>
     </message>
     <message>
-        <location line="+156"/>
+        <location line="+174"/>
         <source>Accept</source>
         <translation>接受</translation>
     </message>
@@ -253,7 +295,7 @@
 <context>
     <name>SideBarActions</name>
     <message>
-        <location filename="../../src/SideBarActions.cpp" line="+32"/>
+        <location filename="../../src/SideBarActions.cpp" line="+38"/>
         <source>User settings</source>
         <translation>用户设置</translation>
     </message>
@@ -281,7 +323,7 @@
 <context>
     <name>StatusIndicator</name>
     <message>
-        <location filename="../../src/timeline/TimelineItem.cpp" line="+169"/>
+        <location filename="../../src/timeline/TimelineItem.cpp" line="+106"/>
         <source>Encrypted</source>
         <translation>加密的</translation>
     </message>
@@ -304,18 +346,18 @@
 <context>
     <name>TextInputWidget</name>
     <message>
-        <location filename="../../src/TextInputWidget.cpp" line="+452"/>
+        <location filename="../../src/TextInputWidget.cpp" line="+506"/>
         <source>Send a file</source>
         <translation>发送一个文件</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location filename="../../src/TextInputWidget.h" line="+154"/>
+        <location line="+13"/>
+        <location filename="../../src/TextInputWidget.h" line="+168"/>
         <source>Write a message...</source>
         <translation>写一条消息...</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+31"/>
         <source>Send a message</source>
         <translation>发送一条消息</translation>
     </message>
@@ -325,7 +367,7 @@
         <translation></translation>
     </message>
     <message>
-        <location line="+77"/>
+        <location line="+75"/>
         <source>Select a file</source>
         <translation>选择一个文件</translation>
     </message>
@@ -343,9 +385,19 @@
 <context>
     <name>TimelineItem</name>
     <message>
-        <location filename="../../src/timeline/TimelineItem.cpp" line="+78"/>
+        <location filename="../../src/timeline/TimelineItem.cpp" line="+85"/>
         <source>Message redaction failed: %1</source>
         <translation>删除消息失败：%1</translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Reply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -359,7 +411,7 @@
 <context>
     <name>TopRoomBar</name>
     <message>
-        <location filename="../../src/TopRoomBar.cpp" line="+68"/>
+        <location filename="../../src/TopRoomBar.cpp" line="+79"/>
         <source>Room options</source>
         <translation>聊天室选项</translation>
     </message>
@@ -387,7 +439,7 @@
 <context>
     <name>TrayIcon</name>
     <message>
-        <location filename="../../src/TrayIcon.cpp" line="+116"/>
+        <location filename="../../src/TrayIcon.cpp" line="+120"/>
         <source>Show</source>
         <translation>显示</translation>
     </message>
@@ -400,7 +452,7 @@
 <context>
     <name>TypingDisplay</name>
     <message>
-        <location filename="../../src/TypingDisplay.cpp" line="+49"/>
+        <location filename="../../src/TypingDisplay.cpp" line="+45"/>
         <source> is typing</source>
         <translation> 正在打字</translation>
     </message>
@@ -413,7 +465,7 @@
 <context>
     <name>UserInfoWidget</name>
     <message>
-        <location filename="../../src/UserInfoWidget.cpp" line="+78"/>
+        <location filename="../../src/UserInfoWidget.cpp" line="+87"/>
         <source>Logout</source>
         <translation>登出</translation>
     </message>
@@ -421,7 +473,7 @@
 <context>
     <name>UserSettingsPage</name>
     <message>
-        <location filename="../../src/UserSettingsPage.cpp" line="+143"/>
+        <location filename="../../src/UserSettingsPage.cpp" line="+156"/>
         <source>Minimize to tray</source>
         <translation>最小化至托盘</translation>
     </message>
@@ -431,12 +483,7 @@
         <translation>在托盘启动</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <source>Re-order rooms based on activity</source>
-        <translation>根据活动重排序聊天室</translation>
-    </message>
-    <message>
-        <location line="+9"/>
+        <location line="+11"/>
         <source>Group&apos;s sidebar</source>
         <translation>群组侧边栏</translation>
     </message>
@@ -457,26 +504,36 @@
     </message>
     <message>
         <location line="+9"/>
-        <source>Scale factor (requires restart)</source>
-        <translation>缩放系数（需要重启）</translation>
+        <source>Scale factor</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+11"/>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Font Family</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+17"/>
         <source>Theme</source>
         <translation>主题</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+27"/>
         <source>Device ID</source>
         <translation>设备 ID</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Device Fingerprint</source>
         <translation>设备指纹</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+11"/>
         <source>Session Keys</source>
         <translation>会话密钥</translation>
     </message>
@@ -501,48 +558,48 @@
         <translation>通用</translation>
     </message>
     <message>
-        <location line="+184"/>
+        <location line="+150"/>
         <source>Open Sessions File</source>
         <translation>打开会话文件</translation>
     </message>
     <message>
         <location line="+4"/>
-        <location line="+16"/>
+        <location line="+18"/>
         <location line="+9"/>
         <location line="+2"/>
         <location line="+2"/>
-        <location line="+17"/>
+        <location line="+19"/>
         <location line="+10"/>
-        <location line="+13"/>
+        <location line="+18"/>
         <location line="+2"/>
         <location line="+2"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location line="-64"/>
-        <location line="+30"/>
+        <location line="-73"/>
+        <location line="+32"/>
         <source>File Password</source>
         <translation>文件密码</translation>
     </message>
     <message>
-        <location line="-29"/>
+        <location line="-31"/>
         <source>Enter the passphrase to decrypt the file:</source>
         <translation>输入密码以解密文件：</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+30"/>
+        <location line="+8"/>
+        <location line="+32"/>
         <source>The password cannot be empty</source>
         <translation>密码不能为空</translation>
     </message>
     <message>
-        <location line="-6"/>
+        <location line="-8"/>
         <source>Enter passphrase to encrypt your session keys:</source>
         <translation>输入密码以加密你的会话密钥：</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+14"/>
         <source>File to save the exported session keys</source>
         <translation>保存导出的会话密钥的文件</translation>
     </message>
@@ -550,7 +607,7 @@
 <context>
     <name>WelcomePage</name>
     <message>
-        <location filename="../../src/WelcomePage.cpp" line="+44"/>
+        <location filename="../../src/WelcomePage.cpp" line="+46"/>
         <source>Welcome to nheko! The desktop client for the Matrix protocol.</source>
         <translation>欢迎使用 nheko! Matrix 协议的桌面客户端。</translation>
     </message>
@@ -560,12 +617,12 @@
         <translation>祝您使用愉快！</translation>
     </message>
     <message>
-        <location line="+19"/>
+        <location line="+23"/>
         <source>REGISTER</source>
         <translation>注册</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+5"/>
         <source>LOGIN</source>
         <translation>登录</translation>
     </message>
@@ -573,12 +630,17 @@
 <context>
     <name>dialogs::CreateRoom</name>
     <message>
-        <location filename="../../src/dialogs/CreateRoom.cpp" line="+41"/>
-        <source>CANCEL</source>
-        <translation>取消</translation>
+        <location filename="../../src/dialogs/CreateRoom.cpp" line="+36"/>
+        <source>Create room</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+2"/>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <location line="+10"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
@@ -611,9 +673,9 @@
 <context>
     <name>dialogs::InviteUsers</name>
     <message>
-        <location filename="../../src/dialogs/InviteUsers.cpp" line="+40"/>
-        <source>CANCEL</source>
-        <translation>取消</translation>
+        <location filename="../../src/dialogs/InviteUsers.cpp" line="+41"/>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
     </message>
     <message>
         <location line="+8"/>
@@ -624,12 +686,17 @@
 <context>
     <name>dialogs::JoinRoom</name>
     <message>
-        <location filename="../../src/dialogs/JoinRoom.cpp" line="+34"/>
-        <source>CANCEL</source>
-        <translation>取消</translation>
+        <location filename="../../src/dialogs/JoinRoom.cpp" line="+30"/>
+        <source>Join</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <source>Room ID or alias</source>
         <translation>聊天室 ID 或别名</translation>
     </message>
@@ -637,12 +704,12 @@
 <context>
     <name>dialogs::LeaveRoom</name>
     <message>
-        <location filename="../../src/dialogs/LeaveRoom.cpp" line="+33"/>
-        <source>CANCEL</source>
-        <translation>取消</translation>
+        <location filename="../../src/dialogs/LeaveRoom.cpp" line="+31"/>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+8"/>
         <source>Are you sure you want to leave?</source>
         <translation>你确定要离开吗？</translation>
     </message>
@@ -650,12 +717,12 @@
 <context>
     <name>dialogs::Logout</name>
     <message>
-        <location filename="../../src/dialogs/Logout.cpp" line="+52"/>
-        <source>CANCEL</source>
-        <translation>取消</translation>
+        <location filename="../../src/dialogs/Logout.cpp" line="+47"/>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+8"/>
         <source>Logout. Are you sure?</source>
         <translation>登出。确定吗？</translation>
     </message>
@@ -673,7 +740,7 @@
         <translation>取消</translation>
     </message>
     <message>
-        <location line="+89"/>
+        <location line="+84"/>
         <source>Media type: %1
 Media size: %2
 </source>
@@ -685,14 +752,14 @@ Media size: %2
 <context>
     <name>dialogs::ReCaptcha</name>
     <message>
-        <location filename="../../src/dialogs/ReCaptcha.cpp" line="+38"/>
-        <source>CONFIRM</source>
-        <translation>确定</translation>
+        <location filename="../../src/dialogs/ReCaptcha.cpp" line="+31"/>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>CANCEL</source>
-        <translation>取消</translation>
+        <location line="+1"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+11"/>
@@ -703,15 +770,25 @@ Media size: %2
 <context>
     <name>dialogs::ReadReceipts</name>
     <message>
-        <location filename="../../src/dialogs/ReadReceipts.cpp" line="+104"/>
+        <location filename="../../src/dialogs/ReadReceipts.cpp" line="+119"/>
         <source>Read receipts</source>
         <translation>阅读回执</translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dialogs::RoomSettings</name>
     <message>
-        <location filename="../../src/dialogs/RoomSettings.cpp" line="+109"/>
+        <location filename="../../src/dialogs/RoomSettings.cpp" line="+113"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
@@ -802,12 +879,17 @@ Media size: %2
         </translation>
     </message>
     <message>
-        <location line="+126"/>
+        <location line="+70"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+69"/>
         <source>Failed to enable encryption: %1</source>
         <translation>启用加密失败：%1</translation>
     </message>
     <message>
-        <location line="+158"/>
+        <location line="+149"/>
         <source>Select an avatar</source>
         <translation>选择一个头像</translation>
     </message>
@@ -836,7 +918,7 @@ Media size: %2
 <context>
     <name>dialogs::UserProfile</name>
     <message>
-        <location filename="../../src/dialogs/UserProfile.cpp" line="+59"/>
+        <location filename="../../src/dialogs/UserProfile.cpp" line="+63"/>
         <source>Ban the user from the room</source>
         <translation>在这个聊天室封禁这个用户</translation>
     </message>
@@ -856,9 +938,14 @@ Media size: %2
         <translation>开始一个聊天</translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+57"/>
         <source>Devices</source>
         <translation>设备</translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>ESC</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/LoginPage.cpp
+++ b/src/LoginPage.cpp
@@ -315,6 +315,12 @@ LoginPage::onLoginButtonClicked()
                           return;
                   }
 
+                  if (res.well_known) {
+                          http::client()->set_server(res.well_known->homeserver.base_url);
+                          nhlog::net()->info("Login requested to user server: " +
+                                             res.well_known->homeserver.base_url);
+                  }
+
                   emit loginOk(res);
           });
 

--- a/src/LoginPage.cpp
+++ b/src/LoginPage.cpp
@@ -209,7 +209,7 @@ LoginPage::onMatrixIdEntered()
                                 emit versionErrorCb(tr("Autodiscovery failed. Unknown error when "
                                                        "requesting .well-known."));
                                 nhlog::net()->error("Autodiscovery failed. Unknown error when "
-                                                    "requesting .weel-known.");
+                                                    "requesting .well-known.");
                                 return;
                         }
 

--- a/src/LoginPage.cpp
+++ b/src/LoginPage.cpp
@@ -20,6 +20,7 @@
 #include <mtx/identifiers.hpp>
 
 #include "Config.h"
+#include "Logging.h"
 #include "LoginPage.h"
 #include "MatrixClient.h"
 #include "ui/FlatButton.h"
@@ -186,7 +187,37 @@ LoginPage::onMatrixIdEntered()
                 serverInput_->setText(homeServer);
 
                 http::client()->set_server(user.hostname());
-                checkHomeserverVersion();
+                http::client()->well_known([this](const mtx::responses::WellKnown &res,
+                                                  mtx::http::RequestErr err) {
+                        if (err) {
+                                using namespace boost::beast::http;
+
+                                if (err->status_code == status::not_found) {
+                                        nhlog::net()->info("Autodiscovery: No .well-known.");
+                                        checkHomeserverVersion();
+                                        return;
+                                }
+
+                                if (!err->parse_error.empty()) {
+                                        emit versionErrorCb(
+                                          tr("Autodiscovery failed. Received malformed response."));
+                                        nhlog::net()->error(
+                                          "Autodiscovery failed. Received malformed response.");
+                                        return;
+                                }
+
+                                emit versionErrorCb(tr("Autodiscovery failed. Unknown error when "
+                                                       "requesting .well-known."));
+                                nhlog::net()->error("Autodiscovery failed. Unknown error when "
+                                                    "requesting .weel-known.");
+                                return;
+                        }
+
+                        nhlog::net()->info("Autodiscovery: Discovered '" + res.homeserver.base_url +
+                                           "'");
+                        http::client()->set_server(res.homeserver.base_url);
+                        checkHomeserverVersion();
+                });
         }
 }
 
@@ -272,7 +303,6 @@ LoginPage::onLoginButtonClicked()
         if (password_input_->text().isEmpty())
                 return loginError(tr("Empty password"));
 
-        http::client()->set_server(serverInput_->text().toStdString());
         http::client()->login(
           user.localpart(),
           password_input_->text().toStdString(),

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -342,10 +342,10 @@ utils::linkColor()
         return QPalette().color(QPalette::Link).name();
 }
 
-int
+uint32_t
 utils::hashQString(const QString &input)
 {
-        auto hash = 0;
+        uint32_t hash = 0;
 
         for (int i = 0; i < input.length(); i++) {
                 hash = input.at(i).digitValue() + ((hash << 5) - hash);
@@ -363,7 +363,7 @@ utils::generateContrastingHexColor(const QString &input, const QString &backgrou
         // Create a color for the input
         auto hash = hashQString(input);
         // create a hue value based on the hash of the input.
-        auto userHue = qAbs(hash % 360);
+        auto userHue = static_cast<int>(qAbs(hash % 360));
         // start with moderate saturation and lightness values.
         auto sat       = 220;
         auto lightness = 125;

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -243,7 +243,7 @@ QString
 linkColor();
 
 //! Returns the hash code of the input QString
-int
+uint32_t
 hashQString(const QString &input);
 
 //! Generate a color (matching #RRGGBB) that has an acceptable contrast to background that is based


### PR DESCRIPTION
With this nheko autodiscovers the server by looking at `/.well-known/matrix/client`. [Specification](https://matrix.org/docs/spec/client_server/latest#server-discovery).

I've also implemented handling the well_known field in login responses, but I don't verify the url there. I expect servers which have such a setup to have setup it correctly. Otherwise I don't know how to handle it correctly, fail the login and request the server name?

The translation update is quite big, as it seems like the translations weren't kept up to date.

This won't build yet, I guess, because I haven't updated the mtxclient hash. I'll do that, when the changes in https://github.com/Nheko-Reborn/mtxclient/pull/19 land. For now this is just provided to ease testing.