### PR TITLE
Add Guix build and installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ sudo apk add nheko
 flatpak install flathub io.github.NhekoReborn.Nheko
 ```
 
+#### Guix
+
+```
+guix install nheko
+```
+
 #### macOS (10.12 and above)
 
 with [macports](https://www.macports.org/) :
@@ -143,6 +149,12 @@ sudo add-apt-repository ppa:george-edison55/cmake-3.x
 sudo add-apt-repository ppa:ubuntu-toolchain-r-test
 sudo apt-get update
 sudo apt-get install -y g++-7 qt59base qt59svg qt59tools qt59multimedia cmake liblmdb-dev libsodium-dev
+```
+
+##### Guix
+
+```bash
+guix environment nheko
 ```
 
 ##### macOS (Xcode 8 or later)


### PR DESCRIPTION
[Nheko](https://guix.gnu.org/packages/nheko-0.6.4/) has been added to the [Guix](https://guix.gnu.org/) package manager!

Being available on the guix system leads some advantages to nheko itself:
- [Reproducible Builds](https://reproducible-builds.org/): no need to _trust_ a downloaded binary.  Users can build and compare the results (using [guix challenge](https://guix.gnu.org/manual/en/html_node/Invoking-guix-challenge.html)), being sure the downloaded binary matches the source code
- Easier hacking: dependencies required to build nheko are fetched easily with the guix environment command.
- Docker(+Tarball) Images: nheko, together with all its dependencies, can be packaged using the [guix pack](https://guix.gnu.org/manual/en/html_node/Invoking-guix-pack.html) command (more details [here](https://guix.gnu.org/blog/2017/creating-bundles-with-guix-pack/)).  With one command it is possible to create a redistributable archive which has the advantages of guix (i.e. reproducible builds) without requiring guix to be installed on the target  
