### PR TITLE
total + first member shows as one too many room members

### DIFF
--- a/src/Cache.cpp
+++ b/src/Cache.cpp
@@ -1530,7 +1530,7 @@ Cache::getRoomName(lmdb::txn &txn, lmdb::dbi &statesdb, lmdb::dbi &membersdb)
         if (total == 2)
                 return first_member;
         else if (total > 2)
-                return QString("%1 and %2 others").arg(first_member).arg(total);
+                return QString("%1 and %2 others").arg(first_member).arg(total - 1);
 
         return "Empty Room";
 }


### PR DESCRIPTION
i was confused by this unintentional eavesdropping feature when a room with me and two friends showed as "user1" and 3 others.