### PR TITLE
Tooltip and Combobox bugs with Breeze / Dark theme

### DIFF
--- a/resources/styles/nheko-dark.qss
+++ b/resources/styles/nheko-dark.qss
@@ -78,8 +78,10 @@ TypingDisplay {
 
 CommunitiesList,
 CommunitiesList > * {
+    border-style: none;
     background-color: #2d3139;
 }
+
 
 FlatButton {
     qproperty-foregroundColor: #727274;
@@ -191,6 +193,10 @@ UserSettingsPage {
 
 #UserSettingScrollWidget {
     background-color: #202228;
+}
+
+#UserSettingScrollWidget > QComboBox {
+    color: #202228;
 }
 
 Avatar {

--- a/resources/styles/nheko.qss
+++ b/resources/styles/nheko.qss
@@ -78,6 +78,7 @@ RoomList > * {
 
 CommunitiesList,
 CommunitiesList > * {
+    border-style: none;
     background-color: #2e3649;
 }
 

--- a/resources/styles/system.qss
+++ b/resources/styles/system.qss
@@ -124,6 +124,11 @@ RoomInfoListItem, UserMentionsWidget {
     qproperty-bubbleFgColor: palette(text);
 }
 
+CommunitiesList,
+CommunitiesList > * {
+    border-style: none;
+}
+
 CommunitiesListItem {
     qproperty-highlightedBackgroundColor: palette(highlight);
     qproperty-hoverBackgroundColor: palette(light);

--- a/src/CommunitiesList.cpp
+++ b/src/CommunitiesList.cpp
@@ -16,8 +16,6 @@ CommunitiesList::CommunitiesList(QWidget *parent)
         sizePolicy.setVerticalStretch(1);
         setSizePolicy(sizePolicy);
 
-        setStyleSheet("border-style: none;");
-
         topLayout_ = new QVBoxLayout(this);
         topLayout_->setSpacing(0);
         topLayout_->setMargin(0);


### PR DESCRIPTION
setStyleSheet was overriding default tooltip theme from the system,
causing themes like Breeze to render white text on a grey bg for
tooltips. Tooltips now render default for the system theme everywhere.

set a theme matching color on the dark theme comboboxes.

Closes Issue #118