### PR TITLE
Add setting to alert on notification

### DIFF
--- a/src/ChatPage.h
+++ b/src/ChatPage.h
@@ -206,7 +206,7 @@ private:
                                          uint16_t notification_count,
                                          uint16_t highlight_count);
         //! Send desktop notification for the received messages.
-        void sendDesktopNotifications(const mtx::responses::Notifications &);
+        void sendNotifications(const mtx::responses::Notifications &);
 
         void showNotificationsDialog(const QPoint &point);
 

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -54,6 +54,7 @@ UserSettings::load()
         QSettings settings;
         tray_                    = settings.value("user/window/tray", false).toBool();
         hasDesktopNotifications_ = settings.value("user/desktop_notifications", true).toBool();
+        hasAlertOnNotification_  = settings.value("user/alert_on_notification", false).toBool();
         startInTray_             = settings.value("user/window/start_in_tray", false).toBool();
         groupView_               = settings.value("user/group_view", true).toBool();
         buttonsInTimeline_       = settings.value("user/timeline/buttons", true).toBool();
@@ -190,6 +191,16 @@ UserSettings::setDesktopNotifications(bool state)
                 return;
         hasDesktopNotifications_ = state;
         emit desktopNotificationsChanged(state);
+        save();
+}
+
+void
+UserSettings::setAlertOnNotification(bool state)
+{
+        if (state == hasAlertOnNotification_)
+                return;
+        hasAlertOnNotification_ = state;
+        emit alertOnNotificationChanged(state);
         save();
 }
 
@@ -334,6 +345,7 @@ UserSettings::save()
         settings.setValue("group_view", groupView_);
         settings.setValue("markdown_enabled", markdown_);
         settings.setValue("desktop_notifications", hasDesktopNotifications_);
+        settings.setValue("alert_on_notification", hasAlertOnNotification_);
         settings.setValue("theme", theme());
         settings.setValue("font_family", font_);
         settings.setValue("emoji_font_family", emojiFont_);
@@ -401,6 +413,7 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         readReceipts_             = new Toggle{this};
         markdown_                 = new Toggle{this};
         desktopNotifications_     = new Toggle{this};
+        alertOnNotification_      = new Toggle{this};
         scaleFactorCombo_         = new QComboBox{this};
         fontSizeCombo_            = new QComboBox{this};
         fontSelectionCombo_       = new QComboBox{this};
@@ -554,6 +567,10 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         boxWrap(tr("Desktop notifications"),
                 desktopNotifications_,
                 tr("Notify about received message when the client is not currently focused."));
+        boxWrap(tr("Alert on notification"),
+                alertOnNotification_,
+                tr("Show an alert when a message is received.\nThis usually causes the application "
+                   "icon in the task bar to animate in some fashion."));
         boxWrap(tr("Highlight message on hover"),
                 messageHoverHighlight_,
                 tr("Change the background color of messages when you hover over them."));
@@ -680,6 +697,10 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
                 settings_->setDesktopNotifications(!disabled);
         });
 
+        connect(alertOnNotification_, &Toggle::toggled, this, [this](bool disabled) {
+                settings_->setAlertOnNotification(!disabled);
+        });
+
         connect(messageHoverHighlight_, &Toggle::toggled, this, [this](bool disabled) {
                 settings_->setMessageHoverHighlight(!disabled);
         });
@@ -725,6 +746,7 @@ UserSettingsPage::showEvent(QShowEvent *)
         readReceipts_->setState(!settings_->readReceipts());
         markdown_->setState(!settings_->markdown());
         desktopNotifications_->setState(!settings_->hasDesktopNotifications());
+        alertOnNotification_->setState(!settings_->hasAlertOnNotification());
         messageHoverHighlight_->setState(!settings_->messageHoverHighlight());
         enlargeEmojiOnlyMessages_->setState(!settings_->enlargeEmojiOnlyMessages());
         deviceIdValue_->setText(QString::fromStdString(http::client()->device_id()));

--- a/src/UserSettingsPage.h
+++ b/src/UserSettingsPage.h
@@ -58,6 +58,8 @@ class UserSettings : public QObject
           bool readReceipts READ readReceipts WRITE setReadReceipts NOTIFY readReceiptsChanged)
         Q_PROPERTY(bool desktopNotifications READ hasDesktopNotifications WRITE
                      setDesktopNotifications NOTIFY desktopNotificationsChanged)
+        Q_PROPERTY(bool alertOnNotification READ hasAlertOnNotification WRITE setAlertOnNotification
+                     NOTIFY alertOnNotificationChanged)
         Q_PROPERTY(
           bool avatarCircles READ avatarCircles WRITE setAvatarCircles NOTIFY avatarCirclesChanged)
         Q_PROPERTY(bool decryptSidebar READ decryptSidebar WRITE setDecryptSidebar NOTIFY
@@ -91,6 +93,7 @@ public:
         void setButtonsInTimeline(bool state);
         void setTimelineMaxWidth(int state);
         void setDesktopNotifications(bool state);
+        void setAlertOnNotification(bool state);
         void setAvatarCircles(bool state);
         void setDecryptSidebar(bool state);
 
@@ -108,6 +111,11 @@ public:
         bool buttonsInTimeline() const { return buttonsInTimeline_; }
         bool readReceipts() const { return readReceipts_; }
         bool hasDesktopNotifications() const { return hasDesktopNotifications_; }
+        bool hasAlertOnNotification() const { return hasAlertOnNotification_; }
+        bool hasNotifications() const
+        {
+                return hasDesktopNotifications() || hasAlertOnNotification();
+        }
         int timelineMaxWidth() const { return timelineMaxWidth_; }
         double fontSize() const { return baseFontSize_; }
         QString font() const { return font_; }
@@ -126,6 +134,7 @@ signals:
         void buttonInTimelineChanged(bool state);
         void readReceiptsChanged(bool state);
         void desktopNotificationsChanged(bool state);
+        void alertOnNotificationChanged(bool state);
         void avatarCirclesChanged(bool state);
         void decryptSidebarChanged(bool state);
         void timelineMaxWidthChanged(int state);
@@ -151,6 +160,7 @@ private:
         bool buttonsInTimeline_;
         bool readReceipts_;
         bool hasDesktopNotifications_;
+        bool hasAlertOnNotification_;
         bool avatarCircles_;
         bool decryptSidebar_;
         int timelineMaxWidth_;
@@ -208,6 +218,7 @@ private:
         Toggle *readReceipts_;
         Toggle *markdown_;
         Toggle *desktopNotifications_;
+        Toggle *alertOnNotification_;
         Toggle *avatarCircles_;
         Toggle *decryptSidebar_;
         QLabel *deviceFingerprintValue_;


### PR DESCRIPTION
The settings defaults to "off", so by default nothing changes for existing users.

[QApplication::alert](https://doc.qt.io/qt-5/qapplication.html#alert):
> Causes an alert to be shown for widget if the window is not the active window. The alert is shown for msec miliseconds. If msec is zero (the default), then the alert is shown indefinitely until the window becomes active again.
> 
> Currently this function does nothing on Qt for Embedded Linux.
> 
> On macOS, this works more at the application level and will cause the application icon to bounce in the dock.
> 
> On Windows, this causes the window's taskbar entry to flash for a time. If msec is zero, the flashing will stop and the taskbar entry will turn a different color (currently orange).
> 
> On X11, this will cause the window to be marked as "demands attention", the window must not be hidden (i.e. not have hide() called on it, but be visible in some sort of way) in order for this to work.