### PR TITLE
escape html before parsing commonmark

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -324,10 +324,25 @@ utils::linkifyMessage(const QString &body)
         return doc;
 }
 
+QByteArray escapeRawHtml(const QByteArray &data) {
+      QByteArray buffer;
+      const size_t length = data.size();
+      buffer.reserve(length);
+      for(size_t pos = 0; pos != length; ++pos) {
+            switch(data.at(pos)) {
+                  case '&':  buffer.append("&amp;");      break;
+                  case '<':  buffer.append("&lt;");       break;
+                  case '>':  buffer.append("&gt;");       break;
+                  default:   buffer.append(data.at(pos)); break;
+            }
+      }
+     return buffer;
+}
+
 QString
 utils::markdownToHtml(const QString &text)
 {
-        const auto str = text.toUtf8();
+        const auto str = escapeRawHtml(text.toUtf8());
         const char *tmp_buf =
           cmark_markdown_to_html(str.constData(), str.size(), CMARK_OPT_DEFAULT);
 


### PR DESCRIPTION
CommonMark (and markdown) allows raw html tags. This is good for writing a complex text but it's probably a bad idea when messaging. If you don't know about this you may type something like
`<yourname>` to mean a placeholder but this will disappear entirely from the text.
Even worse, someone you are chatting with may do that and you won't even notice.

Cmark doesn't have an option to disable raw html so I escape tags before parsing the text.