### PR TITLE
Update Ubuntu 19.10 dependencies list

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ sudo apt-get install -y g++-7 qt59base qt59svg qt59tools qt59multimedia cmake li
 
 ```bash
 # Build requirements + qml modules needed at runtime (you may not need all of them, but the following seem to work according to reports):
-sudo apt install g++-7 cmake liblmdb-dev libsodium-dev qt{base,tools,multimedia}5-dev qml-module-qt{gstreamer,multimedia,quick-extras} libqt5svg5-dev qt{script,quickcontrols2-}5-dev
+sudo apt install g++-7 cmake liblmdb-dev libsodium-dev libssl-dev qt{base,declarative,tools,multimedia,script,quickcontrols2-}5-dev qml-module-qt{gstreamer,multimedia,quick-extras,-labs-settings} libqt5svg5-dev
 ```
 
 ##### Debian Buster (or higher probably)


### PR DESCRIPTION
Add some more dependencies that are definitely needed based on my testing:

- libssl-dev
- qtdeclarative5-dev
- qml-module-qt-labs-settings