### PR TITLE
WIP: Smooth all the things

### DIFF
--- a/resources/qml/Avatar.qml
+++ b/resources/qml/Avatar.qml
@@ -29,7 +29,7 @@ Rectangle {
 		asynchronous: true
 		fillMode: Image.PreserveAspectCrop
 		mipmap: true
-		smooth: false
+		smooth: true
 
 		sourceSize.width: avatar.width
 		sourceSize.height: avatar.height

--- a/resources/qml/delegates/ImageMessage.qml
+++ b/resources/qml/delegates/ImageMessage.qml
@@ -32,6 +32,8 @@ Item {
 		source: model.data.url.replace("mxc://", "image://MxcImage/")
 		asynchronous: true
 		fillMode: Image.PreserveAspectFit
+		smooth: true
+		mipmap: true
 
 		MouseArea {
 			enabled: model.data.type == MtxEvent.ImageMessage && img.status == Image.Ready

--- a/src/ui/Avatar.cpp
+++ b/src/ui/Avatar.cpp
@@ -122,6 +122,7 @@ Avatar::paintEvent(QPaintEvent *)
 
         QPainter painter(this);
         painter.setRenderHint(QPainter::Antialiasing);
+        painter.setRenderHint(QPainter::SmoothPixmapTransform);
 
         QRectF r     = rect();
         const int hs = size_ / 2;


### PR DESCRIPTION
Use bilinear interpolation for avatars and images in the timeline.

I'm still looking at smoothing the following:
* Room avatars (including ctrl+k)
* Communities avatars
* Pixellated avatars on profile views.

So there's probably another PR coming up shortly for these, though I have to dig a bit more into the code to find these (if you have a hint, I'm all ears, I've started to understand the caching and fetching mechanism, but the display one still eludes me a bit). I've had this itch for quite some time, but couldn't get to compile nheko. Might have been an LC issue?

## Before
![partial_2020-08-21-210656_grim](https://user-images.githubusercontent.com/3952726/90942423-0e62f080-e416-11ea-9fca-a3a487d4b096.png)
(look at user avatars)

![partial_2020-08-21-211422_grim](https://user-images.githubusercontent.com/3952726/90942449-22a6ed80-e416-11ea-825f-67fb095f91d2.png)
(my avatar is already using bilinear interpolation on the second screenshot, look at the picture)

## After
![partial_2020-08-21-210817_grim](https://user-images.githubusercontent.com/3952726/90942489-52ee8c00-e416-11ea-8beb-06d843f2386e.png)
![partial_2020-08-21-214547_grim](https://user-images.githubusercontent.com/3952726/90942533-7addef80-e416-11ea-9dda-781acef5572b.png)

