### PR TITLE
Update README with reference to Debian package

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ can be found in the [Github releases](https://github.com/Nheko-Reborn/nheko/rele
 pacaur -S nheko # nheko-git
 ```
 
+#### Debian (10 and above)
+
+```bash
+sudo apt install nheko
+```
+
 #### Fedora
 ```bash
 sudo dnf install nheko


### PR DESCRIPTION
I just discovered the [nheko Debian package](https://packages.debian.org/buster/nheko). It is available in the current stable release (Debian 10 'buster') or higher.