### PR TITLE
Don't request access to the user's home directory

### DIFF
--- a/io.github.NhekoReborn.Nheko.json
+++ b/io.github.NhekoReborn.Nheko.json
@@ -10,7 +10,6 @@
   "rename-appdata-file": "nheko.appdata.xml",
   "finish-args": [
     "--device=dri",
-    "--filesystem=home",
     "--share=ipc",
     "--share=network",
     "--socket=pulseaudio",


### PR DESCRIPTION
Currently, the Nheko flatpaks require access to all files within the user's home directory.  This is a potential security issue, as it compromises the inherent protection of flatpak's sandboxing, and exposes the users files.  Additionally, it might make some flatpak users uncomfortable to see an app that should need home directory access requesting it.

However, Nheko does not require this permission to run.  This can be seen by running `flatpak override --nofilesystem=home io.github.NhekoReborn.Nheko`, which disables access to the home directory.  Even without this permission, there is no issue running Nheko.  This is because all file accesses performed by Nheko either receive dynamic permission from going through and xdg-portal (like a file open menu), or interact with files relative to `$XDG_` directories, which are granted automatically through the sandbox.

We can make this permission change available to all users with a trivial change to the flatpak configuration.