### PR TITLE
Implemented message background highlight feature as per issue #193

### DIFF
--- a/resources/qml/TimelineRow.qml
+++ b/resources/qml/TimelineRow.qml
@@ -13,6 +13,7 @@ MouseArea {
 	height: row.height
 	propagateComposedEvents: true
 	preventStealing: true
+	hoverEnabled: true
 
 	acceptedButtons: Qt.LeftButton | Qt.RightButton
 	onClicked: {
@@ -23,7 +24,10 @@ MouseArea {
 		if (mouse.source === Qt.MouseEventNotSynthesized)
 		messageContextMenu.show(model.id, model.type, model.isEncrypted, row)
 	}
-
+	Rectangle {
+		color: (timelineSettings.message_hover_highlight && parent.containsMouse) ? colors.base : "transparent"
+		anchors.fill: row
+	}
 	RowLayout {
 		id: row
 

--- a/resources/qml/TimelineView.qml
+++ b/resources/qml/TimelineView.qml
@@ -32,6 +32,7 @@ Page {
 		id: timelineSettings
 		category: "user/timeline"
 		property bool buttons: true
+		property bool message_hover_highlight: false
 	}
 
 	Menu {
@@ -97,6 +98,7 @@ Page {
 		}
 
 		BusyIndicator {
+			visible: running
 			anchors.centerIn: parent
             running: timelineManager.isInitialSync
 			height: 200

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -51,11 +51,13 @@ void
 UserSettings::load()
 {
         QSettings settings;
-        isTrayEnabled_                = settings.value("user/window/tray", false).toBool();
-        hasDesktopNotifications_      = settings.value("user/desktop_notifications", true).toBool();
-        isStartInTrayEnabled_         = settings.value("user/window/start_in_tray", false).toBool();
-        isGroupViewEnabled_           = settings.value("user/group_view", true).toBool();
-        isButtonsInTimelineEnabled_   = settings.value("user/timeline/buttons", true).toBool();
+        isTrayEnabled_              = settings.value("user/window/tray", false).toBool();
+        hasDesktopNotifications_    = settings.value("user/desktop_notifications", true).toBool();
+        isStartInTrayEnabled_       = settings.value("user/window/start_in_tray", false).toBool();
+        isGroupViewEnabled_         = settings.value("user/group_view", true).toBool();
+        isButtonsInTimelineEnabled_ = settings.value("user/timeline/buttons", true).toBool();
+        isMessageHoverHighlightEnabled_ =
+          settings.value("user/timeline/message_hover_highlight", false).toBool();
         isMarkdownEnabled_            = settings.value("user/markdown_enabled", true).toBool();
         isTypingNotificationsEnabled_ = settings.value("user/typing_notifications", true).toBool();
         sortByImportance_             = settings.value("user/sort_by_unread", true).toBool();
@@ -165,6 +167,7 @@ UserSettings::save()
 
         settings.beginGroup("timeline");
         settings.setValue("buttons", isButtonsInTimelineEnabled_);
+        settings.setValue("message_hover_highlight", isMessageHoverHighlightEnabled_);
         settings.endGroup();
 
         settings.setValue("avatar_circles", avatarCircles_);
@@ -235,6 +238,7 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         groupViewToggle_         = new Toggle{this};
         timelineButtonsToggle_   = new Toggle{this};
         typingNotifications_     = new Toggle{this};
+        messageHoverHighlight_   = new Toggle{this};
         sortByImportance_        = new Toggle{this};
         readReceipts_            = new Toggle{this};
         markdownEnabled_         = new Toggle{this};
@@ -345,6 +349,7 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         boxWrap(tr("Read receipts"), readReceipts_);
         boxWrap(tr("Send messages as Markdown"), markdownEnabled_);
         boxWrap(tr("Desktop notifications"), desktopNotifications_);
+        boxWrap(tr("Highlight message on hover"), messageHoverHighlight_);
         formLayout_->addRow(uiLabel_);
         formLayout_->addRow(new HorizontalLine{this});
 
@@ -463,6 +468,10 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
                 settings_->setDesktopNotifications(!isDisabled);
         });
 
+        connect(messageHoverHighlight_, &Toggle::toggled, this, [this](bool isDisabled) {
+                settings_->setMessageHoverHighlight(!isDisabled);
+        });
+
         connect(
           sessionKeysImportBtn, &QPushButton::clicked, this, &UserSettingsPage::importSessionKeys);
 
@@ -495,6 +504,7 @@ UserSettingsPage::showEvent(QShowEvent *)
         readReceipts_->setState(!settings_->isReadReceiptsEnabled());
         markdownEnabled_->setState(!settings_->isMarkdownEnabled());
         desktopNotifications_->setState(!settings_->hasDesktopNotifications());
+        messageHoverHighlight_->setState(!settings_->isMessageHoverHighlightEnabled());
         deviceIdValue_->setText(QString::fromStdString(http::client()->device_id()));
 
         deviceFingerprintValue_->setText(

--- a/src/UserSettingsPage.h
+++ b/src/UserSettingsPage.h
@@ -44,6 +44,11 @@ public:
         void load();
         void applyTheme();
         void setTheme(QString theme);
+        void setMessageHoverHighlight(bool state)
+        {
+                isMessageHoverHighlightEnabled_ = state;
+                save();
+        }
         void setTray(bool state)
         {
                 isTrayEnabled_ = state;
@@ -118,6 +123,7 @@ public:
         }
 
         QString theme() const { return !theme_.isEmpty() ? theme_ : defaultTheme_; }
+        bool isMessageHoverHighlightEnabled() const { return isMessageHoverHighlightEnabled_; }
         bool isTrayEnabled() const { return isTrayEnabled_; }
         bool isStartInTrayEnabled() const { return isStartInTrayEnabled_; }
         bool isGroupViewEnabled() const { return isGroupViewEnabled_; }
@@ -144,6 +150,7 @@ private:
             ? "light"
             : "system";
         QString theme_;
+        bool isMessageHoverHighlightEnabled_;
         bool isTrayEnabled_;
         bool isStartInTrayEnabled_;
         bool isGroupViewEnabled_;
@@ -203,6 +210,7 @@ private:
         Toggle *groupViewToggle_;
         Toggle *timelineButtonsToggle_;
         Toggle *typingNotifications_;
+        Toggle *messageHoverHighlight_;
         Toggle *sortByImportance_;
         Toggle *readReceipts_;
         Toggle *markdownEnabled_;


### PR DESCRIPTION
issue #193 
Some options (this new one included) have a bug, where if it's disabled during app startup, when you first try to toggle the option on, it goes from off to off. Works normally after. this kind of thing doesn't happen if during startup, the option was enabled. At least mine and "start in tray" option have this bug.