### PR TITLE
Smooth all the things [v2]

### DIFF
--- a/resources/qml/Avatar.qml
+++ b/resources/qml/Avatar.qml
@@ -33,7 +33,7 @@ Rectangle {
         asynchronous: true
         fillMode: Image.PreserveAspectCrop
         mipmap: true
-        smooth: false
+        smooth: true
         sourceSize.width: avatar.width
         sourceSize.height: avatar.height
         layer.enabled: true

--- a/resources/qml/delegates/ImageMessage.qml
+++ b/resources/qml/delegates/ImageMessage.qml
@@ -29,6 +29,8 @@ Item {
         source: model.data.url.replace("mxc://", "image://MxcImage/")
         asynchronous: true
         fillMode: Image.PreserveAspectFit
+        smooth: true
+        mipmap: true
 
         MouseArea {
             id: mouseArea

--- a/src/ui/Avatar.cpp
+++ b/src/ui/Avatar.cpp
@@ -121,7 +121,9 @@ Avatar::paintEvent(QPaintEvent *)
         bool rounded = QSettings().value("user/avatar_circles", true).toBool();
 
         QPainter painter(this);
-        painter.setRenderHint(QPainter::Antialiasing);
+
+        painter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform |
+                               QPainter::TextAntialiasing);
 
         QRectF r     = rect();
         const int hs = size_ / 2;

--- a/src/ui/Painter.h
+++ b/src/ui/Painter.h
@@ -139,18 +139,10 @@ public:
         PainterHighQualityEnabler(Painter &p)
           : _painter(p)
         {
-                static constexpr QPainter::RenderHint Hints[] = {QPainter::Antialiasing,
-                                                                 QPainter::SmoothPixmapTransform,
-                                                                 QPainter::TextAntialiasing};
+                hints_ = QPainter::Antialiasing | QPainter::SmoothPixmapTransform |
+                         QPainter::TextAntialiasing;
 
-                auto hints = _painter.renderHints();
-                for (const auto &hint : Hints) {
-                        if (!(hints & hint))
-                                hints_ |= hint;
-                }
-
-                if (hints_)
-                        _painter.setRenderHints(hints_);
+                _painter.setRenderHints(hints_);
         }
 
         ~PainterHighQualityEnabler()


### PR DESCRIPTION
Rebased on master, second take on #261

Use bilinear interpolation for avatars and images in the timeline.

This corrects the following pictures:
* Room avatars
  * Room header
  * ctrl-k room switcher
  * room info
* Communities avatars
* User avatars
  * timeline
  * profile views (still blurry due to the synapse bug)
* Timeline pictures

**Remaining work:**
* I really can't find what affects rendering for room avatars in the room list. It also uses Avatars.cpp

## Before
![partial_2020-08-21-210656_grim](https://user-images.githubusercontent.com/3952726/90942423-0e62f080-e416-11ea-9fca-a3a487d4b096.png)
(look at user avatars)

![partial_2020-08-21-211422_grim](https://user-images.githubusercontent.com/3952726/90942449-22a6ed80-e416-11ea-825f-67fb095f91d2.png)
(my avatar is already using bilinear interpolation on the second screenshot, look at the picture)

## After
![partial_2020-08-21-210817_grim](https://user-images.githubusercontent.com/3952726/90942489-52ee8c00-e416-11ea-8beb-06d843f2386e.png)
![partial_2020-08-21-214547_grim](https://user-images.githubusercontent.com/3952726/90942533-7addef80-e416-11ea-9dda-781acef5572b.png)

