### PR TITLE
Place unread rooms higher in the room list

### DIFF
--- a/resources/langs/nheko_de.ts
+++ b/resources/langs/nheko_de.ts
@@ -371,12 +371,12 @@
 <context>
     <name>RoomInfoListItem</name>
     <message>
-        <location filename="../../src/RoomInfoListItem.cpp" line="+97"/>
+        <location filename="../../src/RoomInfoListItem.cpp" line="+98"/>
         <source>Leave room</source>
         <translation>Raum verlassen</translation>
     </message>
     <message>
-        <location line="+154"/>
+        <location line="+158"/>
         <source>Accept</source>
         <translation>Akzeptieren</translation>
     </message>
@@ -491,7 +491,13 @@
         <translation>-- Entschlüsselungsfehler (Fehler bei Suche nach megolm Schlüsseln in Datenbank) --</translation>
     </message>
     <message>
-        <location line="+88"/>
+        <location line="+12"/>
+        <source>-- Decryption Error (%1) --</source>
+        <comment>Placeholder, when the message can&apos;t be decrypted. In this case, the Olm decrytion returned an error, which is passed ad %1.</comment>
+        <translation type="unfinished">-- Entschlüsselungsfehler (%1) --</translation>
+    </message>
+    <message>
+        <location line="+76"/>
         <source>Message redaction failed: %1</source>
         <translation>Nachricht zurückziehen fehlgeschlagen: %1</translation>
     </message>
@@ -522,13 +528,7 @@
         <translation type="unfinished">-- Verschlüsseltes Event (keine Schlüssel zur Entschlüsselung gefunden) --</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <source>-- Decryption Error (%1) --</source>
-        <comment>Placeholder, when the message can&apos;t be decrypted. In this case, the Olm decrytion returned an error, which is passed as %1.</comment>
-        <translation type="unfinished">-- Entschlüsselungsfehler (%1) --</translation>
-    </message>
-    <message>
-        <location line="+29"/>
+        <location line="+75"/>
         <source>-- Encrypted Event (Unknown event type) --</source>
         <comment>Placeholder, when the message was decrypted, but we couldn&apos;t parse it, because Nheko/mtxclient don&apos;t support that event type yet.</comment>
         <translation type="unfinished">-- Verschlüsseltes Event (Unbekannter Eventtyp) --</translation>
@@ -782,7 +782,7 @@
 <context>
     <name>UserSettingsPage</name>
     <message>
-        <location filename="../../src/UserSettingsPage.cpp" line="+296"/>
+        <location filename="../../src/UserSettingsPage.cpp" line="+299"/>
         <source>Minimize to tray</source>
         <translation>Ins Benachrichtigungsfeld minimieren</translation>
     </message>
@@ -810,6 +810,11 @@
         <location line="+1"/>
         <source>Typing notifications</source>
         <translation>Schreibbenachrichtigungen</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sort rooms by unreads</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
@@ -857,7 +862,7 @@
         <translation>Gerätefingerabdruck</translation>
     </message>
     <message>
-        <location line="-57"/>
+        <location line="-58"/>
         <source>Session Keys</source>
         <translation>Sitzungsschlüssel</translation>
     </message>
@@ -877,22 +882,22 @@
         <translation>VERSCHLÜSSELUNG</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-62"/>
         <source>GENERAL</source>
         <translation>ALLGEMEINES</translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+24"/>
         <source>INTERFACE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+106"/>
+        <location line="+107"/>
         <source>Emoji Font Family</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
+        <location line="+152"/>
         <source>Open Sessions File</source>
         <translation>Öffne Sessions Datei</translation>
     </message>

--- a/resources/langs/nheko_el.ts
+++ b/resources/langs/nheko_el.ts
@@ -371,12 +371,12 @@
 <context>
     <name>RoomInfoListItem</name>
     <message>
-        <location filename="../../src/RoomInfoListItem.cpp" line="+97"/>
+        <location filename="../../src/RoomInfoListItem.cpp" line="+98"/>
         <source>Leave room</source>
         <translation>Βγές</translation>
     </message>
     <message>
-        <location line="+154"/>
+        <location line="+158"/>
         <source>Accept</source>
         <translation>Αποδοχή</translation>
     </message>
@@ -491,7 +491,13 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
+        <location line="+12"/>
+        <source>-- Decryption Error (%1) --</source>
+        <comment>Placeholder, when the message can&apos;t be decrypted. In this case, the Olm decrytion returned an error, which is passed ad %1.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+76"/>
         <source>Message redaction failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -522,13 +528,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
-        <source>-- Decryption Error (%1) --</source>
-        <comment>Placeholder, when the message can&apos;t be decrypted. In this case, the Olm decrytion returned an error, which is passed as %1.</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+29"/>
+        <location line="+75"/>
         <source>-- Encrypted Event (Unknown event type) --</source>
         <comment>Placeholder, when the message was decrypted, but we couldn&apos;t parse it, because Nheko/mtxclient don&apos;t support that event type yet.</comment>
         <translation type="unfinished"></translation>
@@ -782,7 +782,7 @@
 <context>
     <name>UserSettingsPage</name>
     <message>
-        <location filename="../../src/UserSettingsPage.cpp" line="+296"/>
+        <location filename="../../src/UserSettingsPage.cpp" line="+299"/>
         <source>Minimize to tray</source>
         <translation>Ελαχιστοποίηση</translation>
     </message>
@@ -809,6 +809,11 @@
     <message>
         <location line="+1"/>
         <source>Typing notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sort rooms by unreads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -857,7 +862,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-57"/>
+        <location line="-58"/>
         <source>Session Keys</source>
         <translation type="unfinished"></translation>
     </message>
@@ -877,22 +882,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-62"/>
         <source>GENERAL</source>
         <translation>ΓΕΝΙΚΑ</translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+24"/>
         <source>INTERFACE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+106"/>
+        <location line="+107"/>
         <source>Emoji Font Family</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
+        <location line="+152"/>
         <source>Open Sessions File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/resources/langs/nheko_en.ts
+++ b/resources/langs/nheko_en.ts
@@ -371,12 +371,12 @@
 <context>
     <name>RoomInfoListItem</name>
     <message>
-        <location filename="../../src/RoomInfoListItem.cpp" line="+97"/>
+        <location filename="../../src/RoomInfoListItem.cpp" line="+98"/>
         <source>Leave room</source>
         <translation>Leave room</translation>
     </message>
     <message>
-        <location line="+154"/>
+        <location line="+158"/>
         <source>Accept</source>
         <translation>Accept</translation>
     </message>
@@ -491,7 +491,13 @@
         <translation>-- Decryption Error (failed to retrieve megolm keys from db) --</translation>
     </message>
     <message>
-        <location line="+88"/>
+        <location line="+12"/>
+        <source>-- Decryption Error (%1) --</source>
+        <comment>Placeholder, when the message can&apos;t be decrypted. In this case, the Olm decrytion returned an error, which is passed ad %1.</comment>
+        <translation type="unfinished">-- Decryption Error (%1) --</translation>
+    </message>
+    <message>
+        <location line="+76"/>
         <source>Message redaction failed: %1</source>
         <translation>Message redaction failed: %1</translation>
     </message>
@@ -522,13 +528,7 @@
         <translation type="unfinished">-- Encrypted Event (No keys found for decryption) --</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <source>-- Decryption Error (%1) --</source>
-        <comment>Placeholder, when the message can&apos;t be decrypted. In this case, the Olm decrytion returned an error, which is passed as %1.</comment>
-        <translation type="unfinished">-- Decryption Error (%1) --</translation>
-    </message>
-    <message>
-        <location line="+29"/>
+        <location line="+75"/>
         <source>-- Encrypted Event (Unknown event type) --</source>
         <comment>Placeholder, when the message was decrypted, but we couldn&apos;t parse it, because Nheko/mtxclient don&apos;t support that event type yet.</comment>
         <translation type="unfinished">-- Encrypted Event (Unknown event type) --</translation>
@@ -782,7 +782,7 @@
 <context>
     <name>UserSettingsPage</name>
     <message>
-        <location filename="../../src/UserSettingsPage.cpp" line="+296"/>
+        <location filename="../../src/UserSettingsPage.cpp" line="+299"/>
         <source>Minimize to tray</source>
         <translation>Minimize to tray</translation>
     </message>
@@ -810,6 +810,11 @@
         <location line="+1"/>
         <source>Typing notifications</source>
         <translation>Typing notifications</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sort rooms by unreads</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
@@ -857,7 +862,7 @@
         <translation>Device Fingerprint</translation>
     </message>
     <message>
-        <location line="-57"/>
+        <location line="-58"/>
         <source>Session Keys</source>
         <translation>Session Keys</translation>
     </message>
@@ -877,22 +882,22 @@
         <translation>ENCRYPTION</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-62"/>
         <source>GENERAL</source>
         <translation>GENERAL</translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+24"/>
         <source>INTERFACE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+106"/>
+        <location line="+107"/>
         <source>Emoji Font Family</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
+        <location line="+152"/>
         <source>Open Sessions File</source>
         <translation>Open Sessions File</translation>
     </message>

--- a/resources/langs/nheko_fi.ts
+++ b/resources/langs/nheko_fi.ts
@@ -371,12 +371,12 @@
 <context>
     <name>RoomInfoListItem</name>
     <message>
-        <location filename="../../src/RoomInfoListItem.cpp" line="+97"/>
+        <location filename="../../src/RoomInfoListItem.cpp" line="+98"/>
         <source>Leave room</source>
         <translation>Poistu huoneesta</translation>
     </message>
     <message>
-        <location line="+154"/>
+        <location line="+158"/>
         <source>Accept</source>
         <translation>Hyväksy</translation>
     </message>
@@ -491,7 +491,13 @@
         <translation type="unfinished">-- Virhe purkaessa salausta (megolm-avaimien hakeminen tietokannasta epäonnistui) --</translation>
     </message>
     <message>
-        <location line="+88"/>
+        <location line="+12"/>
+        <source>-- Decryption Error (%1) --</source>
+        <comment>Placeholder, when the message can&apos;t be decrypted. In this case, the Olm decrytion returned an error, which is passed ad %1.</comment>
+        <translation type="unfinished">-- Virhe purkaessa salausta (%1) --</translation>
+    </message>
+    <message>
+        <location line="+76"/>
         <source>Message redaction failed: %1</source>
         <translation type="unfinished">Viestin poisto epäonnistui: %1</translation>
     </message>
@@ -522,13 +528,7 @@
         <translation type="unfinished">-- Salattu viesti (salauksen purkuavaimia ei löydetty) --</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <source>-- Decryption Error (%1) --</source>
-        <comment>Placeholder, when the message can&apos;t be decrypted. In this case, the Olm decrytion returned an error, which is passed as %1.</comment>
-        <translation type="unfinished">-- Virhe purkaessa salausta (%1) --</translation>
-    </message>
-    <message>
-        <location line="+29"/>
+        <location line="+75"/>
         <source>-- Encrypted Event (Unknown event type) --</source>
         <comment>Placeholder, when the message was decrypted, but we couldn&apos;t parse it, because Nheko/mtxclient don&apos;t support that event type yet.</comment>
         <translation type="unfinished">-- Salattu viesti (tuntematon viestityyppi) --</translation>
@@ -782,7 +782,7 @@
 <context>
     <name>UserSettingsPage</name>
     <message>
-        <location filename="../../src/UserSettingsPage.cpp" line="+296"/>
+        <location filename="../../src/UserSettingsPage.cpp" line="+299"/>
         <source>Minimize to tray</source>
         <translation>Pienennä ilmoitusalueelle</translation>
     </message>
@@ -810,6 +810,11 @@
         <location line="+1"/>
         <source>Typing notifications</source>
         <translation>Kirjoitusilmoitukset</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sort rooms by unreads</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
@@ -857,7 +862,7 @@
         <translation>Laitteen sormenjälki</translation>
     </message>
     <message>
-        <location line="-57"/>
+        <location line="-58"/>
         <source>Session Keys</source>
         <translation>Istunnon avaimet</translation>
     </message>
@@ -877,22 +882,22 @@
         <translation>SALAUS</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-62"/>
         <source>GENERAL</source>
         <translation>YLEISET ASETUKSET</translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+24"/>
         <source>INTERFACE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+106"/>
+        <location line="+107"/>
         <source>Emoji Font Family</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
+        <location line="+152"/>
         <source>Open Sessions File</source>
         <translation>Avaa Istuntoavaintiedosto</translation>
     </message>

--- a/resources/langs/nheko_fr.ts
+++ b/resources/langs/nheko_fr.ts
@@ -372,12 +372,12 @@
 <context>
     <name>RoomInfoListItem</name>
     <message>
-        <location filename="../../src/RoomInfoListItem.cpp" line="+97"/>
+        <location filename="../../src/RoomInfoListItem.cpp" line="+98"/>
         <source>Leave room</source>
         <translation>Quitter le salon</translation>
     </message>
     <message>
-        <location line="+154"/>
+        <location line="+158"/>
         <source>Accept</source>
         <translation>Accepter</translation>
     </message>
@@ -492,7 +492,13 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
+        <location line="+12"/>
+        <source>-- Decryption Error (%1) --</source>
+        <comment>Placeholder, when the message can&apos;t be decrypted. In this case, the Olm decrytion returned an error, which is passed ad %1.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+76"/>
         <source>Message redaction failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -523,13 +529,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
-        <source>-- Decryption Error (%1) --</source>
-        <comment>Placeholder, when the message can&apos;t be decrypted. In this case, the Olm decrytion returned an error, which is passed as %1.</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+29"/>
+        <location line="+75"/>
         <source>-- Encrypted Event (Unknown event type) --</source>
         <comment>Placeholder, when the message was decrypted, but we couldn&apos;t parse it, because Nheko/mtxclient don&apos;t support that event type yet.</comment>
         <translation type="unfinished"></translation>
@@ -783,7 +783,7 @@
 <context>
     <name>UserSettingsPage</name>
     <message>
-        <location filename="../../src/UserSettingsPage.cpp" line="+296"/>
+        <location filename="../../src/UserSettingsPage.cpp" line="+299"/>
         <source>Minimize to tray</source>
         <translation>Réduire à la barre des tâches</translation>
     </message>
@@ -811,6 +811,11 @@
         <location line="+1"/>
         <source>Typing notifications</source>
         <translation>Notifications d&apos;écriture</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sort rooms by unreads</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
@@ -858,7 +863,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-57"/>
+        <location line="-58"/>
         <source>Session Keys</source>
         <translation type="unfinished"></translation>
     </message>
@@ -878,22 +883,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-62"/>
         <source>GENERAL</source>
         <translation>GÉNÉRAL</translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+24"/>
         <source>INTERFACE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+106"/>
+        <location line="+107"/>
         <source>Emoji Font Family</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
+        <location line="+152"/>
         <source>Open Sessions File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/resources/langs/nheko_ja.ts
+++ b/resources/langs/nheko_ja.ts
@@ -371,12 +371,12 @@
 <context>
     <name>RoomInfoListItem</name>
     <message>
-        <location filename="../../src/RoomInfoListItem.cpp" line="+97"/>
+        <location filename="../../src/RoomInfoListItem.cpp" line="+98"/>
         <source>Leave room</source>
         <translation>部屋を出る</translation>
     </message>
     <message>
-        <location line="+154"/>
+        <location line="+158"/>
         <source>Accept</source>
         <translation>容認</translation>
     </message>
@@ -491,7 +491,13 @@
         <translation>-- 復号エラー (データベースからmegolm鍵を取得できませんでした) --</translation>
     </message>
     <message>
-        <location line="+88"/>
+        <location line="+12"/>
+        <source>-- Decryption Error (%1) --</source>
+        <comment>Placeholder, when the message can&apos;t be decrypted. In this case, the Olm decrytion returned an error, which is passed ad %1.</comment>
+        <translation type="unfinished">-- 復号エラー (%1) --</translation>
+    </message>
+    <message>
+        <location line="+76"/>
         <source>Message redaction failed: %1</source>
         <translation>メッセージを編集できませんでした: %1</translation>
     </message>
@@ -522,13 +528,7 @@
         <translation type="unfinished">-- 暗号化イベント (復号鍵が見つかりません) --</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <source>-- Decryption Error (%1) --</source>
-        <comment>Placeholder, when the message can&apos;t be decrypted. In this case, the Olm decrytion returned an error, which is passed as %1.</comment>
-        <translation type="unfinished">-- 復号エラー (%1) --</translation>
-    </message>
-    <message>
-        <location line="+29"/>
+        <location line="+75"/>
         <source>-- Encrypted Event (Unknown event type) --</source>
         <comment>Placeholder, when the message was decrypted, but we couldn&apos;t parse it, because Nheko/mtxclient don&apos;t support that event type yet.</comment>
         <translation type="unfinished">-- 暗号化イベント (不明なイベント型です) --</translation>
@@ -781,7 +781,7 @@
 <context>
     <name>UserSettingsPage</name>
     <message>
-        <location filename="../../src/UserSettingsPage.cpp" line="+296"/>
+        <location filename="../../src/UserSettingsPage.cpp" line="+299"/>
         <source>Minimize to tray</source>
         <translation>トレイへ最小化</translation>
     </message>
@@ -809,6 +809,11 @@
         <location line="+1"/>
         <source>Typing notifications</source>
         <translation>入力状態の通知</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sort rooms by unreads</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
@@ -856,7 +861,7 @@
         <translation>デバイスの指紋</translation>
     </message>
     <message>
-        <location line="-57"/>
+        <location line="-58"/>
         <source>Session Keys</source>
         <translation>セッション鍵</translation>
     </message>
@@ -876,22 +881,22 @@
         <translation>暗号化</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-62"/>
         <source>GENERAL</source>
         <translation>全般</translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+24"/>
         <source>INTERFACE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+106"/>
+        <location line="+107"/>
         <source>Emoji Font Family</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
+        <location line="+152"/>
         <source>Open Sessions File</source>
         <translation>セッションファイルを開く</translation>
     </message>

--- a/resources/langs/nheko_nl.ts
+++ b/resources/langs/nheko_nl.ts
@@ -371,12 +371,12 @@
 <context>
     <name>RoomInfoListItem</name>
     <message>
-        <location filename="../../src/RoomInfoListItem.cpp" line="+97"/>
+        <location filename="../../src/RoomInfoListItem.cpp" line="+98"/>
         <source>Leave room</source>
         <translation>Kamer verlaten</translation>
     </message>
     <message>
-        <location line="+154"/>
+        <location line="+158"/>
         <source>Accept</source>
         <translation>Accepteren</translation>
     </message>
@@ -491,7 +491,13 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
+        <location line="+12"/>
+        <source>-- Decryption Error (%1) --</source>
+        <comment>Placeholder, when the message can&apos;t be decrypted. In this case, the Olm decrytion returned an error, which is passed ad %1.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+76"/>
         <source>Message redaction failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -522,13 +528,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
-        <source>-- Decryption Error (%1) --</source>
-        <comment>Placeholder, when the message can&apos;t be decrypted. In this case, the Olm decrytion returned an error, which is passed as %1.</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+29"/>
+        <location line="+75"/>
         <source>-- Encrypted Event (Unknown event type) --</source>
         <comment>Placeholder, when the message was decrypted, but we couldn&apos;t parse it, because Nheko/mtxclient don&apos;t support that event type yet.</comment>
         <translation type="unfinished"></translation>
@@ -782,7 +782,7 @@
 <context>
     <name>UserSettingsPage</name>
     <message>
-        <location filename="../../src/UserSettingsPage.cpp" line="+296"/>
+        <location filename="../../src/UserSettingsPage.cpp" line="+299"/>
         <source>Minimize to tray</source>
         <translation>Minimaliseren naar systeemvak</translation>
     </message>
@@ -810,6 +810,11 @@
         <location line="+1"/>
         <source>Typing notifications</source>
         <translation>Meldingen bij typen van berichten</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sort rooms by unreads</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
@@ -857,7 +862,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-57"/>
+        <location line="-58"/>
         <source>Session Keys</source>
         <translation type="unfinished"></translation>
     </message>
@@ -877,22 +882,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-62"/>
         <source>GENERAL</source>
         <translation>ALGEMEEN</translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+24"/>
         <source>INTERFACE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+106"/>
+        <location line="+107"/>
         <source>Emoji Font Family</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
+        <location line="+152"/>
         <source>Open Sessions File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/resources/langs/nheko_pl.ts
+++ b/resources/langs/nheko_pl.ts
@@ -371,12 +371,12 @@
 <context>
     <name>RoomInfoListItem</name>
     <message>
-        <location filename="../../src/RoomInfoListItem.cpp" line="+97"/>
+        <location filename="../../src/RoomInfoListItem.cpp" line="+98"/>
         <source>Leave room</source>
         <translation>Opuść pokój</translation>
     </message>
     <message>
-        <location line="+154"/>
+        <location line="+158"/>
         <source>Accept</source>
         <translation>Akceptuj</translation>
     </message>
@@ -491,7 +491,13 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
+        <location line="+12"/>
+        <source>-- Decryption Error (%1) --</source>
+        <comment>Placeholder, when the message can&apos;t be decrypted. In this case, the Olm decrytion returned an error, which is passed ad %1.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+76"/>
         <source>Message redaction failed: %1</source>
         <translation type="unfinished">Redagowanie wiadomości nie powiodło się: %1</translation>
     </message>
@@ -522,13 +528,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
-        <source>-- Decryption Error (%1) --</source>
-        <comment>Placeholder, when the message can&apos;t be decrypted. In this case, the Olm decrytion returned an error, which is passed as %1.</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+29"/>
+        <location line="+75"/>
         <source>-- Encrypted Event (Unknown event type) --</source>
         <comment>Placeholder, when the message was decrypted, but we couldn&apos;t parse it, because Nheko/mtxclient don&apos;t support that event type yet.</comment>
         <translation type="unfinished"></translation>
@@ -783,7 +783,7 @@
 <context>
     <name>UserSettingsPage</name>
     <message>
-        <location filename="../../src/UserSettingsPage.cpp" line="+296"/>
+        <location filename="../../src/UserSettingsPage.cpp" line="+299"/>
         <source>Minimize to tray</source>
         <translation>Zminimalizuj do paska zadań</translation>
     </message>
@@ -811,6 +811,11 @@
         <location line="+1"/>
         <source>Typing notifications</source>
         <translation>Powiadomienia o pisaniu</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sort rooms by unreads</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
@@ -858,7 +863,7 @@
         <translation>Odcisk palca urządzenia</translation>
     </message>
     <message>
-        <location line="-57"/>
+        <location line="-58"/>
         <source>Session Keys</source>
         <translation type="unfinished"></translation>
     </message>
@@ -878,22 +883,22 @@
         <translation>SZYFROWANIE</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-62"/>
         <source>GENERAL</source>
         <translation>OGÓLNE</translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+24"/>
         <source>INTERFACE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+106"/>
+        <location line="+107"/>
         <source>Emoji Font Family</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
+        <location line="+152"/>
         <source>Open Sessions File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/resources/langs/nheko_ru.ts
+++ b/resources/langs/nheko_ru.ts
@@ -371,12 +371,12 @@
 <context>
     <name>RoomInfoListItem</name>
     <message>
-        <location filename="../../src/RoomInfoListItem.cpp" line="+97"/>
+        <location filename="../../src/RoomInfoListItem.cpp" line="+98"/>
         <source>Leave room</source>
         <translation>Покинуть комнату</translation>
     </message>
     <message>
-        <location line="+154"/>
+        <location line="+158"/>
         <source>Accept</source>
         <translation>Принять</translation>
     </message>
@@ -491,7 +491,13 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
+        <location line="+12"/>
+        <source>-- Decryption Error (%1) --</source>
+        <comment>Placeholder, when the message can&apos;t be decrypted. In this case, the Olm decrytion returned an error, which is passed ad %1.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+76"/>
         <source>Message redaction failed: %1</source>
         <translation type="unfinished">Ошибка редактирования сообщения: %1</translation>
     </message>
@@ -522,13 +528,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
-        <source>-- Decryption Error (%1) --</source>
-        <comment>Placeholder, when the message can&apos;t be decrypted. In this case, the Olm decrytion returned an error, which is passed as %1.</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+29"/>
+        <location line="+75"/>
         <source>-- Encrypted Event (Unknown event type) --</source>
         <comment>Placeholder, when the message was decrypted, but we couldn&apos;t parse it, because Nheko/mtxclient don&apos;t support that event type yet.</comment>
         <translation type="unfinished"></translation>
@@ -783,7 +783,7 @@
 <context>
     <name>UserSettingsPage</name>
     <message>
-        <location filename="../../src/UserSettingsPage.cpp" line="+296"/>
+        <location filename="../../src/UserSettingsPage.cpp" line="+299"/>
         <source>Minimize to tray</source>
         <translation>Сворачивать в системную панель</translation>
     </message>
@@ -811,6 +811,11 @@
         <location line="+1"/>
         <source>Typing notifications</source>
         <translation>Сообщать о наборе сообщения</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sort rooms by unreads</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
@@ -858,7 +863,7 @@
         <translation>Отпечаток устройства</translation>
     </message>
     <message>
-        <location line="-57"/>
+        <location line="-58"/>
         <source>Session Keys</source>
         <translation>Ключи сеанса</translation>
     </message>
@@ -878,22 +883,22 @@
         <translation>ШИФРОВАНИЕ</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-62"/>
         <source>GENERAL</source>
         <translation>ГЛАВНОЕ</translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+24"/>
         <source>INTERFACE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+106"/>
+        <location line="+107"/>
         <source>Emoji Font Family</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
+        <location line="+152"/>
         <source>Open Sessions File</source>
         <translation>Открыть файл сеансов</translation>
     </message>

--- a/resources/langs/nheko_zh_CN.ts
+++ b/resources/langs/nheko_zh_CN.ts
@@ -371,12 +371,12 @@
 <context>
     <name>RoomInfoListItem</name>
     <message>
-        <location filename="../../src/RoomInfoListItem.cpp" line="+97"/>
+        <location filename="../../src/RoomInfoListItem.cpp" line="+98"/>
         <source>Leave room</source>
         <translation>离开聊天室</translation>
     </message>
     <message>
-        <location line="+154"/>
+        <location line="+158"/>
         <source>Accept</source>
         <translation>接受</translation>
     </message>
@@ -491,7 +491,13 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
+        <location line="+12"/>
+        <source>-- Decryption Error (%1) --</source>
+        <comment>Placeholder, when the message can&apos;t be decrypted. In this case, the Olm decrytion returned an error, which is passed ad %1.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+76"/>
         <source>Message redaction failed: %1</source>
         <translation type="unfinished">删除消息失败：%1</translation>
     </message>
@@ -522,13 +528,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
-        <source>-- Decryption Error (%1) --</source>
-        <comment>Placeholder, when the message can&apos;t be decrypted. In this case, the Olm decrytion returned an error, which is passed as %1.</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+29"/>
+        <location line="+75"/>
         <source>-- Encrypted Event (Unknown event type) --</source>
         <comment>Placeholder, when the message was decrypted, but we couldn&apos;t parse it, because Nheko/mtxclient don&apos;t support that event type yet.</comment>
         <translation type="unfinished"></translation>
@@ -781,7 +781,7 @@
 <context>
     <name>UserSettingsPage</name>
     <message>
-        <location filename="../../src/UserSettingsPage.cpp" line="+296"/>
+        <location filename="../../src/UserSettingsPage.cpp" line="+299"/>
         <source>Minimize to tray</source>
         <translation>最小化至托盘</translation>
     </message>
@@ -809,6 +809,11 @@
         <location line="+1"/>
         <source>Typing notifications</source>
         <translation>打字通知</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sort rooms by unreads</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
@@ -856,7 +861,7 @@
         <translation>设备指纹</translation>
     </message>
     <message>
-        <location line="-57"/>
+        <location line="-58"/>
         <source>Session Keys</source>
         <translation>会话密钥</translation>
     </message>
@@ -876,22 +881,22 @@
         <translation>加密</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-62"/>
         <source>GENERAL</source>
         <translation>通用</translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+24"/>
         <source>INTERFACE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+106"/>
+        <location line="+107"/>
         <source>Emoji Font Family</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
+        <location line="+152"/>
         <source>Open Sessions File</source>
         <translation>打开会话文件</translation>
     </message>

--- a/src/ChatPage.cpp
+++ b/src/ChatPage.cpp
@@ -100,7 +100,7 @@ ChatPage::ChatPage(QSharedPointer<UserSettings> userSettings, QWidget *parent)
 
         user_info_widget_    = new UserInfoWidget(sideBar_);
         user_mentions_popup_ = new popups::UserMentions();
-        room_list_           = new RoomList(sideBar_);
+        room_list_           = new RoomList(userSettings, sideBar_);
         connect(room_list_, &RoomList::joinRoom, this, &ChatPage::joinRoom);
 
         sideBarLayout_->addWidget(user_info_widget_);

--- a/src/RoomInfoListItem.cpp
+++ b/src/RoomInfoListItem.cpp
@@ -327,6 +327,11 @@ RoomInfoListItem::updateUnreadMessageCount(int count, int highlightedCount)
 unsigned short int
 RoomInfoListItem::calculateImportance() const
 {
+        // 0: All messages and minor events read
+        // 1: Contains unread minor events (joins/notices/muted messages)
+        // 2: Contains unread messages
+        // 3: Contains mentions
+        // 4: Is a room invite
         return (hasUnreadMessages_) +
                (unreadHighlightedMsgCount_ + unreadMsgCount_ != 0) +
                (unreadHighlightedMsgCount_ != 0) +

--- a/src/RoomInfoListItem.cpp
+++ b/src/RoomInfoListItem.cpp
@@ -353,8 +353,6 @@ RoomInfoListItem::calculateImportance() const
                 return NewMentions;
         } else if (unreadMsgCount_) {
                 return NewMessage;
-                // } else if (hasUnreadMessages_ && !settings->isIgnoreMinorEventsEnabled()) {
-                //         return NewMinorEvents;
         } else {
                 return AllEventsRead;
         }

--- a/src/RoomInfoListItem.cpp
+++ b/src/RoomInfoListItem.cpp
@@ -324,6 +324,15 @@ RoomInfoListItem::updateUnreadMessageCount(int count, int highlightedCount)
         update();
 }
 
+unsigned short int
+RoomInfoListItem::calculateImportance() const
+{
+        return (hasUnreadMessages_) +
+               (unreadMsgCount_ != 0) +
+               (unreadHighlightedMsgCount_ != 0) +
+               (isInvite()) * 4;
+}
+
 void
 RoomInfoListItem::setPressedState(bool state)
 {

--- a/src/RoomInfoListItem.cpp
+++ b/src/RoomInfoListItem.cpp
@@ -329,29 +329,32 @@ RoomInfoListItem::updateUnreadMessageCount(int count, int highlightedCount)
         update();
 }
 
-enum NotificationImportance : unsigned short
+enum NotificationImportance : short
 {
-        AllEventsRead  = 0,
-        NewMinorEvents = 1,
-        NewMessage     = 2,
-        NewMentions    = 3,
-        Invite         = 4
+        ImportanceDisabled = -1,
+        AllEventsRead      = 0,
+        NewMinorEvents     = 1, // This is currently unused
+        NewMessage         = 2,
+        NewMentions        = 3,
+        Invite             = 4
 };
 
 unsigned short int
 RoomInfoListItem::calculateImportance() const
 {
         // Returns the degree of importance of the unread messages in the room.
-        // If ignoreMinorEvents is set to true in the settings, then
-        // NewMinorEvents will always be rounded down to AllEventsRead
-        if (isInvite()) {
+        // If sorting by importance is disabled in settings, this only ever
+        // returns ImportanceDisabled
+        if (!settings->isSortByImportanceEnabled()) {
+                return ImportanceDisabled;
+        } else if (isInvite()) {
                 return Invite;
         } else if (unreadHighlightedMsgCount_) {
                 return NewMentions;
         } else if (unreadMsgCount_) {
                 return NewMessage;
-        } else if (hasUnreadMessages_ && !settings->isIgnoreMinorEventsEnabled()) {
-                return NewMinorEvents;
+                // } else if (hasUnreadMessages_ && !settings->isIgnoreMinorEventsEnabled()) {
+                //         return NewMinorEvents;
         } else {
                 return AllEventsRead;
         }

--- a/src/RoomInfoListItem.cpp
+++ b/src/RoomInfoListItem.cpp
@@ -332,10 +332,8 @@ RoomInfoListItem::calculateImportance() const
         // 2: Contains unread messages
         // 3: Contains mentions
         // 4: Is a room invite
-        return (hasUnreadMessages_) +
-               (unreadHighlightedMsgCount_ + unreadMsgCount_ != 0) +
-               (unreadHighlightedMsgCount_ != 0) +
-               (isInvite()) * 4;
+        return (hasUnreadMessages_) + (unreadHighlightedMsgCount_ + unreadMsgCount_ != 0) +
+               (unreadHighlightedMsgCount_ != 0) + (isInvite()) * 4;
 }
 
 void

--- a/src/RoomInfoListItem.cpp
+++ b/src/RoomInfoListItem.cpp
@@ -333,10 +333,9 @@ enum NotificationImportance : short
 {
         ImportanceDisabled = -1,
         AllEventsRead      = 0,
-        NewMinorEvents     = 1, // This is currently unused
-        NewMessage         = 2,
-        NewMentions        = 3,
-        Invite             = 4
+        NewMessage         = 1,
+        NewMentions        = 2,
+        Invite             = 3
 };
 
 unsigned short int
@@ -344,11 +343,11 @@ RoomInfoListItem::calculateImportance() const
 {
         // Returns the degree of importance of the unread messages in the room.
         // If sorting by importance is disabled in settings, this only ever
-        // returns ImportanceDisabled
-        if (!settings->isSortByImportanceEnabled()) {
-                return ImportanceDisabled;
-        } else if (isInvite()) {
+        // returns ImportanceDisabled or Invite
+        if (isInvite()) {
                 return Invite;
+        } else if (!settings->isSortByImportanceEnabled()) {
+                return ImportanceDisabled;
         } else if (unreadHighlightedMsgCount_) {
                 return NewMentions;
         } else if (unreadMsgCount_) {

--- a/src/RoomInfoListItem.cpp
+++ b/src/RoomInfoListItem.cpp
@@ -324,6 +324,15 @@ RoomInfoListItem::updateUnreadMessageCount(int count, int highlightedCount)
         update();
 }
 
+enum NotificationImportance : unsigned short
+{
+        AllEventsRead  = 0,
+        NewMinorEvents = 1,
+        NewMessage     = 2,
+        NewMentions    = 3,
+        Invite         = 4
+};
+
 unsigned short int
 RoomInfoListItem::calculateImportance() const
 {
@@ -332,8 +341,17 @@ RoomInfoListItem::calculateImportance() const
         // 2: Contains unread messages
         // 3: Contains mentions
         // 4: Is a room invite
-        return (hasUnreadMessages_) + (unreadHighlightedMsgCount_ + unreadMsgCount_ != 0) +
-               (unreadHighlightedMsgCount_ != 0) + (isInvite()) * 4;
+        if (isInvite()) {
+                return Invite;
+        } else if (unreadHighlightedMsgCount_) {
+                return NewMentions;
+        } else if (unreadMsgCount_) {
+                return NewMessage;
+        } else if (hasUnreadMessages_) {
+                return NewMinorEvents;
+        } else {
+                return AllEventsRead;
+        }
 }
 
 void

--- a/src/RoomInfoListItem.cpp
+++ b/src/RoomInfoListItem.cpp
@@ -328,7 +328,7 @@ unsigned short int
 RoomInfoListItem::calculateImportance() const
 {
         return (hasUnreadMessages_) +
-               (unreadMsgCount_ != 0) +
+               (unreadHighlightedMsgCount_ + unreadMsgCount_ != 0) +
                (unreadHighlightedMsgCount_ != 0) +
                (isInvite()) * 4;
 }

--- a/src/RoomInfoListItem.cpp
+++ b/src/RoomInfoListItem.cpp
@@ -338,7 +338,7 @@ enum NotificationImportance : short
         Invite             = 3
 };
 
-unsigned short int
+short int
 RoomInfoListItem::calculateImportance() const
 {
         // Returns the degree of importance of the unread messages in the room.

--- a/src/RoomInfoListItem.h
+++ b/src/RoomInfoListItem.h
@@ -25,6 +25,7 @@
 #include <mtx/responses.hpp>
 
 #include "CacheStructs.h"
+#include "UserSettingsPage.h"
 #include "ui/Avatar.h"
 
 class Menu;
@@ -63,7 +64,10 @@ class RoomInfoListItem : public QWidget
         Q_PROPERTY(QColor btnTextColor READ btnTextColor WRITE setBtnTextColor)
 
 public:
-        RoomInfoListItem(QString room_id, const RoomInfo &info, QWidget *parent = nullptr);
+        RoomInfoListItem(QString room_id,
+                         const RoomInfo &info,
+                         QSharedPointer<UserSettings> userSettings,
+                         QWidget *parent = nullptr);
 
         void updateUnreadMessageCount(int count, int highlightedCount);
         void clearUnreadMessageCount() { updateUnreadMessageCount(0, 0); };
@@ -216,4 +220,6 @@ private:
 
         QColor bubbleBgColor_;
         QColor bubbleFgColor_;
+
+        QSharedPointer<UserSettings> settings;
 };

--- a/src/RoomInfoListItem.h
+++ b/src/RoomInfoListItem.h
@@ -72,7 +72,7 @@ public:
         void updateUnreadMessageCount(int count, int highlightedCount);
         void clearUnreadMessageCount() { updateUnreadMessageCount(0, 0); };
 
-        unsigned short int calculateImportance() const;
+        short int calculateImportance() const;
 
         QString roomId() { return roomId_; }
         bool isPressed() const { return isPressed_; }

--- a/src/RoomInfoListItem.h
+++ b/src/RoomInfoListItem.h
@@ -68,6 +68,8 @@ public:
         void updateUnreadMessageCount(int count, int highlightedCount);
         void clearUnreadMessageCount() { updateUnreadMessageCount(0, 0); };
 
+        unsigned short int calculateImportance() const;
+
         QString roomId() { return roomId_; }
         bool isPressed() const { return isPressed_; }
         int unreadMessageCount() const { return unreadMsgCount_; }
@@ -128,7 +130,7 @@ public:
                         roomType_ = RoomType::Joined;
         }
 
-        bool isInvite() { return roomType_ == RoomType::Invited; }
+        bool isInvite() const { return roomType_ == RoomType::Invited; }
         void setReadState(bool hasUnreadMessages)
         {
                 if (hasUnreadMessages_ != hasUnreadMessages) {

--- a/src/RoomList.cpp
+++ b/src/RoomList.cpp
@@ -65,7 +65,7 @@ RoomList::RoomList(QSharedPointer<UserSettings> userSettings, QWidget *parent)
         topLayout_->addWidget(scrollArea_);
 
         connect(this, &RoomList::updateRoomAvatarCb, this, &RoomList::updateRoomAvatar);
-        connect(userSettings.get(),
+        connect(userSettings.data(),
                 &UserSettings::roomSortingChanged,
                 this,
                 &RoomList::sortRoomsByLastMessage);

--- a/src/RoomList.cpp
+++ b/src/RoomList.cpp
@@ -331,8 +331,10 @@ RoomList::updateRoomDescription(const QString &roomid, const DescInfo &info)
         emit sortRoomsByLastMessage();
 }
 
-struct room_sort {
-        bool operator() (const RoomInfoListItem * a, const RoomInfoListItem * b) const {
+struct room_sort
+{
+        bool operator()(const RoomInfoListItem *a, const RoomInfoListItem *b) const
+        {
                 // Sort by "importance" (i.e. invites before mentions before
                 // notifs before new events before old events), then secondly
                 // by recency.
@@ -340,16 +342,18 @@ struct room_sort {
                 // Checking importance first
                 const auto a_importance = a->calculateImportance();
                 const auto b_importance = b->calculateImportance();
-                if(a_importance != b_importance) {
+                if (a_importance != b_importance) {
                         return a_importance > b_importance;
                 }
 
                 // Now sort by recency
                 // Zero if empty, otherwise the time that the event occured
-                const uint64_t a_recency = a->lastMessageInfo().userid.isEmpty() ? 0 :
-                                           a->lastMessageInfo().datetime.toMSecsSinceEpoch();
-                const uint64_t b_recency = b->lastMessageInfo().userid.isEmpty() ? 0 :
-                                           b->lastMessageInfo().datetime.toMSecsSinceEpoch();
+                const uint64_t a_recency = a->lastMessageInfo().userid.isEmpty()
+                                             ? 0
+                                             : a->lastMessageInfo().datetime.toMSecsSinceEpoch();
+                const uint64_t b_recency = b->lastMessageInfo().userid.isEmpty()
+                                             ? 0
+                                             : b->lastMessageInfo().datetime.toMSecsSinceEpoch();
                 return a_recency > b_recency;
         }
 };

--- a/src/RoomList.cpp
+++ b/src/RoomList.cpp
@@ -65,6 +65,10 @@ RoomList::RoomList(QSharedPointer<UserSettings> userSettings, QWidget *parent)
         topLayout_->addWidget(scrollArea_);
 
         connect(this, &RoomList::updateRoomAvatarCb, this, &RoomList::updateRoomAvatar);
+        connect(userSettings.get(),
+                &UserSettings::roomSortingChanged,
+                this,
+                &RoomList::sortRoomsByLastMessage);
 }
 
 void

--- a/src/RoomList.cpp
+++ b/src/RoomList.cpp
@@ -123,6 +123,8 @@ RoomList::updateUnreadMessageCount(const QString &roomid, int count, int highlig
         rooms_[roomid]->updateUnreadMessageCount(count, highlightedCount);
 
         calculateUnreadMessageCount();
+
+        sortRoomsByLastMessage();
 }
 
 void

--- a/src/RoomList.cpp
+++ b/src/RoomList.cpp
@@ -27,11 +27,13 @@
 #include "MainWindow.h"
 #include "RoomInfoListItem.h"
 #include "RoomList.h"
+#include "UserSettingsPage.h"
 #include "Utils.h"
 #include "ui/OverlayModal.h"
 
-RoomList::RoomList(QWidget *parent)
+RoomList::RoomList(QSharedPointer<UserSettings> userSettings, QWidget *parent)
   : QWidget(parent)
+  , settings(userSettings)
 {
         topLayout_ = new QVBoxLayout(this);
         topLayout_->setSpacing(0);
@@ -68,7 +70,7 @@ RoomList::RoomList(QWidget *parent)
 void
 RoomList::addRoom(const QString &room_id, const RoomInfo &info)
 {
-        auto room_item = new RoomInfoListItem(room_id, info, scrollArea_);
+        auto room_item = new RoomInfoListItem(room_id, info, settings, scrollArea_);
         room_item->setRoomName(QString::fromStdString(std::move(info.name)));
 
         connect(room_item, &RoomInfoListItem::clicked, this, &RoomList::highlightSelectedRoom);
@@ -492,7 +494,7 @@ RoomList::updateRoom(const QString &room_id, const RoomInfo &info)
 void
 RoomList::addInvitedRoom(const QString &room_id, const RoomInfo &info)
 {
-        auto room_item = new RoomInfoListItem(room_id, info, scrollArea_);
+        auto room_item = new RoomInfoListItem(room_id, info, settings, scrollArea_);
 
         connect(room_item, &RoomInfoListItem::acceptInvite, this, &RoomList::acceptInvite);
         connect(room_item, &RoomInfoListItem::declineInvite, this, &RoomList::declineInvite);

--- a/src/RoomList.h
+++ b/src/RoomList.h
@@ -23,6 +23,9 @@
 #include <QVBoxLayout>
 #include <QWidget>
 
+#include "CacheStructs.h"
+#include "UserSettingsPage.h"
+
 class LeaveRoomDialog;
 class OverlayModal;
 class RoomInfoListItem;
@@ -35,7 +38,7 @@ class RoomList : public QWidget
         Q_OBJECT
 
 public:
-        explicit RoomList(QWidget *parent = nullptr);
+        explicit RoomList(QSharedPointer<UserSettings> userSettings, QWidget *parent = nullptr);
 
         void initialize(const QMap<QString, RoomInfo> &info);
         void sync(const std::map<QString, RoomInfo> &info);
@@ -100,4 +103,5 @@ private:
         QString selectedRoom_;
 
         bool isSortPending_ = false;
+        QSharedPointer<UserSettings> settings;
 };

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -57,6 +57,7 @@ UserSettings::load()
         isGroupViewEnabled_           = settings.value("user/group_view", true).toBool();
         isMarkdownEnabled_            = settings.value("user/markdown_enabled", true).toBool();
         isTypingNotificationsEnabled_ = settings.value("user/typing_notifications", true).toBool();
+        ignoreMinorEvents_            = settings.value("user/minor_events", false).toBool();
         isReadReceiptsEnabled_        = settings.value("user/read_receipts", true).toBool();
         theme_                        = settings.value("user/theme", defaultTheme_).toString();
         font_                         = settings.value("user/font_family", "default").toString();
@@ -130,6 +131,7 @@ UserSettings::save()
 
         settings.setValue("font_size", baseFontSize_);
         settings.setValue("typing_notifications", isTypingNotificationsEnabled_);
+        settings.setValue("minor_events", ignoreMinorEvents_);
         settings.setValue("read_receipts", isReadReceiptsEnabled_);
         settings.setValue("group_view", isGroupViewEnabled_);
         settings.setValue("markdown_enabled", isMarkdownEnabled_);
@@ -191,6 +193,7 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         avatarCircles_           = new Toggle{this};
         groupViewToggle_         = new Toggle{this};
         typingNotifications_     = new Toggle{this};
+        ignoreMinorEvents_       = new Toggle{this};
         readReceipts_            = new Toggle{this};
         markdownEnabled_         = new Toggle{this};
         desktopNotifications_    = new Toggle{this};
@@ -293,6 +296,7 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         boxWrap(tr("Circular Avatars"), avatarCircles_);
         boxWrap(tr("Group's sidebar"), groupViewToggle_);
         boxWrap(tr("Typing notifications"), typingNotifications_);
+        boxWrap(tr("Ignore minor events in room list"), ignoreMinorEvents_);
         formLayout_->addRow(new HorizontalLine{this});
         boxWrap(tr("Read receipts"), readReceipts_);
         boxWrap(tr("Send messages as Markdown"), markdownEnabled_);
@@ -394,6 +398,10 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
                 settings_->setTypingNotifications(!isDisabled);
         });
 
+        connect(ignoreMinorEvents_, &Toggle::toggled, this, [this](bool isDisabled) {
+                settings_->setIgnoreMinorEvents(!isDisabled);
+        });
+
         connect(readReceipts_, &Toggle::toggled, this, [this](bool isDisabled) {
                 settings_->setReadReceipts(!isDisabled);
         });
@@ -428,6 +436,7 @@ UserSettingsPage::showEvent(QShowEvent *)
         groupViewToggle_->setState(!settings_->isGroupViewEnabled());
         avatarCircles_->setState(!settings_->isAvatarCirclesEnabled());
         typingNotifications_->setState(!settings_->isTypingNotificationsEnabled());
+        ignoreMinorEvents_->setState(!settings_->isIgnoreMinorEventsEnabled());
         readReceipts_->setState(!settings_->isReadReceiptsEnabled());
         markdownEnabled_->setState(!settings_->isMarkdownEnabled());
         desktopNotifications_->setState(!settings_->hasDesktopNotifications());

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -58,7 +58,7 @@ UserSettings::load()
         isButtonsInTimelineEnabled_   = settings.value("user/timeline/buttons", true).toBool();
         isMarkdownEnabled_            = settings.value("user/markdown_enabled", true).toBool();
         isTypingNotificationsEnabled_ = settings.value("user/typing_notifications", true).toBool();
-        ignoreMinorEvents_            = settings.value("user/minor_events", false).toBool();
+        sortByImportance_             = settings.value("user/sort_by_unread", true).toBool();
         isReadReceiptsEnabled_        = settings.value("user/read_receipts", true).toBool();
         theme_                        = settings.value("user/theme", defaultTheme_).toString();
         font_                         = settings.value("user/font_family", "default").toString();
@@ -136,7 +136,7 @@ UserSettings::save()
 
         settings.setValue("font_size", baseFontSize_);
         settings.setValue("typing_notifications", isTypingNotificationsEnabled_);
-        settings.setValue("minor_events", ignoreMinorEvents_);
+        settings.setValue("minor_events", sortByImportance_);
         settings.setValue("read_receipts", isReadReceiptsEnabled_);
         settings.setValue("group_view", isGroupViewEnabled_);
         settings.setValue("markdown_enabled", isMarkdownEnabled_);
@@ -199,7 +199,7 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         groupViewToggle_         = new Toggle{this};
         timelineButtonsToggle_   = new Toggle{this};
         typingNotifications_     = new Toggle{this};
-        ignoreMinorEvents_       = new Toggle{this};
+        sortByImportance_        = new Toggle{this};
         readReceipts_            = new Toggle{this};
         markdownEnabled_         = new Toggle{this};
         desktopNotifications_    = new Toggle{this};
@@ -303,7 +303,7 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         boxWrap(tr("Group's sidebar"), groupViewToggle_);
         boxWrap(tr("Show buttons in timeline"), timelineButtonsToggle_);
         boxWrap(tr("Typing notifications"), typingNotifications_);
-        boxWrap(tr("Ignore minor events in room list"), ignoreMinorEvents_);
+        boxWrap(tr("Sort rooms by unreads"), sortByImportance_);
         formLayout_->addRow(new HorizontalLine{this});
         boxWrap(tr("Read receipts"), readReceipts_);
         boxWrap(tr("Send messages as Markdown"), markdownEnabled_);
@@ -405,8 +405,8 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
                 settings_->setTypingNotifications(!isDisabled);
         });
 
-        connect(ignoreMinorEvents_, &Toggle::toggled, this, [this](bool isDisabled) {
-                settings_->setIgnoreMinorEvents(!isDisabled);
+        connect(sortByImportance_, &Toggle::toggled, this, [this](bool isDisabled) {
+                settings_->setSortByImportance(!isDisabled);
         });
 
         connect(timelineButtonsToggle_, &Toggle::toggled, this, [this](bool isDisabled) {
@@ -447,7 +447,7 @@ UserSettingsPage::showEvent(QShowEvent *)
         groupViewToggle_->setState(!settings_->isGroupViewEnabled());
         avatarCircles_->setState(!settings_->isAvatarCirclesEnabled());
         typingNotifications_->setState(!settings_->isTypingNotificationsEnabled());
-        ignoreMinorEvents_->setState(!settings_->isIgnoreMinorEventsEnabled());
+        sortByImportance_->setState(!settings_->isSortByImportanceEnabled());
         timelineButtonsToggle_->setState(!settings_->isButtonsInTimelineEnabled());
         readReceipts_->setState(!settings_->isReadReceiptsEnabled());
         markdownEnabled_->setState(!settings_->isMarkdownEnabled());

--- a/src/UserSettingsPage.h
+++ b/src/UserSettingsPage.h
@@ -87,6 +87,12 @@ public:
                 save();
         }
 
+        void setIgnoreMinorEvents(bool state)
+        {
+                ignoreMinorEvents_ = state;
+                save();
+        }
+
         void setDesktopNotifications(bool state)
         {
                 hasDesktopNotifications_ = state;
@@ -106,6 +112,7 @@ public:
         bool isAvatarCirclesEnabled() const { return avatarCircles_; }
         bool isMarkdownEnabled() const { return isMarkdownEnabled_; }
         bool isTypingNotificationsEnabled() const { return isTypingNotificationsEnabled_; }
+        bool isIgnoreMinorEventsEnabled() const { return ignoreMinorEvents_; }
         bool isReadReceiptsEnabled() const { return isReadReceiptsEnabled_; }
         bool hasDesktopNotifications() const { return hasDesktopNotifications_; }
         double fontSize() const { return baseFontSize_; }
@@ -127,6 +134,7 @@ private:
         bool isGroupViewEnabled_;
         bool isMarkdownEnabled_;
         bool isTypingNotificationsEnabled_;
+        bool ignoreMinorEvents_;
         bool isReadReceiptsEnabled_;
         bool hasDesktopNotifications_;
         bool avatarCircles_;
@@ -176,6 +184,7 @@ private:
         Toggle *startInTrayToggle_;
         Toggle *groupViewToggle_;
         Toggle *typingNotifications_;
+        Toggle *ignoreMinorEvents_;
         Toggle *readReceipts_;
         Toggle *markdownEnabled_;
         Toggle *desktopNotifications_;

--- a/src/UserSettingsPage.h
+++ b/src/UserSettingsPage.h
@@ -87,9 +87,9 @@ public:
                 save();
         }
 
-        void setIgnoreMinorEvents(bool state)
+        void setSortByImportance(bool state)
         {
-                ignoreMinorEvents_ = state;
+                sortByImportance_ = state;
                 emit roomSortingChanged();
         }
 
@@ -118,7 +118,7 @@ public:
         bool isAvatarCirclesEnabled() const { return avatarCircles_; }
         bool isMarkdownEnabled() const { return isMarkdownEnabled_; }
         bool isTypingNotificationsEnabled() const { return isTypingNotificationsEnabled_; }
-        bool isIgnoreMinorEventsEnabled() const { return ignoreMinorEvents_; }
+        bool isSortByImportanceEnabled() const { return sortByImportance_; }
         bool isButtonsInTimelineEnabled() const { return isButtonsInTimelineEnabled_; }
         bool isReadReceiptsEnabled() const { return isReadReceiptsEnabled_; }
         bool hasDesktopNotifications() const { return hasDesktopNotifications_; }
@@ -142,7 +142,7 @@ private:
         bool isGroupViewEnabled_;
         bool isMarkdownEnabled_;
         bool isTypingNotificationsEnabled_;
-        bool ignoreMinorEvents_;
+        bool sortByImportance_;
         bool isButtonsInTimelineEnabled_;
         bool isReadReceiptsEnabled_;
         bool hasDesktopNotifications_;
@@ -194,7 +194,7 @@ private:
         Toggle *groupViewToggle_;
         Toggle *timelineButtonsToggle_;
         Toggle *typingNotifications_;
-        Toggle *ignoreMinorEvents_;
+        Toggle *sortByImportance_;
         Toggle *readReceipts_;
         Toggle *markdownEnabled_;
         Toggle *desktopNotifications_;

--- a/src/UserSettingsPage.h
+++ b/src/UserSettingsPage.h
@@ -87,7 +87,11 @@ public:
                 save();
         }
 
-        void setIgnoreMinorEvents(bool state) { ignoreMinorEvents_ = state; }
+        void setIgnoreMinorEvents(bool state)
+        {
+                ignoreMinorEvents_ = state;
+                emit roomSortingChanged();
+        }
 
         void setButtonsInTimeline(bool state)
         {
@@ -124,6 +128,7 @@ public:
 
 signals:
         void groupViewStateChanged(bool state);
+        void roomSortingChanged();
 
 private:
         // Default to system theme if QT_QPA_PLATFORMTHEME var is set.

--- a/src/UserSettingsPage.h
+++ b/src/UserSettingsPage.h
@@ -87,10 +87,7 @@ public:
                 save();
         }
 
-        void setIgnoreMinorEvents(bool state)
-        {
-                ignoreMinorEvents_ = state;
-        }
+        void setIgnoreMinorEvents(bool state) { ignoreMinorEvents_ = state; }
 
         void setButtonsInTimeline(bool state)
         {


### PR DESCRIPTION
Currently, rooms in the room list are sorted exclusively by the last message time.  This leads to problems when a message has an unread message from a while ago.  Such a room sinks down in the room list, leading to it going unnoticed, despite the fact that most users would want to see the contents of that room.  This can happen in situations like when the user doesn't read through all of their unreads before stepping away from nheko, or receiving a bunch more.  Additionally, this is in contrast to the typical UX in other apps, making it somewhat counterintuitive.

This pull request modifies the sorting mechanism for the room list to sort the rooms primarily by "importance", and second by recency.  Importance is a number between zero and four indicating the class of unread message present in the room.  0 indicates no message, 1 indicates minor messages, 2 indicates general messages, 3 indicates mentions, and 4 is reserved for room invites.  Rooms with the same class are grouped together, and within groups, messages are sorted by recency.

As a note, this is my first time working with C++, so please let me know if my code looks attrocious, so I can fix it and improve my style and become more familiar with the projects architecture.