### PR TITLE
Mitigate webrtc race condition

### DIFF
--- a/src/WebRTCSession.cpp
+++ b/src/WebRTCSession.cpp
@@ -2,10 +2,12 @@
 #include <QQuickItem>
 #include <algorithm>
 #include <cctype>
+#include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <optional>
 #include <string_view>
+#include <thread>
 #include <utility>
 
 #include "ChatPage.h"
@@ -854,6 +856,9 @@ WebRTCSession::acceptOffer(const std::string &sdp)
                 gst_webrtc_session_description_free(offer);
                 return false;
         }
+
+        // avoid a race that sometimes leaves the generated answer without media tracks (a=ssrc lines)
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
         // set-remote-description first, then create-answer
         GstPromise *promise = gst_promise_new_with_change_func(createAnswer, webrtc_, nullptr);


### PR DESCRIPTION
Sometimes this happens: Alice (any client) calls Bob (Nheko). The call connects but Alice is unable to hear Bob (although Bob can hear Alice). This occurs because the media track (a=ssrc line) is missing from Nheko's answer sdp. Looks like a race in webrtcbin where the code to add the media track can execute after the sdp has already been set. Will look at it further to confirm and raise it with GStreamer. In the meantime this mitigation has worked every time for me so far.