### PR TITLE
Removed double-sanitization of names in "... is typing" messages

### DIFF
--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -1443,7 +1443,7 @@ TimelineModel::formatTypingUsers(const std::vector<QString> &users, QColor bg)
         QStringList uidWithoutLast;
 
         auto formatUser = [this, bg](const QString &user_id) -> QString {
-                auto uncoloredUsername = escapeEmoji(displayName(user_id).toHtmlEscaped());
+                auto uncoloredUsername = escapeEmoji(displayName(user_id));
                 QString prefix =
                   QString("<font color=\"%1\">").arg(manager_->userColor(user_id, bg).name());
 


### PR DESCRIPTION
Like I know everyone wants to be careful with corona and whatnot, but i think we only need to sanitize this string once.

(the ` TimelineModel::displayName` function already sanitizes its output, so we don't need to do it again here.  Caused a bug where users with certain characters would display wrong.  e.g. `Emi <3` would display as `Emi &lt;3 is typing...`)