### PR TITLE
Remove move() in ImageOverlay

### DIFF
--- a/src/dialogs/ImageOverlay.cpp
+++ b/src/dialogs/ImageOverlay.cpp
@@ -43,7 +43,6 @@ ImageOverlay::ImageOverlay(QPixmap image, QWidget *parent)
 
         screen_ = QGuiApplication::primaryScreen()->availableGeometry();
 
-        move(QApplication::desktop()->mapToGlobal(screen_.topLeft()));
         resize(screen_.size());
 
         connect(this, SIGNAL(closing()), this, SLOT(close()));

--- a/src/dialogs/ImageOverlay.cpp
+++ b/src/dialogs/ImageOverlay.cpp
@@ -41,10 +41,6 @@ ImageOverlay::ImageOverlay(QPixmap image, QWidget *parent)
         setAttribute(Qt::WA_DeleteOnClose, true);
         setWindowState(Qt::WindowFullScreen);
 
-        screen_ = QGuiApplication::primaryScreen()->availableGeometry();
-
-        resize(screen_.size());
-
         connect(this, SIGNAL(closing()), this, SLOT(close()));
 
         raise();
@@ -59,15 +55,15 @@ ImageOverlay::paintEvent(QPaintEvent *event)
         painter.setRenderHint(QPainter::Antialiasing);
 
         // Full screen overlay.
-        painter.fillRect(QRect(0, 0, screen_.width(), screen_.height()), QColor(55, 55, 55, 170));
+        painter.fillRect(QRect(0, 0, width(), height()), QColor(55, 55, 55, 170));
 
         // Left and Right margins
-        int outer_margin = screen_.width() * 0.12;
+        int outer_margin = width() * 0.12;
         int buttonSize   = 36;
         int margin       = outer_margin * 0.1;
 
-        int max_width  = screen_.width() - 2 * outer_margin;
-        int max_height = screen_.height();
+        int max_width  = width() - 2 * outer_margin;
+        int max_height = height();
 
         image_ = utils::scaleDown(max_width, max_height, originalImage_);
 
@@ -75,10 +71,9 @@ ImageOverlay::paintEvent(QPaintEvent *event)
         int diff_y = max_height - image_.height();
 
         content_ = QRect(outer_margin + diff_x / 2, diff_y / 2, image_.width(), image_.height());
-        close_button_ =
-          QRect(screen_.width() - margin - buttonSize, margin, buttonSize, buttonSize);
+        close_button_ = QRect(width() - margin - buttonSize, margin, buttonSize, buttonSize);
         save_button_ =
-          QRect(screen_.width() - (2 * margin) - (2 * buttonSize), margin, buttonSize, buttonSize);
+          QRect(width() - (2 * margin) - (2 * buttonSize), margin, buttonSize, buttonSize);
 
         // Draw main content_.
         painter.drawPixmap(content_, image_);

--- a/src/dialogs/ImageOverlay.h
+++ b/src/dialogs/ImageOverlay.h
@@ -44,6 +44,5 @@ private:
         QRect content_;
         QRect close_button_;
         QRect save_button_;
-        QRect screen_;
 };
 } // dialogs

--- a/src/timeline/TimelineViewManager.cpp
+++ b/src/timeline/TimelineViewManager.cpp
@@ -158,7 +158,7 @@ TimelineViewManager::openImageOverlay(QString mxcUrl, QString eventId) const
                 auto pixmap = QPixmap::fromImage(imgResponse->textureFactory()->image());
 
                 auto imgDialog = new dialogs::ImageOverlay(pixmap);
-                imgDialog->show();
+                imgDialog->showFullScreen();
                 connect(imgDialog, &dialogs::ImageOverlay::saving, timeline_, [this, eventId]() {
                         timeline_->saveMedia(eventId);
                 });


### PR DESCRIPTION
it was causing the full screen image overlay to appear on the "primary display" vs. the actual display nheko is running on.

removing the move() call makes the overlay follow the window around.

I wasn't able to get the `parent()->screen` method working first go.

I tested on plasma, Nico in the matrix room said he'd give it a shot in his DE to see if it works there as well.