### PR TITLE
Better image overlay handling when downloading

### DIFF
--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -1271,7 +1271,7 @@ TimelineModel::addPendingMessage(mtx::events::collections::TimelineEvents event)
                 emit nextPendingMessage();
 }
 
-void
+bool
 TimelineModel::saveMedia(QString eventId) const
 {
         mtx::events::collections::TimelineEvents event = events.value(eventId);
@@ -1309,7 +1309,7 @@ TimelineModel::saveMedia(QString eventId) const
           manager_->getWidget(), dialogTitle, openLocation, filterString);
 
         if (filename.isEmpty())
-                return;
+                return false;
 
         const auto url = mxcUrl.toStdString();
 
@@ -1340,10 +1340,13 @@ TimelineModel::saveMedia(QString eventId) const
 
                           file.write(QByteArray(temp.data(), (int)temp.size()));
                           file.close();
+
+                          return;
                   } catch (const std::exception &e) {
                           nhlog::ui()->warn("Error while saving file to: {}", e.what());
                   }
           });
+        return true;
 }
 
 void

--- a/src/timeline/TimelineModel.h
+++ b/src/timeline/TimelineModel.h
@@ -186,7 +186,7 @@ public:
         Q_INVOKABLE int idToIndex(QString id) const;
         Q_INVOKABLE QString indexToId(int index) const;
         Q_INVOKABLE void cacheMedia(QString eventId);
-        Q_INVOKABLE void saveMedia(QString eventId) const;
+        Q_INVOKABLE bool saveMedia(QString eventId) const;
 
         void addEvents(const mtx::responses::Timeline &events);
         template<class T>

--- a/src/timeline/TimelineViewManager.cpp
+++ b/src/timeline/TimelineViewManager.cpp
@@ -175,9 +175,20 @@ TimelineViewManager::openImageOverlay(QString mxcUrl, QString eventId) const
 
                 auto imgDialog = new dialogs::ImageOverlay(pixmap);
                 imgDialog->showFullScreen();
-                connect(imgDialog, &dialogs::ImageOverlay::saving, timeline_, [this, eventId]() {
-                        timeline_->saveMedia(eventId);
-                });
+                connect(imgDialog,
+                        &dialogs::ImageOverlay::saving,
+                        timeline_,
+                        [this, eventId, imgDialog]() {
+                                // hide the overlay while presenting the save dialog for better
+                                // cross platform support.
+                                imgDialog->hide();
+
+                                if (!timeline_->saveMedia(eventId)) {
+                                        imgDialog->show();
+                                } else {
+                                        imgDialog->close();
+                                }
+                        });
         });
 }
 


### PR DESCRIPTION
 - hides the overlay when prompting for download location
 - cancel re-shows the dialog
 - success closes the overlay
 - would be nice to have a return code from the download fn in
 mtxclient.

Closes #140