### PR TITLE
Adapt device monitoring for GStreamer 1.18

### DIFF
--- a/src/WebRTCSession.cpp
+++ b/src/WebRTCSession.cpp
@@ -21,7 +21,7 @@ WebRTCSession::WebRTCSession()
 {
         qRegisterMetaType<WebRTCSession::State>();
         connect(this, &WebRTCSession::stateChanged, this, &WebRTCSession::setState);
-#if GST_CHECK_VERSION(1, 18, 0)
+#if defined (GSTREAMER_AVAILABLE) && GST_CHECK_VERSION(1, 18, 0)
         init();
 #endif
 }

--- a/src/WebRTCSession.cpp
+++ b/src/WebRTCSession.cpp
@@ -21,9 +21,7 @@ WebRTCSession::WebRTCSession()
 {
         qRegisterMetaType<WebRTCSession::State>();
         connect(this, &WebRTCSession::stateChanged, this, &WebRTCSession::setState);
-#if defined(GSTREAMER_AVAILABLE) && GST_CHECK_VERSION(1, 18, 0)
         init();
-#endif
 }
 
 bool

--- a/src/WebRTCSession.cpp
+++ b/src/WebRTCSession.cpp
@@ -21,7 +21,7 @@ WebRTCSession::WebRTCSession()
 {
         qRegisterMetaType<WebRTCSession::State>();
         connect(this, &WebRTCSession::stateChanged, this, &WebRTCSession::setState);
-#if defined (GSTREAMER_AVAILABLE) && GST_CHECK_VERSION(1, 18, 0)
+#if defined(GSTREAMER_AVAILABLE) && GST_CHECK_VERSION(1, 18, 0)
         init();
 #endif
 }

--- a/src/WebRTCSession.h
+++ b/src/WebRTCSession.h
@@ -7,7 +7,6 @@
 
 #include "mtx/events/voip.hpp"
 
-typedef struct _GList GList;
 typedef struct _GstElement GstElement;
 
 class WebRTCSession : public QObject
@@ -71,12 +70,12 @@ private:
         unsigned int busWatchId_ = 0;
         std::string stunServer_;
         std::vector<std::string> turnServers_;
-        GList *audioSources_  = nullptr;
         int audioSourceIndex_ = -1;
 
         bool startPipeline(int opusPayloadType);
         bool createPipeline(int opusPayloadType);
         void refreshDevices();
+        void startDeviceMonitor();
 
 public:
         WebRTCSession(WebRTCSession const &) = delete;


### PR DESCRIPTION
GStreamer 1.18 fixes device discovery so that a call to gst_device_monitor_get_devices is unnecessary. In fact in 1.18 that call produces some additional unwanted results on first invocation. Keeping 1.16 unchanged though since get_devices works well there and I'm not getting device-removed bus messages under 1.16. At least on my machine.