### PR TITLE
use the standard system download path for file downloads

### DIFF
--- a/src/TextInputWidget.cpp
+++ b/src/TextInputWidget.cpp
@@ -626,8 +626,9 @@ TextInputWidget::command(QString command, QString args)
 void
 TextInputWidget::openFileSelection()
 {
+        const QString homeFolder = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
         const auto fileName =
-          QFileDialog::getOpenFileName(this, tr("Select a file"), "", tr("All Files (*)"));
+          QFileDialog::getOpenFileName(this, tr("Select a file"), homeFolder, tr("All Files (*)"));
 
         if (fileName.isEmpty())
                 return;

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -27,6 +27,7 @@
 #include <QPushButton>
 #include <QScrollArea>
 #include <QSettings>
+#include <QStandardPaths>
 #include <QString>
 #include <QTextStream>
 
@@ -513,7 +514,9 @@ UserSettingsPage::paintEvent(QPaintEvent *)
 void
 UserSettingsPage::importSessionKeys()
 {
-        auto fileName = QFileDialog::getOpenFileName(this, tr("Open Sessions File"), "", "");
+        const QString homeFolder = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
+        const QString fileName =
+          QFileDialog::getOpenFileName(this, tr("Open Sessions File"), homeFolder, "");
 
         QFile file(fileName);
         if (!file.open(QIODevice::ReadOnly)) {
@@ -572,7 +575,8 @@ UserSettingsPage::exportSessionKeys()
         }
 
         // Open file dialog to save the file.
-        auto fileName =
+        const QString homeFolder = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
+        const QString fileName =
           QFileDialog::getSaveFileName(this, tr("File to save the exported session keys"), "", "");
 
         QFile file(fileName);

--- a/src/dialogs/RoomSettings.cpp
+++ b/src/dialogs/RoomSettings.cpp
@@ -11,6 +11,7 @@
 #include <QPushButton>
 #include <QShortcut>
 #include <QShowEvent>
+#include <QStandardPaths>
 #include <QStyleOption>
 #include <QVBoxLayout>
 
@@ -740,8 +741,10 @@ RoomSettings::resetErrorLabel()
 void
 RoomSettings::updateAvatar()
 {
-        const auto fileName =
-          QFileDialog::getOpenFileName(this, tr("Select an avatar"), "", tr("All Files (*)"));
+        const QString picturesFolder =
+          QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
+        const QString fileName = QFileDialog::getOpenFileName(
+          this, tr("Select an avatar"), picturesFolder, tr("All Files (*)"));
 
         if (fileName.isEmpty())
                 return;

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -1299,7 +1299,8 @@ TimelineModel::saveMedia(QString eventId) const
         }
 
         const QString filterString = QMimeDatabase().mimeTypeForName(mimeType).filterString();
-        const QString downloadsFolder = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
+        const QString downloadsFolder =
+          QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
         const QString openLocation = downloadsFolder + "/" + originalFilename;
 
         const QString filename = QFileDialog::getSaveFileName(

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -1298,10 +1298,12 @@ TimelineModel::saveMedia(QString eventId) const
                 dialogTitle = tr("Save file");
         }
 
-        QString filterString = QMimeDatabase().mimeTypeForName(mimeType).filterString();
+        const QString filterString = QMimeDatabase().mimeTypeForName(mimeType).filterString();
+        const QString downloadsFolder = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
+        const QString openLocation = downloadsFolder + "/" + originalFilename;
 
-        auto filename = QFileDialog::getSaveFileName(
-          manager_->getWidget(), dialogTitle, originalFilename, filterString);
+        const QString filename = QFileDialog::getSaveFileName(
+          manager_->getWidget(), dialogTitle, openLocation, filterString);
 
         if (filename.isEmpty())
                 return;


### PR DESCRIPTION
QFileDialog's dir arg (which was set to the incoming file name from the
Matrix download) can take a full path to suggest. By prepending
QStandardPaths::DownloadLocation, it opens to the system's download
folder and proposes the filename as the download name.

Using QStandardPaths should make this work on other platforms, and from
what I read, its possible for this to return an empty string on
platforms where it doesn't support it, so this should essentially
revert to the previous functionality if Qt can't determine the system's
download location.