### PR TITLE
Improve wording in multiple strings.

### DIFF
--- a/resources/qml/device-verification/Waiting.qml
+++ b/resources/qml/device-verification/Waiting.qml
@@ -21,9 +21,9 @@ Pane {
                 case "WaitingForOtherToAccept":
                     return qsTr("Waiting for other side to accept the verification request.");
                 case "WaitingForKeys":
-                    return qsTr("Waiting for other side to continue the verification request.");
+                    return qsTr("Waiting for other side to continue the verification process.");
                 case "WaitingForMac":
-                    return qsTr("Waiting for other side to complete the verification request.");
+                    return qsTr("Waiting for other side to complete the verification process.");
                 }
             }
             color: colors.text

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -655,9 +655,9 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         formLayout_->addRow(uiLabel_);
         formLayout_->addRow(new HorizontalLine{this});
 
-        boxWrap(tr("Mobile mode"),
+        boxWrap(tr("Touchscreen mode"),
                 mobileMode_,
-                tr("Will prevent text selection in the timeline to make scrolling easier."));
+                tr("Will prevent text selection in the timeline to make touch scrolling easier."));
 #if !defined(Q_OS_MAC)
         boxWrap(tr("Scale factor"),
                 scaleFactorCombo_,

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -687,7 +687,7 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         boxWrap(tr("Device ID"), deviceIdValue_);
         boxWrap(tr("Device Fingerprint"), deviceFingerprintValue_);
         boxWrap(
-          tr("Share keys with trusted users"),
+          tr("Share keys with verified users and devices"),
           shareKeysWithTrustedUsers_,
           tr("Automatically replies to key requests from other users, if they are verified."));
         formLayout_->addRow(new HorizontalLine{this});

--- a/src/timeline/TimelineViewManager.cpp
+++ b/src/timeline/TimelineViewManager.cpp
@@ -407,8 +407,8 @@ TimelineViewManager::verifyUser(QString userid)
         }
 
         emit ChatPage::instance()->showNotification(
-          tr("No share room with this user found. Create an "
-             "encrypted room with this user and try again."));
+          tr("No encrypted private chat found with this user. Create an "
+             "encrypted private chat with this user and try again."));
 }
 
 void


### PR DESCRIPTION
As I was translating the new strings, I wondered a few things as usual, and also spotted a few opportunities for improving the original text.

Not every modification might be worth keeping, but this is probably better than weblate for reviewing.

I feel like I should have done this as well for the 400 other strings. If you prefer this format, I can keep this up.

One thing I slightly dislike: I didn't update the setting keys to reflect the updated wording ("mobile mode" for instance).