### PR TITLE
Delete text on Ctrl-U

### DIFF
--- a/src/TextInputWidget.cpp
+++ b/src/TextInputWidget.cpp
@@ -165,6 +165,9 @@ FilteredTextEdit::keyPressEvent(QKeyEvent *event)
                 MacHelper::showEmojiWindow();
 #endif
 
+        if (event->modifiers() == Qt::ControlModifier && event->key() == Qt::Key_U)
+                QTextEdit::setText("");
+
         if (!isModifier) {
                 if (!typingTimer_->isActive())
                         emit startedTyping();


### PR DESCRIPTION
For those who like the terminal shortcut of Ctrl-U, nheko now supports it as well.

N.B. various shells implement ^U differently. Bash will delete all characters before cursor, while Zsh deletes all typed characters. For simplicity, nheko deletes all typed text.