### PR TITLE
UserSettingsPage: device fingerprint on its own line

### DIFF
--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -293,7 +293,7 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         QFont monospaceFont;
         monospaceFont.setFamily("Monospace");
         monospaceFont.setStyleHint(QFont::Monospace);
-        monospaceFont.setPointSizeF(monospaceFont.pointSizeF() * 0.9);
+        monospaceFont.setPointSizeF(monospaceFont.pointSizeF() * 0.8);
 
         auto deviceIdLayout = new QHBoxLayout;
         deviceIdLayout->setContentsMargins(0, OptionMargin, 0, OptionMargin);
@@ -310,6 +310,9 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         auto deviceFingerprintLayout = new QHBoxLayout;
         deviceFingerprintLayout->setContentsMargins(0, OptionMargin, 0, OptionMargin);
 
+        auto deviceFingerprintValueLayout = new QHBoxLayout;
+        deviceFingerprintValueLayout->setContentsMargins(0, 0, 0, OptionMargin);
+
         auto deviceFingerprintLabel = new QLabel(tr("Device Fingerprint"), this);
         deviceFingerprintLabel->setFont(font);
         deviceFingerprintLabel->setMargin(0);
@@ -317,7 +320,7 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         deviceFingerprintValue_->setTextInteractionFlags(Qt::TextSelectableByMouse);
         deviceFingerprintValue_->setFont(monospaceFont);
         deviceFingerprintLayout->addWidget(deviceFingerprintLabel, 1);
-        deviceFingerprintLayout->addWidget(deviceFingerprintValue_);
+        deviceFingerprintValueLayout->addWidget(deviceFingerprintValue_, 0, Qt::AlignRight);
 
         auto sessionKeysLayout = new QHBoxLayout;
         sessionKeysLayout->setContentsMargins(0, OptionMargin, 0, OptionMargin);
@@ -336,6 +339,7 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
 
         encryptionLayout_->addLayout(deviceIdLayout);
         encryptionLayout_->addLayout(deviceFingerprintLayout);
+        encryptionLayout_->addLayout(deviceFingerprintValueLayout);
         encryptionLayout_->addWidget(new HorizontalLine{this});
         encryptionLayout_->addLayout(sessionKeysLayout);
 


### PR DESCRIPTION
pinephone users have an unusable settings page, as the device fingerprint stops the layout from shrinking enough to fit the form toggles into view.

the `deviceFingerprintValue_` is now on a new line, and the font size for `monospaceFont` has been slightly reduced. this also makes the device ID label a smidge smaller, but IMO it looks like it fits.

now the thing hitching the layout is the dropdowns for font selection. it seems like this could probably be solved with a more cohesive mobile / responsive design than fixing individual widgets. but I think maybe its worth making the settings screen usable on mobile at all vs. waiting for a big refactor.

I realize all this discussion happened in the matrix room without any maintainers around, happy to hear any feedback or whether you have alternative plans to address this.

as of 0.7.0-dev look:
![image](https://user-images.githubusercontent.com/60991921/74398825-3500f880-4def-11ea-98f2-832288e575b8.png)

new look:
![image](https://user-images.githubusercontent.com/60991921/74398746-06831d80-4def-11ea-9055-b8b3c517f8a5.png)

