### PR TITLE
Add support for more m.room.events in timeline

### DIFF
--- a/resources/langs/nheko_de.ts
+++ b/resources/langs/nheko_de.ts
@@ -277,6 +277,11 @@
         <source>removed topic</source>
         <translation>Raumthema wurde entfernt.</translation>
     </message>
+    <message>
+        <location line="+6"/>
+        <source>%1 created and configured room: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Placeholder</name>
@@ -474,7 +479,7 @@
 <context>
     <name>TimelineModel</name>
     <message>
-        <location filename="../../src/timeline/TimelineModel.cpp" line="+711"/>
+        <location filename="../../src/timeline/TimelineModel.cpp" line="+714"/>
         <source>-- Encrypted Event (No keys found for decryption) --</source>
         <comment>Placeholder, when the message was not decrypted yet or can&apos;t be decrypted</comment>
         <translation>-- verschlüsselter Event (keine Schlüssel zur Entschlüsselung gefunden) --</translation>
@@ -538,12 +543,57 @@
         </translation>
     </message>
     <message>
-        <location line="+96"/>
+        <location line="+68"/>
+        <source>%1 opened the room to the public</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>%1 made this room require and invitation to join</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>%1 made the room open to guests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>%1 has closed the room to guest access</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>%1 made the room history world readable. Events may be now read by non-joined people</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>%1 set the room history visible to members from this point on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>%1 set the room history visible to members since they were invited</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>%1 set the room history visible to members since they joined the room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>%1 has changed the room&apos;s permissions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+48"/>
         <source>%1 was invited.</source>
         <translation>%1 wurde eingeladen.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+11"/>
         <source>%1 changed their display name and avatar.</source>
         <translation>%1 hat den Anzeigenamen und Avatar geändert.</translation>
     </message>
@@ -563,7 +613,7 @@
         <translation>%1 hat den Raum betreten.</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+9"/>
         <source>%1 rejected their invite.</source>
         <translation>%1 hat die Einladung abgewiesen.</translation>
     </message>
@@ -600,16 +650,21 @@
     <message>
         <location line="+2"/>
         <source>%1 left after having already left!</source>
-        <comment>This is a leave event after the user already left and shouln&apos;t happen apart from state resets</comment>
-        <translation>%1 hat den Raum verlassen.</translation>
+        <comment>This is a leave event after the user already left and shouldn&apos;t happen apart from state resets</comment>
+        <translation type="unfinished">%1 hat den Raum verlassen.</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>%1 was banned.</source>
-        <translation>%1 wurde gebannt.</translation>
+        <location line="+7"/>
+        <source>%1 was banned</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+8"/>
+        <source> Reason: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-5"/>
         <source>%1 knocked.</source>
         <translation>%1 hat angeklopft.</translation>
     </message>

--- a/resources/langs/nheko_el.ts
+++ b/resources/langs/nheko_el.ts
@@ -277,6 +277,11 @@
         <source>removed topic</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+6"/>
+        <source>%1 created and configured room: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Placeholder</name>
@@ -474,7 +479,7 @@
 <context>
     <name>TimelineModel</name>
     <message>
-        <location filename="../../src/timeline/TimelineModel.cpp" line="+711"/>
+        <location filename="../../src/timeline/TimelineModel.cpp" line="+714"/>
         <source>-- Encrypted Event (No keys found for decryption) --</source>
         <comment>Placeholder, when the message was not decrypted yet or can&apos;t be decrypted</comment>
         <translation type="unfinished"></translation>
@@ -538,12 +543,57 @@
         </translation>
     </message>
     <message>
-        <location line="+96"/>
+        <location line="+68"/>
+        <source>%1 opened the room to the public</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>%1 made this room require and invitation to join</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>%1 made the room open to guests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>%1 has closed the room to guest access</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>%1 made the room history world readable. Events may be now read by non-joined people</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>%1 set the room history visible to members from this point on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>%1 set the room history visible to members since they were invited</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>%1 set the room history visible to members since they joined the room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>%1 has changed the room&apos;s permissions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+48"/>
         <source>%1 was invited.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+11"/>
         <source>%1 changed their display name and avatar.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -563,7 +613,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+9"/>
         <source>%1 rejected their invite.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -600,16 +650,21 @@
     <message>
         <location line="+2"/>
         <source>%1 left after having already left!</source>
-        <comment>This is a leave event after the user already left and shouln&apos;t happen apart from state resets</comment>
+        <comment>This is a leave event after the user already left and shouldn&apos;t happen apart from state resets</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>%1 was banned.</source>
+        <location line="+7"/>
+        <source>%1 was banned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+8"/>
+        <source> Reason: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-5"/>
         <source>%1 knocked.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/resources/langs/nheko_en.ts
+++ b/resources/langs/nheko_en.ts
@@ -277,6 +277,11 @@
         <source>removed topic</source>
         <translation>removed topic</translation>
     </message>
+    <message>
+        <location line="+6"/>
+        <source>%1 created and configured room: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Placeholder</name>
@@ -474,7 +479,7 @@
 <context>
     <name>TimelineModel</name>
     <message>
-        <location filename="../../src/timeline/TimelineModel.cpp" line="+711"/>
+        <location filename="../../src/timeline/TimelineModel.cpp" line="+714"/>
         <source>-- Encrypted Event (No keys found for decryption) --</source>
         <comment>Placeholder, when the message was not decrypted yet or can&apos;t be decrypted</comment>
         <translation>-- Encrypted Event (No keys found for decryption) --</translation>
@@ -538,12 +543,57 @@
         </translation>
     </message>
     <message>
-        <location line="+96"/>
+        <location line="+68"/>
+        <source>%1 opened the room to the public</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>%1 made this room require and invitation to join</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>%1 made the room open to guests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>%1 has closed the room to guest access</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>%1 made the room history world readable. Events may be now read by non-joined people</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>%1 set the room history visible to members from this point on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>%1 set the room history visible to members since they were invited</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>%1 set the room history visible to members since they joined the room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>%1 has changed the room&apos;s permissions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+48"/>
         <source>%1 was invited.</source>
         <translation>%1 was invited.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+11"/>
         <source>%1 changed their display name and avatar.</source>
         <translation>%1 changed their display name and avatar.</translation>
     </message>
@@ -563,7 +613,7 @@
         <translation>%1 joined.</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+9"/>
         <source>%1 rejected their invite.</source>
         <translation>%1 rejected their invite.</translation>
     </message>
@@ -600,16 +650,21 @@
     <message>
         <location line="+2"/>
         <source>%1 left after having already left!</source>
-        <comment>This is a leave event after the user already left and shouln&apos;t happen apart from state resets</comment>
-        <translation>%1 left after having already left!</translation>
+        <comment>This is a leave event after the user already left and shouldn&apos;t happen apart from state resets</comment>
+        <translation type="unfinished">%1 left after having already left!</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>%1 was banned.</source>
-        <translation>%1 was banned.</translation>
+        <location line="+7"/>
+        <source>%1 was banned</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+8"/>
+        <source> Reason: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-5"/>
         <source>%1 knocked.</source>
         <translation>%1 knocked.</translation>
     </message>

--- a/resources/langs/nheko_fi.ts
+++ b/resources/langs/nheko_fi.ts
@@ -277,6 +277,11 @@
         <source>removed topic</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+6"/>
+        <source>%1 created and configured room: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Placeholder</name>
@@ -474,7 +479,7 @@
 <context>
     <name>TimelineModel</name>
     <message>
-        <location filename="../../src/timeline/TimelineModel.cpp" line="+711"/>
+        <location filename="../../src/timeline/TimelineModel.cpp" line="+714"/>
         <source>-- Encrypted Event (No keys found for decryption) --</source>
         <comment>Placeholder, when the message was not decrypted yet or can&apos;t be decrypted</comment>
         <translation type="unfinished">-- Salattu viesti (salauksen purkuavaimia ei löydetty) --</translation>
@@ -538,12 +543,57 @@
         </translation>
     </message>
     <message>
-        <location line="+96"/>
+        <location line="+68"/>
+        <source>%1 opened the room to the public</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>%1 made this room require and invitation to join</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>%1 made the room open to guests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>%1 has closed the room to guest access</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>%1 made the room history world readable. Events may be now read by non-joined people</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>%1 set the room history visible to members from this point on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>%1 set the room history visible to members since they were invited</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>%1 set the room history visible to members since they joined the room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>%1 has changed the room&apos;s permissions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+48"/>
         <source>%1 was invited.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+11"/>
         <source>%1 changed their display name and avatar.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -563,7 +613,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+9"/>
         <source>%1 rejected their invite.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -600,16 +650,21 @@
     <message>
         <location line="+2"/>
         <source>%1 left after having already left!</source>
-        <comment>This is a leave event after the user already left and shouln&apos;t happen apart from state resets</comment>
+        <comment>This is a leave event after the user already left and shouldn&apos;t happen apart from state resets</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>%1 was banned.</source>
+        <location line="+7"/>
+        <source>%1 was banned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+8"/>
+        <source> Reason: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-5"/>
         <source>%1 knocked.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/resources/langs/nheko_fr.ts
+++ b/resources/langs/nheko_fr.ts
@@ -277,6 +277,11 @@
         <source>removed topic</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+6"/>
+        <source>%1 created and configured room: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Placeholder</name>
@@ -475,7 +480,7 @@
 <context>
     <name>TimelineModel</name>
     <message>
-        <location filename="../../src/timeline/TimelineModel.cpp" line="+711"/>
+        <location filename="../../src/timeline/TimelineModel.cpp" line="+714"/>
         <source>-- Encrypted Event (No keys found for decryption) --</source>
         <comment>Placeholder, when the message was not decrypted yet or can&apos;t be decrypted</comment>
         <translation type="unfinished"></translation>
@@ -539,12 +544,57 @@
         </translation>
     </message>
     <message>
-        <location line="+96"/>
+        <location line="+68"/>
+        <source>%1 opened the room to the public</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>%1 made this room require and invitation to join</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>%1 made the room open to guests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>%1 has closed the room to guest access</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>%1 made the room history world readable. Events may be now read by non-joined people</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>%1 set the room history visible to members from this point on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>%1 set the room history visible to members since they were invited</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>%1 set the room history visible to members since they joined the room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>%1 has changed the room&apos;s permissions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+48"/>
         <source>%1 was invited.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+11"/>
         <source>%1 changed their display name and avatar.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -564,7 +614,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+9"/>
         <source>%1 rejected their invite.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -601,16 +651,21 @@
     <message>
         <location line="+2"/>
         <source>%1 left after having already left!</source>
-        <comment>This is a leave event after the user already left and shouln&apos;t happen apart from state resets</comment>
+        <comment>This is a leave event after the user already left and shouldn&apos;t happen apart from state resets</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>%1 was banned.</source>
+        <location line="+7"/>
+        <source>%1 was banned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+8"/>
+        <source> Reason: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-5"/>
         <source>%1 knocked.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/resources/langs/nheko_ja.ts
+++ b/resources/langs/nheko_ja.ts
@@ -277,6 +277,11 @@
         <source>removed topic</source>
         <translation>話題が削除されました</translation>
     </message>
+    <message>
+        <location line="+6"/>
+        <source>%1 created and configured room: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Placeholder</name>
@@ -474,7 +479,7 @@
 <context>
     <name>TimelineModel</name>
     <message>
-        <location filename="../../src/timeline/TimelineModel.cpp" line="+711"/>
+        <location filename="../../src/timeline/TimelineModel.cpp" line="+714"/>
         <source>-- Encrypted Event (No keys found for decryption) --</source>
         <comment>Placeholder, when the message was not decrypted yet or can&apos;t be decrypted</comment>
         <translation>-- 暗号化イベント (復号鍵が見つかりません) --</translation>
@@ -537,12 +542,57 @@
         </translation>
     </message>
     <message>
-        <location line="+96"/>
+        <location line="+68"/>
+        <source>%1 opened the room to the public</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>%1 made this room require and invitation to join</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>%1 made the room open to guests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>%1 has closed the room to guest access</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>%1 made the room history world readable. Events may be now read by non-joined people</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>%1 set the room history visible to members from this point on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>%1 set the room history visible to members since they were invited</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>%1 set the room history visible to members since they joined the room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>%1 has changed the room&apos;s permissions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+48"/>
         <source>%1 was invited.</source>
         <translation>%1が招待されました。</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+11"/>
         <source>%1 changed their display name and avatar.</source>
         <translation>%1が表示名とアバターを変更しました。</translation>
     </message>
@@ -562,7 +612,7 @@
         <translation>%1が参加しました。</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+9"/>
         <source>%1 rejected their invite.</source>
         <translation>%1が招待を拒否しました。</translation>
     </message>
@@ -599,16 +649,21 @@
     <message>
         <location line="+2"/>
         <source>%1 left after having already left!</source>
-        <comment>This is a leave event after the user already left and shouln&apos;t happen apart from state resets</comment>
-        <translation>退出済みの%1が退出しました!</translation>
+        <comment>This is a leave event after the user already left and shouldn&apos;t happen apart from state resets</comment>
+        <translation type="unfinished">退出済みの%1が退出しました!</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>%1 was banned.</source>
-        <translation>%1が永久追放されました。</translation>
+        <location line="+7"/>
+        <source>%1 was banned</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+8"/>
+        <source> Reason: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-5"/>
         <source>%1 knocked.</source>
         <translation>%1がノックしました。</translation>
     </message>

--- a/resources/langs/nheko_nl.ts
+++ b/resources/langs/nheko_nl.ts
@@ -277,6 +277,11 @@
         <source>removed topic</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+6"/>
+        <source>%1 created and configured room: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Placeholder</name>
@@ -474,7 +479,7 @@
 <context>
     <name>TimelineModel</name>
     <message>
-        <location filename="../../src/timeline/TimelineModel.cpp" line="+711"/>
+        <location filename="../../src/timeline/TimelineModel.cpp" line="+714"/>
         <source>-- Encrypted Event (No keys found for decryption) --</source>
         <comment>Placeholder, when the message was not decrypted yet or can&apos;t be decrypted</comment>
         <translation type="unfinished"></translation>
@@ -538,12 +543,57 @@
         </translation>
     </message>
     <message>
-        <location line="+96"/>
+        <location line="+68"/>
+        <source>%1 opened the room to the public</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>%1 made this room require and invitation to join</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>%1 made the room open to guests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>%1 has closed the room to guest access</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>%1 made the room history world readable. Events may be now read by non-joined people</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>%1 set the room history visible to members from this point on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>%1 set the room history visible to members since they were invited</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>%1 set the room history visible to members since they joined the room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>%1 has changed the room&apos;s permissions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+48"/>
         <source>%1 was invited.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+11"/>
         <source>%1 changed their display name and avatar.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -563,7 +613,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+9"/>
         <source>%1 rejected their invite.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -600,16 +650,21 @@
     <message>
         <location line="+2"/>
         <source>%1 left after having already left!</source>
-        <comment>This is a leave event after the user already left and shouln&apos;t happen apart from state resets</comment>
+        <comment>This is a leave event after the user already left and shouldn&apos;t happen apart from state resets</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>%1 was banned.</source>
+        <location line="+7"/>
+        <source>%1 was banned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+8"/>
+        <source> Reason: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-5"/>
         <source>%1 knocked.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/resources/langs/nheko_pl.ts
+++ b/resources/langs/nheko_pl.ts
@@ -277,6 +277,11 @@
         <source>removed topic</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+6"/>
+        <source>%1 created and configured room: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Placeholder</name>
@@ -474,7 +479,7 @@
 <context>
     <name>TimelineModel</name>
     <message>
-        <location filename="../../src/timeline/TimelineModel.cpp" line="+711"/>
+        <location filename="../../src/timeline/TimelineModel.cpp" line="+714"/>
         <source>-- Encrypted Event (No keys found for decryption) --</source>
         <comment>Placeholder, when the message was not decrypted yet or can&apos;t be decrypted</comment>
         <translation type="unfinished"></translation>
@@ -539,12 +544,57 @@
         </translation>
     </message>
     <message>
-        <location line="+96"/>
+        <location line="+68"/>
+        <source>%1 opened the room to the public</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>%1 made this room require and invitation to join</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>%1 made the room open to guests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>%1 has closed the room to guest access</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>%1 made the room history world readable. Events may be now read by non-joined people</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>%1 set the room history visible to members from this point on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>%1 set the room history visible to members since they were invited</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>%1 set the room history visible to members since they joined the room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>%1 has changed the room&apos;s permissions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+48"/>
         <source>%1 was invited.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+11"/>
         <source>%1 changed their display name and avatar.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -564,7 +614,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+9"/>
         <source>%1 rejected their invite.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -601,16 +651,21 @@
     <message>
         <location line="+2"/>
         <source>%1 left after having already left!</source>
-        <comment>This is a leave event after the user already left and shouln&apos;t happen apart from state resets</comment>
+        <comment>This is a leave event after the user already left and shouldn&apos;t happen apart from state resets</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>%1 was banned.</source>
+        <location line="+7"/>
+        <source>%1 was banned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+8"/>
+        <source> Reason: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-5"/>
         <source>%1 knocked.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/resources/langs/nheko_ru.ts
+++ b/resources/langs/nheko_ru.ts
@@ -277,6 +277,11 @@
         <source>removed topic</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+6"/>
+        <source>%1 created and configured room: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Placeholder</name>
@@ -474,7 +479,7 @@
 <context>
     <name>TimelineModel</name>
     <message>
-        <location filename="../../src/timeline/TimelineModel.cpp" line="+711"/>
+        <location filename="../../src/timeline/TimelineModel.cpp" line="+714"/>
         <source>-- Encrypted Event (No keys found for decryption) --</source>
         <comment>Placeholder, when the message was not decrypted yet or can&apos;t be decrypted</comment>
         <translation type="unfinished"></translation>
@@ -539,12 +544,57 @@
         </translation>
     </message>
     <message>
-        <location line="+96"/>
+        <location line="+68"/>
+        <source>%1 opened the room to the public</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>%1 made this room require and invitation to join</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>%1 made the room open to guests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>%1 has closed the room to guest access</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>%1 made the room history world readable. Events may be now read by non-joined people</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>%1 set the room history visible to members from this point on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>%1 set the room history visible to members since they were invited</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>%1 set the room history visible to members since they joined the room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>%1 has changed the room&apos;s permissions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+48"/>
         <source>%1 was invited.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+11"/>
         <source>%1 changed their display name and avatar.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -564,7 +614,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+9"/>
         <source>%1 rejected their invite.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -601,16 +651,21 @@
     <message>
         <location line="+2"/>
         <source>%1 left after having already left!</source>
-        <comment>This is a leave event after the user already left and shouln&apos;t happen apart from state resets</comment>
+        <comment>This is a leave event after the user already left and shouldn&apos;t happen apart from state resets</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>%1 was banned.</source>
+        <location line="+7"/>
+        <source>%1 was banned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+8"/>
+        <source> Reason: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-5"/>
         <source>%1 knocked.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/resources/langs/nheko_zh_CN.ts
+++ b/resources/langs/nheko_zh_CN.ts
@@ -277,6 +277,11 @@
         <source>removed topic</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+6"/>
+        <source>%1 created and configured room: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Placeholder</name>
@@ -474,7 +479,7 @@
 <context>
     <name>TimelineModel</name>
     <message>
-        <location filename="../../src/timeline/TimelineModel.cpp" line="+711"/>
+        <location filename="../../src/timeline/TimelineModel.cpp" line="+714"/>
         <source>-- Encrypted Event (No keys found for decryption) --</source>
         <comment>Placeholder, when the message was not decrypted yet or can&apos;t be decrypted</comment>
         <translation type="unfinished"></translation>
@@ -537,12 +542,57 @@
         </translation>
     </message>
     <message>
-        <location line="+96"/>
+        <location line="+68"/>
+        <source>%1 opened the room to the public</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>%1 made this room require and invitation to join</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>%1 made the room open to guests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>%1 has closed the room to guest access</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>%1 made the room history world readable. Events may be now read by non-joined people</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>%1 set the room history visible to members from this point on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>%1 set the room history visible to members since they were invited</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>%1 set the room history visible to members since they joined the room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>%1 has changed the room&apos;s permissions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+48"/>
         <source>%1 was invited.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+11"/>
         <source>%1 changed their display name and avatar.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -562,7 +612,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+9"/>
         <source>%1 rejected their invite.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -599,16 +649,21 @@
     <message>
         <location line="+2"/>
         <source>%1 left after having already left!</source>
-        <comment>This is a leave event after the user already left and shouln&apos;t happen apart from state resets</comment>
+        <comment>This is a leave event after the user already left and shouldn&apos;t happen apart from state resets</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>%1 was banned.</source>
+        <location line="+7"/>
+        <source>%1 was banned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+8"/>
+        <source> Reason: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-5"/>
         <source>%1 knocked.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/resources/qml/delegates/MessageDelegate.qml
+++ b/resources/qml/delegates/MessageDelegate.qml
@@ -82,6 +82,37 @@ Item {
 			}
 		}
 		DelegateChoice {
+			roleValue: MtxEvent.RoomCreate
+			NoticeMessage {
+				text: qsTr("%1 created and configured room: %2").arg(model.data.userName).arg(model.data.roomId)
+			}
+		}
+		DelegateChoice {
+			// TODO: make a more complex formatter for the power levels.
+			roleValue: MtxEvent.PowerLevels
+			NoticeMessage {
+				text: timelineManager.timeline.formatPowerLevelEvent(model.data.id)
+			}
+		}
+		DelegateChoice {
+			roleValue: MtxEvent.RoomJoinRules
+			NoticeMessage {
+				text: timelineManager.timeline.formatJoinRuleEvent(model.data.id)
+			}
+		}
+		DelegateChoice {
+			roleValue: MtxEvent.RoomHistoryVisibility
+			NoticeMessage {
+				text: timelineManager.timeline.formatHistoryVisibilityEvent(model.data.id)
+			}
+		}
+		DelegateChoice {
+			roleValue: MtxEvent.RoomGuestAccess
+			NoticeMessage {
+				text: timelineManager.timeline.formatGuestAccessEvent(model.data.id)
+			}
+		}
+		DelegateChoice {
 			roleValue: MtxEvent.Member
 			NoticeMessage {
 				text: timelineManager.timeline.formatMemberEvent(model.data.id);

--- a/src/timeline/TimelineModel.h
+++ b/src/timeline/TimelineModel.h
@@ -35,17 +35,17 @@ enum EventType
         /// m.room.canonical_alias
         CanonicalAlias,
         /// m.room.create
-        Create,
+        RoomCreate,
         /// m.room.encrypted.
         Encrypted,
         /// m.room.encryption.
         Encryption,
         /// m.room.guest_access
-        GuestAccess,
+        RoomGuestAccess,
         /// m.room.history_visibility
-        HistoryVisibility,
+        RoomHistoryVisibility,
         /// m.room.join_rules
-        JoinRules,
+        RoomJoinRules,
         /// m.room.member
         Member,
         /// m.room.name
@@ -152,6 +152,7 @@ public:
                 State,
                 IsEncrypted,
                 ReplyTo,
+                RoomId,
                 RoomName,
                 RoomTopic,
                 Dump,
@@ -170,6 +171,10 @@ public:
         Q_INVOKABLE QString formatDateSeparator(QDate date) const;
         Q_INVOKABLE QString formatTypingUsers(const std::vector<QString> &users, QColor bg);
         Q_INVOKABLE QString formatMemberEvent(QString id);
+        Q_INVOKABLE QString formatJoinRuleEvent(QString id);
+        Q_INVOKABLE QString formatHistoryVisibilityEvent(QString id);
+        Q_INVOKABLE QString formatGuestAccessEvent(QString id);
+        Q_INVOKABLE QString formatPowerLevelEvent(QString id);
 
         Q_INVOKABLE QString escapeEmoji(QString str) const;
         Q_INVOKABLE void viewRawMessage(QString id) const;


### PR DESCRIPTION
 - add delegate choice for more events:
    - room create
    - power levels
    - room join rules
    - room history visibility
    - room guest access 
 - rename some RoomEventType structs to be more consistent
 - added reason: formatting to membership events arbitrarily
 - added translations