### PR TITLE
remove setStyleSheet calls directly from widget code

### DIFF
--- a/resources/styles/nheko-dark.qss
+++ b/resources/styles/nheko-dark.qss
@@ -52,11 +52,18 @@ dialogs--JoinRoom > QLineEdit {
     color: #caccd1;
 }
 
+emoji--Panel QWidget { border: none; }
+emoji--Panel QScrollBar:vertical { width: 0px; margin: 0px; }
+emoji--Panel QScrollBar::handle:vertical { min-height: 30px; }
+
 emoji--Category,
 emoji--Category > * {
     background-color: #2d3139;
-    color: #caccd1;
+    color: #727274;
+}
 
+emoji--Category QLabel {
+    margin: 20px 0 20px 8px;
 }
 
 TimelineItem {
@@ -237,3 +244,5 @@ SnackBar {
     qproperty-textColor: #caccd1;
     qproperty-bgColor: #202228;
 }
+
+QSplitter::handle { image: none; }

--- a/resources/styles/nheko.qss
+++ b/resources/styles/nheko.qss
@@ -187,6 +187,10 @@ emoji--Panel > * {
     color: #333;
 }
 
+emoji--Panel QWidget { border: none; }
+emoji--Panel QScrollBar:vertical { width: 0px; margin: 0px; }
+emoji--Panel QScrollBar::handle:vertical { min-height: 30px; }
+
 emoji--Category {
     qproperty-hoverBackgroundColor: rgba(200, 200, 200, 70);
 }
@@ -196,6 +200,8 @@ emoji--Category > * {
     background-color: white;
     color: #ccc;
 }
+
+emoji--Category QLabel { margin: 20px 0 20px 8px; }
 
 FloatingButton {
     qproperty-backgroundColor: #efefef;
@@ -239,3 +245,5 @@ SnackBar {
     qproperty-textColor: white;
     qproperty-bgColor: #495057;
 }
+
+QSplitter::handle { image: none; }

--- a/resources/styles/system.qss
+++ b/resources/styles/system.qss
@@ -138,6 +138,10 @@ emoji--Panel > * {
     color: palette(text);
 }
 
+emoji--Panel QWidget { border: none; }
+emoji--Panel QScrollBar:vertical { width: 0px; margin: 0px; }
+emoji--Panel QScrollBar::handle:vertical { min-height: 30px; }
+
 emoji--Category {
     qproperty-hoverBackgroundColor: palette(highlight);
 }
@@ -146,6 +150,10 @@ emoji--Category,
 emoji--Category > * {
     background-color: palette(window);
     color: palette(text);
+}
+
+emoji--Category QLabel {
+    margin: 20px 0 20px 8px;
 }
 
 FloatingButton {
@@ -164,3 +172,5 @@ Toggle {
     qproperty-inactiveColor: palette(mid);
     qproperty-trackColor: palette(base);
 }
+
+QSplitter::handle { image: none; }

--- a/src/Splitter.cpp
+++ b/src/Splitter.cpp
@@ -28,7 +28,6 @@ Splitter::Splitter(QWidget *parent)
 {
         connect(this, &QSplitter::splitterMoved, this, &Splitter::onSplitterMoved);
         setChildrenCollapsible(false);
-        setStyleSheet("QSplitter::handle { image: none; }");
 }
 
 void

--- a/src/emoji/Category.cpp
+++ b/src/emoji/Category.cpp
@@ -75,7 +75,6 @@ Category::Category(QString category, std::vector<Emoji> emoji, QWidget *parent)
 
         category_ = new QLabel(category, this);
         category_->setFont(font);
-        category_->setStyleSheet("margin: 20px 0 20px 8px;");
 
         mainLayout_->addWidget(category_);
         mainLayout_->addWidget(emojiListView_);

--- a/src/emoji/Panel.cpp
+++ b/src/emoji/Panel.cpp
@@ -35,10 +35,6 @@ Panel::Panel(QWidget *parent)
   , height_{350}
   , categoryIconSize_{20}
 {
-        setStyleSheet("QWidget {border: none;}"
-                      "QScrollBar:vertical { width: 0px; margin: 0px; }"
-                      "QScrollBar::handle:vertical { min-height: 30px; }");
-
         setAttribute(Qt::WA_ShowWithoutActivating, true);
         setWindowFlags(Qt::Tool | Qt::FramelessWindowHint | Qt::NoDropShadowWindowHint);
 

--- a/src/ui/TextField.cpp
+++ b/src/ui/TextField.cpp
@@ -103,23 +103,6 @@ TextField::label() const
 }
 
 void
-TextField::setTextColor(const QColor &color)
-{
-        text_color_ = color;
-        setStyleSheet(QString("QLineEdit { color: %1; }").arg(color.name()));
-}
-
-QColor
-TextField::textColor() const
-{
-        if (!text_color_.isValid()) {
-                return QPalette().color(QPalette::Text);
-        }
-
-        return text_color_;
-}
-
-void
 TextField::setLabelColor(const QColor &color)
 {
         label_color_ = color;

--- a/src/ui/TextField.h
+++ b/src/ui/TextField.h
@@ -15,7 +15,6 @@ class TextField : public QLineEdit
 {
         Q_OBJECT
 
-        Q_PROPERTY(QColor textColor WRITE setTextColor READ textColor)
         Q_PROPERTY(QColor inkColor WRITE setInkColor READ inkColor)
         Q_PROPERTY(QColor labelColor WRITE setLabelColor READ labelColor)
         Q_PROPERTY(QColor underlineColor WRITE setUnderlineColor READ underlineColor)
@@ -30,12 +29,10 @@ public:
         void setLabelColor(const QColor &color);
         void setLabelFontSize(qreal size);
         void setShowLabel(bool value);
-        void setTextColor(const QColor &color);
         void setUnderlineColor(const QColor &color);
 
         QColor inkColor() const;
         QColor labelColor() const;
-        QColor textColor() const;
         QColor underlineColor() const;
         QColor backgroundColor() const;
         QString label() const;
@@ -52,7 +49,6 @@ private:
         QColor ink_color_;
         QColor background_color_;
         QColor label_color_;
-        QColor text_color_;
         QColor underline_color_;
         QString label_text_;
         TextFieldLabel *label_;


### PR DESCRIPTION
since using it has caused some weird style bugs, and there's a focus on moving more toward the qss files and consistent theming, axe all the setStyleSheet calls everywhere.

removed from:
 - emoji panel scrollbars
 - emoji category labels
 - splitter image handles
 - textfield setTextColor impl

small change to the category separator label for better contrast /
readability in dark mode.

removed setTextColor completely from TextField. Doesn't appear to be in
use anywhere, and aligns with focus going more toward qss theming and away
from unnecessary qproperty when targeting using qss rules is more clear and concise.