### PR TITLE
Add visual indication that data is being fetched

### DIFF
--- a/resources/qml/TimelineView.qml
+++ b/resources/qml/TimelineView.qml
@@ -93,7 +93,7 @@ Page {
 
 		BusyIndicator {
 			anchors.centerIn: parent
-            running: timelineManager.isInitialSync || chat.model.paginationInProgress
+            running: timelineManager.isInitialSync
 			height: 200
 			width: 200
 			z: 3
@@ -251,6 +251,13 @@ Page {
 				}
 			}
 
+            footer:  BusyIndicator {
+                anchors.horizontalCenter: parent.horizontalCenter
+                running: chat.model && chat.model.paginationInProgress
+                height: 50
+                width: 50
+                z: 3
+            }
 		}
 
 		Rectangle {

--- a/resources/qml/TimelineView.qml
+++ b/resources/qml/TimelineView.qml
@@ -93,7 +93,7 @@ Page {
 
 		BusyIndicator {
 			anchors.centerIn: parent
-			running: timelineManager.isInitialSync
+            running: timelineManager.isInitialSync || chat.model.paginationInProgress
 			height: 200
 			width: 200
 			z: 3

--- a/src/timeline/TimelineModel.h
+++ b/src/timeline/TimelineModel.h
@@ -124,6 +124,7 @@ class TimelineModel : public QAbstractListModel
         Q_PROPERTY(std::vector<QString> typingUsers READ typingUsers WRITE updateTypingUsers NOTIFY
                      typingUsersChanged)
         Q_PROPERTY(QString reply READ reply WRITE setReply NOTIFY replyChanged RESET resetReply)
+        Q_PROPERTY(bool paginationInProgress READ paginationInProgress NOTIFY paginationInProgressChanged)
 
 public:
         explicit TimelineModel(TimelineViewManager *manager,
@@ -208,6 +209,7 @@ public slots:
                 }
         }
         std::vector<QString> typingUsers() const { return typingUsers_; }
+        bool paginationInProgress() const { return m_paginationInProgress; }
 
         QString reply() const { return reply_; }
         void setReply(QString newReply)
@@ -246,6 +248,7 @@ signals:
         void eventFetched(QString requestingEvent, mtx::events::collections::TimelineEvents event);
         void typingUsersChanged(std::vector<QString> users);
         void replyChanged(QString reply);
+        void paginationInProgressChanged(const bool);
 
 private:
         DecryptionResult decryptEvent(
@@ -261,6 +264,8 @@ private:
                                mtx::http::RequestErr err);
         void readEvent(const std::string &id);
 
+        void setPaginationInProgress(const bool paginationInProgress);
+
         QHash<QString, mtx::events::collections::TimelineEvents> events;
         QSet<QString> read;
         QList<QString> pending;
@@ -270,8 +275,8 @@ private:
         QString prev_batch_token_;
 
         bool isInitialSync        = true;
-        bool paginationInProgress = false;
         bool decryptDescription   = true;
+        bool m_paginationInProgress = false;
 
         QString currentId;
         QString reply_;

--- a/src/timeline/TimelineModel.h
+++ b/src/timeline/TimelineModel.h
@@ -124,7 +124,8 @@ class TimelineModel : public QAbstractListModel
         Q_PROPERTY(std::vector<QString> typingUsers READ typingUsers WRITE updateTypingUsers NOTIFY
                      typingUsersChanged)
         Q_PROPERTY(QString reply READ reply WRITE setReply NOTIFY replyChanged RESET resetReply)
-        Q_PROPERTY(bool paginationInProgress READ paginationInProgress NOTIFY paginationInProgressChanged)
+        Q_PROPERTY(
+          bool paginationInProgress READ paginationInProgress NOTIFY paginationInProgressChanged)
 
 public:
         explicit TimelineModel(TimelineViewManager *manager,
@@ -274,8 +275,8 @@ private:
         QString room_id_;
         QString prev_batch_token_;
 
-        bool isInitialSync        = true;
-        bool decryptDescription   = true;
+        bool isInitialSync          = true;
+        bool decryptDescription     = true;
         bool m_paginationInProgress = false;
 
         QString currentId;


### PR DESCRIPTION
This turns `paginationInProgress` field of `TimelineModel` into a `Q_PROPERTY`, so the Ui can bind to it.

For the moment, I'm showing the same spinner as we do during initial sync. It's not ideal, on the count of being giant and in the middle but it's better than nothing. We can make it more subtle later.