### PR TITLE
Full-size view for image avatars

### DIFF
--- a/resources/qml/Avatar.qml
+++ b/resources/qml/Avatar.qml
@@ -9,6 +9,8 @@ Rectangle {
     property alias url: img.source
     property string userid
     property string displayName
+ 
+    property string usrUrl: TimelineManager.timeline.avatarUrl(userid)
 
     width: 48
     height: 48
@@ -49,6 +51,14 @@ Rectangle {
 
         }
 
+        MouseArea {
+            id: mouseArea
+
+            anchors.fill: parent
+            onClicked: {
+                TimelineManager.openImageOverlay(usrUrl, TimelineManager.timeline.data.id)
+            }
+        }
     }
 
     Rectangle {

--- a/src/timeline/TimelineViewManager.cpp
+++ b/src/timeline/TimelineViewManager.cpp
@@ -339,6 +339,7 @@ TimelineViewManager::toggleCameraView()
 void
 TimelineViewManager::openImageOverlay(QString mxcUrl, QString eventId) const
 {
+        if (mxcUrl.isEmpty() || mxcUrl.isNull()) { return; }
         QQuickImageResponse *imgResponse =
           imgProvider->requestImageResponse(mxcUrl.remove("mxc://"), QSize());
         connect(imgResponse, &QQuickImageResponse::finished, this, [this, eventId, imgResponse]() {


### PR DESCRIPTION
- View enlarged version of avatars (images)
- TO-DO: add support for GIF avatars. GIFs should probably appear as static images in the Timeline, but users should be able to see the animated GIF upon clicking on the Avatar from the User info bar. (Does this sound correct @deepbluev7 ?)