### PR TITLE
Allow sending text after `shrug`

### DIFF
--- a/src/TextInputWidget.cpp
+++ b/src/TextInputWidget.cpp
@@ -703,7 +703,7 @@ TextInputWidget::command(QString command, QString args)
         } else if (command == "roomnick") {
                 emit changeRoomNick(args);
         } else if (command == "shrug") {
-                emit sendTextMessage("¯\\_(ツ)_/¯");
+                emit sendTextMessage("¯\\_(ツ)_/¯" + (args.isEmpty() ? "" : " " + args));
         } else if (command == "fliptable") {
                 emit sendTextMessage("(╯°□°)╯︵ ┻━┻");
         } else if (command == "unfliptable") {


### PR DESCRIPTION
¯\\_(ツ)_/¯ IDK, I like to write something after, sometimes

Allow sending:

`¯\_(ツ)_/¯ some text`

By entering:

`/shrug some text`

It's supported in Element. If you did it in nheko, you just used to lose the extra text.

Not putting text is still supported, a ternary operator makes sure a space is only inserted if the text isn't empty, to avoid having a trailing space.

![partial_2020-10-31-230431_grim](https://user-images.githubusercontent.com/3952726/97791047-898f1280-1bce-11eb-8a5d-5fcb0431517f.png)

Sorry for the force-push, I changed some wording in the commit message, then I added spaces around operators...