### PR TITLE
Replace QHBoxLayout with QFormLayout in UserSettings

### DIFF
--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -437,15 +437,12 @@ UserSettingsPage::resizeEvent(QResizeEvent *event)
 {
         auto preWidth_ = width();
 
-        formLayout_->setContentsMargins(0, LayoutTopMargin, 0, LayoutBottomMargin);
-        double contentMinWidth = formLayout_->minimumSize().width();
-
-        if (preWidth_ * 0.6 > contentMinWidth)
-                sideMargin_ = preWidth_ * 0.2;
+        if (preWidth_ * 0.5 > LayoutMinWidth)
+                sideMargin_ = preWidth_ * 0.25;
         else
-                sideMargin_ = static_cast<double>(preWidth_ - contentMinWidth) / 2.;
+                sideMargin_ = static_cast<double>(preWidth_ - LayoutMinWidth) / 2.;
 
-        if (sideMargin_ < 40)
+        if (sideMargin_ < 60)
                 sideMargin_ = 0;
 
         formLayout_->setContentsMargins(

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -205,7 +205,8 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         avatarCircles_->setFixedSize(64, 48);
 
         auto uiLabel_ = new QLabel{tr("INTERFACE"), this};
-        uiLabel_->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
+        uiLabel_->setFixedHeight(uiLabel_->minimumHeight() + LayoutTopMargin);
+        uiLabel_->setAlignment(Qt::AlignBottom);
         uiLabel_->setFont(font);
 
         for (double option = 1; option <= 3; option += 0.25)
@@ -242,7 +243,8 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         themeCombo_->setCurrentIndex(themeIndex);
 
         auto encryptionLabel_ = new QLabel{tr("ENCRYPTION"), this};
-        encryptionLabel_->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
+        encryptionLabel_->setFixedHeight(encryptionLabel_->minimumHeight() + LayoutTopMargin);
+        encryptionLabel_->setAlignment(Qt::AlignBottom);
         encryptionLabel_->setFont(font);
 
         QFont monospaceFont;
@@ -295,7 +297,6 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         boxWrap(tr("Read receipts"), readReceipts_);
         boxWrap(tr("Send messages as Markdown"), markdownEnabled_);
         boxWrap(tr("Desktop notifications"), desktopNotifications_);
-        formLayout_->addRow(new QLabel{"", this});
         formLayout_->addRow(uiLabel_);
         formLayout_->addRow(new HorizontalLine{this});
 
@@ -314,7 +315,6 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
 #endif
 
         boxWrap(tr("Theme"), themeCombo_);
-        formLayout_->addRow(new QLabel{"", this});
         formLayout_->addRow(encryptionLabel_);
         formLayout_->addRow(new HorizontalLine{this});
         boxWrap(tr("Device ID"), deviceIdValue_);

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -331,9 +331,14 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
 
         QScroller::grabGesture(scrollArea_, QScroller::TouchGesture);
 
+        auto spacingAroundForm = new QHBoxLayout;
+        spacingAroundForm->addStretch(1);
+        spacingAroundForm->addLayout(formLayout_, 0);
+        spacingAroundForm->addStretch(1);
+
         auto scrollAreaContents_ = new QWidget{this};
         scrollAreaContents_->setObjectName("UserSettingScrollWidget");
-        scrollAreaContents_->setLayout(formLayout_);
+        scrollAreaContents_->setLayout(spacingAroundForm);
 
         scrollArea_->setWidget(scrollAreaContents_);
         topLayout_->addLayout(topBarLayout_);
@@ -430,31 +435,6 @@ UserSettingsPage::showEvent(QShowEvent *)
 
         deviceFingerprintValue_->setText(
           utils::humanReadableFingerprint(olm::client()->identity_keys().ed25519));
-}
-
-void
-UserSettingsPage::resizeEvent(QResizeEvent *event)
-{
-        auto preWidth = width();
-
-        // based on the width of the widest item currently in the layout
-        // deviceFingerprintValue_ used for recalculating the margins of
-        // the formLayout_ on resize to help with small screens and mobile devices.
-
-        double minFormWidth = deviceFingerprintValue_->width();
-
-        if (preWidth * 0.5 > minFormWidth)
-                sideMargin_ = preWidth * 0.25;
-        else
-                sideMargin_ = static_cast<double>(preWidth - minFormWidth) / 2.;
-
-        if (sideMargin_ < 60)
-                sideMargin_ = 0;
-
-        formLayout_->setContentsMargins(
-          sideMargin_, LayoutTopMargin, sideMargin_, LayoutBottomMargin);
-
-        QWidget::resizeEvent(event);
 }
 
 void

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -152,12 +152,12 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
   : QWidget{parent}
   , settings_{settings}
 {
-        topLayout_ = new QVBoxLayout(this);
+        topLayout_ = new QVBoxLayout{this};
 
         QIcon icon;
         icon.addFile(":/icons/icons/ui/angle-pointing-to-left.png");
 
-        auto backBtn_ = new FlatButton(this);
+        auto backBtn_ = new FlatButton{this};
         backBtn_->setMinimumSize(QSize(24, 24));
         backBtn_->setIcon(icon);
         backBtn_->setIconSize(QSize(24, 24));
@@ -182,54 +182,56 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         formLayout_->setRowWrapPolicy(QFormLayout::WrapLongRows);
         formLayout_->setHorizontalSpacing(0);
 
-        auto general_ = new QLabel(tr("GENERAL"), this);
+        auto general_ = new QLabel{tr("GENERAL"), this};
         general_->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
         general_->setFont(font);
 
-        trayToggle_        = new Toggle(this);
-        startInTrayToggle_ = new Toggle(this);
+        trayToggle_              = new Toggle{this};
+        startInTrayToggle_       = new Toggle{this};
+        avatarCircles_           = new Toggle{this};
+        groupViewToggle_         = new Toggle{this};
+        typingNotifications_     = new Toggle{this};
+        readReceipts_            = new Toggle{this};
+        markdownEnabled_         = new Toggle{this};
+        desktopNotifications_    = new Toggle{this};
+        scaleFactorCombo_        = new QComboBox{this};
+        fontSizeCombo_           = new QComboBox{this};
+        fontSelectionCombo_      = new QComboBox{this};
+        emojiFontSelectionCombo_ = new QComboBox{this};
 
         if (!settings_->isTrayEnabled())
                 startInTrayToggle_->setDisabled(true);
 
-        avatarCircles_        = new Toggle(this);
-        groupViewToggle_      = new Toggle(this);
-        typingNotifications_  = new Toggle(this);
-        readReceipts_         = new Toggle(this);
-        markdownEnabled_      = new Toggle(this);
-        desktopNotifications_ = new Toggle(this);
-        scaleFactorCombo_     = new QComboBox(this);
+        avatarCircles_->setFixedSize(64, 48);
+
+        auto uiLabel_ = new QLabel{tr("INTERFACE"), this};
+        uiLabel_->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
+        uiLabel_->setFont(font);
+
         for (double option = 1; option <= 3; option += 0.25)
                 scaleFactorCombo_->addItem(QString::number(option));
-        fontSizeCombo_ = new QComboBox(this);
         for (double option = 10; option < 17; option += 0.5)
                 fontSizeCombo_->addItem(QString("%1 ").arg(QString::number(option)));
 
-        fontSelectionCombo_      = new QComboBox(this);
-        emojiFontSelectionCombo_ = new QComboBox(this);
-
         QFontDatabase fontDb;
         auto fontFamilies = fontDb.families();
-
-        // TODO: Is there a way to limit to just emojis, rather than
-        // all emoji fonts?
-        auto emojiFamilies = fontDb.families(QFontDatabase::Symbol);
-
         for (const auto &family : fontFamilies) {
                 fontSelectionCombo_->addItem(family);
         }
 
+        // TODO: Is there a way to limit to just emojis, rather than
+        // all emoji fonts?
+        auto emojiFamilies = fontDb.families(QFontDatabase::Symbol);
         for (const auto &family : emojiFamilies) {
                 emojiFontSelectionCombo_->addItem(family);
         }
 
-        int fontIndex = fontSelectionCombo_->findText(settings_->font());
-        fontSelectionCombo_->setCurrentIndex(fontIndex);
+        fontSelectionCombo_->setCurrentIndex(fontSelectionCombo_->findText(settings_->font()));
 
-        fontIndex = emojiFontSelectionCombo_->findText(settings_->emojiFont());
-        emojiFontSelectionCombo_->setCurrentIndex(fontIndex);
+        emojiFontSelectionCombo_->setCurrentIndex(
+          emojiFontSelectionCombo_->findText(settings_->emojiFont()));
 
-        themeCombo_ = new QComboBox(this);
+        themeCombo_ = new QComboBox{this};
         themeCombo_->addItem("Light");
         themeCombo_->addItem("Dark");
         themeCombo_->addItem("System");
@@ -239,7 +241,7 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         int themeIndex = themeCombo_->findText(themeStr);
         themeCombo_->setCurrentIndex(themeIndex);
 
-        auto encryptionLabel_ = new QLabel(tr("ENCRYPTION"), this);
+        auto encryptionLabel_ = new QLabel{tr("ENCRYPTION"), this};
         encryptionLabel_->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
         encryptionLabel_->setFont(font);
 
@@ -256,31 +258,34 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         deviceFingerprintValue_->setTextInteractionFlags(Qt::TextSelectableByMouse);
         deviceFingerprintValue_->setFont(monospaceFont);
 
-        auto sessionKeysLabel = new QLabel(tr("Session Keys"), this);
+        std::string fingerprintPlaceHolder_(44, 'x');
+        deviceFingerprintValue_->setText(utils::humanReadableFingerprint(fingerprintPlaceHolder_));
+
+        auto sessionKeysLabel = new QLabel{tr("Session Keys"), this};
         sessionKeysLabel->setFont(font);
         sessionKeysLabel->setMargin(OptionMargin);
 
         auto sessionKeysImportBtn = new QPushButton{tr("IMPORT"), this};
         auto sessionKeysExportBtn = new QPushButton{tr("EXPORT"), this};
 
-        auto sessionKeysLayout = new QHBoxLayout(this);
-        sessionKeysLayout->addWidget(new QLabel("", this), 1, Qt::AlignRight);
+        auto sessionKeysLayout = new QHBoxLayout;
+        sessionKeysLayout->addWidget(new QLabel{"", this}, 1, Qt::AlignRight);
         sessionKeysLayout->addWidget(sessionKeysExportBtn, 0, Qt::AlignRight);
         sessionKeysLayout->addWidget(sessionKeysImportBtn, 0, Qt::AlignRight);
 
         auto boxWrap = [this, &font](QString labelText, QWidget *field) {
-                auto label = new QLabel(labelText, this);
+                auto label = new QLabel{labelText, this};
                 label->setFont(font);
                 label->setMargin(OptionMargin);
 
-                auto layout = new QHBoxLayout(this);
+                auto layout = new QHBoxLayout;
                 layout->addWidget(field, 0, Qt::AlignRight);
 
                 formLayout_->addRow(label, layout);
         };
 
         formLayout_->addRow(general_);
-        formLayout_->addRow(new HorizontalLine(this));
+        formLayout_->addRow(new HorizontalLine{this});
         boxWrap(tr("Minimize to tray"), trayToggle_);
         boxWrap(tr("Start in tray"), startInTrayToggle_);
         formLayout_->addRow(new HorizontalLine{this});
@@ -291,36 +296,34 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         boxWrap(tr("Read receipts"), readReceipts_);
         boxWrap(tr("Send messages as Markdown"), markdownEnabled_);
         boxWrap(tr("Desktop notifications"), desktopNotifications_);
-        formLayout_->addRow(new QLabel("", this));
+        formLayout_->addRow(new QLabel{"", this});
+        formLayout_->addRow(uiLabel_);
         formLayout_->addRow(new HorizontalLine{this});
+
+#if !defined(Q_OS_MAC)
         boxWrap(tr("Scale factor"), scaleFactorCombo_);
-        boxWrap(tr("Font size"), fontSizeCombo_);
-        formLayout_->addRow(new HorizontalLine(this));
-        boxWrap(tr("Font Family"), fontSelectionCombo_);
-        boxWrap(tr("Emoji Font Family"), emojiFontSelectionCombo_);
-        boxWrap(tr("Theme"), themeCombo_);
-        formLayout_->addRow(new QLabel("", this));
-        formLayout_->addRow(encryptionLabel_);
-        formLayout_->addRow(new HorizontalLine(this));
-        boxWrap(tr("Device ID"), deviceIdValue_);
-        boxWrap(tr("Device Fingerprint"), deviceFingerprintValue_);
-        formLayout_->addRow(new HorizontalLine(this));
-        formLayout_->addRow(sessionKeysLabel, sessionKeysLayout);
-
-        mainLayout_ = new QVBoxLayout;
-        mainLayout_->setAlignment(Qt::AlignTop);
-        mainLayout_->setSpacing(7);
-        mainLayout_->setContentsMargins(
-          sideMargin_, LayoutTopMargin, sideMargin_, LayoutBottomMargin);
-        mainLayout_->addLayout(formLayout_);
-
-#if defined(Q_OS_MAC)
-        // TODO: hide these with formlayout
+#else
         scaleFactorCombo_->hide();
+#endif
+        boxWrap(tr("Font size"), fontSizeCombo_);
+        boxWrap(tr("Font Family"), fontSelectionCombo_);
+
+#if !defined(Q_OS_MAC)
+        boxWrap(tr("Emoji Font Family"), emojiFontSelectionCombo_);
+#else
         emojiFontSelectionCombo_->hide();
 #endif
 
-        auto scrollArea_ = new QScrollArea(this);
+        boxWrap(tr("Theme"), themeCombo_);
+        formLayout_->addRow(new QLabel{"", this});
+        formLayout_->addRow(encryptionLabel_);
+        formLayout_->addRow(new HorizontalLine{this});
+        boxWrap(tr("Device ID"), deviceIdValue_);
+        boxWrap(tr("Device Fingerprint"), deviceFingerprintValue_);
+        formLayout_->addRow(new HorizontalLine{this});
+        formLayout_->addRow(sessionKeysLabel, sessionKeysLayout);
+
+        auto scrollArea_ = new QScrollArea{this};
         scrollArea_->setFrameShape(QFrame::NoFrame);
         scrollArea_->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
         scrollArea_->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
@@ -329,9 +332,9 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
 
         QScroller::grabGesture(scrollArea_, QScroller::TouchGesture);
 
-        auto scrollAreaContents_ = new QWidget(this);
+        auto scrollAreaContents_ = new QWidget{this};
         scrollAreaContents_->setObjectName("UserSettingScrollWidget");
-        scrollAreaContents_->setLayout(mainLayout_);
+        scrollAreaContents_->setLayout(formLayout_);
 
         scrollArea_->setWidget(scrollAreaContents_);
         topLayout_->addLayout(topBarLayout_);
@@ -433,18 +436,20 @@ UserSettingsPage::showEvent(QShowEvent *)
 void
 UserSettingsPage::resizeEvent(QResizeEvent *event)
 {
-        mainLayout_->setContentsMargins(0, LayoutTopMargin, 0, LayoutBottomMargin);
-        double contentMinWidth = mainLayout_->minimumSize().width();
+        auto preWidth_ = width();
 
-        if (event->size().width() * 0.6 > contentMinWidth)
-                sideMargin_ = width() * 0.2;
+        formLayout_->setContentsMargins(0, LayoutTopMargin, 0, LayoutBottomMargin);
+        double contentMinWidth = formLayout_->minimumSize().width();
+
+        if (preWidth_ * 0.6 > contentMinWidth)
+                sideMargin_ = preWidth_ * 0.2;
         else
-                sideMargin_ = static_cast<double>(event->size().width() - contentMinWidth) / 2.;
+                sideMargin_ = static_cast<double>(preWidth_ - contentMinWidth) / 2.;
 
-        if (sideMargin_ < 70)
+        if (sideMargin_ < 40)
                 sideMargin_ = 0;
 
-        mainLayout_->setContentsMargins(
+        formLayout_->setContentsMargins(
           sideMargin_, LayoutTopMargin, sideMargin_, LayoutBottomMargin);
 
         QWidget::resizeEvent(event);

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -258,8 +258,7 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         deviceFingerprintValue_->setTextInteractionFlags(Qt::TextSelectableByMouse);
         deviceFingerprintValue_->setFont(monospaceFont);
 
-        std::string fingerprintPlaceHolder_(44, 'x');
-        deviceFingerprintValue_->setText(utils::humanReadableFingerprint(fingerprintPlaceHolder_));
+        deviceFingerprintValue_->setText(utils::humanReadableFingerprint(QString(44, 'X')));
 
         auto sessionKeysLabel = new QLabel{tr("Session Keys"), this};
         sessionKeysLabel->setFont(font);

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -435,12 +435,12 @@ UserSettingsPage::showEvent(QShowEvent *)
 void
 UserSettingsPage::resizeEvent(QResizeEvent *event)
 {
-        auto preWidth_ = width();
+        auto preWidth = width();
 
-        if (preWidth_ * 0.5 > LayoutMinWidth)
-                sideMargin_ = preWidth_ * 0.25;
+        if (preWidth * 0.5 > LayoutMinWidth)
+                sideMargin_ = preWidth * 0.25;
         else
-                sideMargin_ = static_cast<double>(preWidth_ - LayoutMinWidth) / 2.;
+                sideMargin_ = static_cast<double>(preWidth - LayoutMinWidth) / 2.;
 
         if (sideMargin_ < 60)
                 sideMargin_ = 0;

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -437,10 +437,16 @@ UserSettingsPage::resizeEvent(QResizeEvent *event)
 {
         auto preWidth = width();
 
-        if (preWidth * 0.5 > LayoutMinWidth)
+        // based on the width of the widest item currently in the layout
+        // deviceFingerprintValue_ used for recalculating the margins of
+        // the formLayout_ on resize to help with small screens and mobile devices.
+
+        double minFormWidth = deviceFingerprintValue_->width();
+
+        if (preWidth * 0.5 > minFormWidth)
                 sideMargin_ = preWidth * 0.25;
         else
-                sideMargin_ = static_cast<double>(preWidth - LayoutMinWidth) / 2.;
+                sideMargin_ = static_cast<double>(preWidth - minFormWidth) / 2.;
 
         if (sideMargin_ < 60)
                 sideMargin_ = 0;

--- a/src/UserSettingsPage.h
+++ b/src/UserSettingsPage.h
@@ -33,11 +33,6 @@ constexpr int OptionMargin       = 6;
 constexpr int LayoutTopMargin    = 50;
 constexpr int LayoutBottomMargin = LayoutTopMargin;
 
-// based on the width of the widest item currently in the layout (deviceFingerprintValue_)
-// used for recalculating the margins of the formLayout_ on resize to help with small screens and
-// mobile devices.
-constexpr int LayoutMinWidth = 385;
-
 class UserSettings : public QObject
 {
         Q_OBJECT

--- a/src/UserSettingsPage.h
+++ b/src/UserSettingsPage.h
@@ -19,6 +19,7 @@
 
 #include <QComboBox>
 #include <QFontDatabase>
+#include <QFormLayout>
 #include <QFrame>
 #include <QLabel>
 #include <QLayout>
@@ -166,6 +167,7 @@ private slots:
 private:
         // Layouts
         QVBoxLayout *topLayout_;
+        QFormLayout *formLayout_;
         QVBoxLayout *mainLayout_;
         QHBoxLayout *topBarLayout_;
 

--- a/src/UserSettingsPage.h
+++ b/src/UserSettingsPage.h
@@ -152,7 +152,6 @@ public:
 
 protected:
         void showEvent(QShowEvent *event) override;
-        void resizeEvent(QResizeEvent *event) override;
         void paintEvent(QPaintEvent *event) override;
 
 signals:

--- a/src/UserSettingsPage.h
+++ b/src/UserSettingsPage.h
@@ -167,9 +167,8 @@ private slots:
 private:
         // Layouts
         QVBoxLayout *topLayout_;
-        QFormLayout *formLayout_;
-        QVBoxLayout *mainLayout_;
         QHBoxLayout *topBarLayout_;
+        QFormLayout *formLayout_;
 
         // Shared settings object.
         QSharedPointer<UserSettings> settings_;

--- a/src/UserSettingsPage.h
+++ b/src/UserSettingsPage.h
@@ -33,6 +33,11 @@ constexpr int OptionMargin       = 6;
 constexpr int LayoutTopMargin    = 50;
 constexpr int LayoutBottomMargin = LayoutTopMargin;
 
+// based on the width of the widest item currently in the layout (deviceFingerprintValue_)
+// used for recalculating the margins of the formLayout_ on resize to help with small screens and
+// mobile devices.
+constexpr int LayoutMinWidth = 385;
+
 class UserSettings : public QObject
 {
         Q_OBJECT


### PR DESCRIPTION
This allows form fields to wrap dynamically when they are too long for
the view. This should help mobile and small screen users to configure
the app without having to force it into portrait mode, or not be able to
reach the settings fields at all.

Supersedes #115 , handled with a different approach.

I'm still not completely happy with the scaling behaviour, and auto-wrapping that we were talking about in the matrix room. I feel like my unfamiliarity with Qt is stopping me from getting it to apply the behaviour I'm looking for, as I'm not knowledgeable enough with the inner workings of how to control the layouts.

My previous attempts to try to get all fields wrapping was to go into `resizeEvent` and try adding different rules for `QFormLayout->setRowWrapPolicy`depending on the margin width math that's already going on there. But when you wrap all the rows, it causes a resize again and there's a lot of ugly flashing that goes on. I left them out of this PR because I wasn't happy with both the implementation nor the behaviour.

I'd love some help getting this the extra mile if you agree with the approach within.