### PR TITLE
Add option for unique config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Specifically there is support for:
 - Basic communities support.
 - Room switcher (ctrl-K).
 - Light, Dark & System themes.
+- Creating separate profiles (command line only, use `--profile=name`).
 
 ## Installation
 

--- a/src/ChatPage.cpp
+++ b/src/ChatPage.cpp
@@ -272,7 +272,7 @@ ChatPage::ChatPage(QSharedPointer<UserSettings> userSettings, QWidget *parent)
         connect(room_list_,
                 SIGNAL(totalUnreadMessageCountUpdated(int)),
                 this,
-                SLOT(showUnreadMessageNotification(int)));
+                SIGNAL(unreadMessages(int)));
 
         connect(text_input_,
                 &TextInputWidget::sendTextMessage,
@@ -626,7 +626,7 @@ ChatPage::resetUI()
         user_info_widget_->reset();
         view_manager_->clearAll();
 
-        showUnreadMessageNotification(0);
+        emit unreadMessages(0);
 }
 
 void
@@ -749,18 +749,6 @@ ChatPage::bootstrap(QString userid, QString homeserver, QString token)
 
         getProfileInfo();
         tryInitialSync();
-}
-
-void
-ChatPage::showUnreadMessageNotification(int count)
-{
-        emit unreadMessages(count);
-
-        // TODO: Make the default title a const.
-        if (count == 0)
-                emit changeWindowTitle("nheko");
-        else
-                emit changeWindowTitle(QString("nheko (%1)").arg(count));
 }
 
 void

--- a/src/ChatPage.h
+++ b/src/ChatPage.h
@@ -130,7 +130,7 @@ signals:
 
         void contentLoaded();
         void closing();
-        void changeWindowTitle(const QString &msg);
+        void changeWindowTitle(const int);
         void unreadMessages(int count);
         void showNotification(const QString &msg);
         void showLoginPage(const QString &msg);
@@ -188,7 +188,6 @@ signals:
         void receivedDeviceVerificationDone(const mtx::events::msg::KeyVerificationDone &message);
 
 private slots:
-        void showUnreadMessageNotification(int count);
         void logout();
         void removeRoom(const QString &room_id);
         void dropToLoginPage(const QString &msg);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -53,10 +53,11 @@
 
 MainWindow *MainWindow::instance_ = nullptr;
 
-MainWindow::MainWindow(QWidget *parent)
-  : QMainWindow(parent)
+MainWindow::MainWindow(const QString profile, QWidget *parent)
+  : QMainWindow(parent),
+    profile_{ profile }
 {
-        setWindowTitle("nheko");
+        setWindowTitle(0);
         setObjectName("MainWindow");
 
         modal_ = new OverlayModal(this);
@@ -104,7 +105,7 @@ MainWindow::MainWindow(QWidget *parent)
         connect(
           chat_page_, &ChatPage::showOverlayProgressBar, this, &MainWindow::showOverlayProgressBar);
         connect(
-          chat_page_, SIGNAL(changeWindowTitle(QString)), this, SLOT(setWindowTitle(QString)));
+          chat_page_, &ChatPage::unreadMessages, this, &MainWindow::setWindowTitle);
         connect(chat_page_, SIGNAL(unreadMessages(int)), trayIcon_, SLOT(setUnreadCount(int)));
         connect(chat_page_, &ChatPage::showLoginPage, this, [this](const QString &msg) {
                 login_page_->loginError(msg);
@@ -176,6 +177,19 @@ MainWindow::MainWindow(QWidget *parent)
         if (loadJdenticonPlugin()) {
                 nhlog::ui()->info("loaded jdenticon.");
         }
+}
+
+void
+MainWindow::setWindowTitle(int notificationCount)
+{
+        QString name = "nheko";
+        if (!profile_.isEmpty())
+                name += " | " + profile_;
+        if (notificationCount > 0)
+        {
+                name.append(QString{" (%1)"}.arg(notificationCount));
+        }
+        QMainWindow::setWindowTitle(name);
 }
 
 void

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -62,7 +62,7 @@ class MainWindow : public QMainWindow
         Q_OBJECT
 
 public:
-        explicit MainWindow(QWidget *parent = nullptr);
+        explicit MainWindow(const QString name, QWidget *parent = nullptr);
 
         static MainWindow *instance() { return instance_; };
         void saveCurrentWindowSize();
@@ -113,6 +113,8 @@ private slots:
         void showOverlayProgressBar();
         void removeOverlayProgressBar();
 
+        virtual void setWindowTitle(int notificationCount);
+
 private:
         bool loadJdenticonPlugin();
 
@@ -147,4 +149,6 @@ private:
         LoadingIndicator *spinner_ = nullptr;
 
         JdenticonInterface *jdenticonInteface_ = nullptr;
+
+        QString profile_;
 };

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -36,6 +36,7 @@
 #include <QString>
 #include <QTextStream>
 #include <QtQml>
+#include <QCoreApplication>
 
 #include "Cache.h"
 #include "Config.h"
@@ -433,6 +434,8 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         font.setPointSizeF(font.pointSizeF() * 1.1);
 
         auto versionInfo = new QLabel(QString("%1 | %2").arg(nheko::version).arg(nheko::build_os));
+        if (QCoreApplication::applicationName() != "nheko")
+                versionInfo->setText(versionInfo->text() + " | " + tr("profile: %1").arg(QCoreApplication::applicationName()));
         versionInfo->setTextInteractionFlags(Qt::TextBrowserInteraction);
 
         topBarLayout_ = new QHBoxLayout;


### PR DESCRIPTION
When you pass the `--config=name` option, the internal application name will be set to the value of `name`. Other valid forms are `-c=name`, `--config name`, and `-c name`.