### PR TITLE
Add support for viewing avatar images in full size

### DIFF
--- a/resources/qml/Avatar.qml
+++ b/resources/qml/Avatar.qml
@@ -55,9 +55,7 @@ Rectangle {
             id: mouseArea
 
             anchors.fill: parent
-            onClicked: {
-                TimelineManager.openImageOverlay(usrUrl, TimelineManager.timeline.data.id)
-            }
+            onClicked: TimelineManager.openImageOverlay(TimelineManager.timeline.avatarUrl(userid), TimelineManager.timeline.data.id)
         }
     }
 

--- a/resources/qml/Avatar.qml
+++ b/resources/qml/Avatar.qml
@@ -9,8 +9,6 @@ Rectangle {
     property alias url: img.source
     property string userid
     property string displayName
- 
-    property string usrUrl: TimelineManager.timeline.avatarUrl(userid)
 
     width: 48
     height: 48

--- a/resources/qml/Avatar.qml
+++ b/resources/qml/Avatar.qml
@@ -9,6 +9,8 @@ Rectangle {
     property alias url: img.source
     property string userid
     property string displayName
+ 
+    property string usrUrl: TimelineManager.timeline.avatarUrl(userid)
 
     width: 48
     height: 48
@@ -49,6 +51,14 @@ Rectangle {
 
         }
 
+        MouseArea {
+            id: mouseArea
+
+            anchors.fill: parent
+            onClicked: {
+                TimelineManager.openImageOverlay(usrUrl, TimelineManager.timeline.data.id)
+            }
+        }
     }
 
     Rectangle {

--- a/src/timeline/TimelineViewManager.cpp
+++ b/src/timeline/TimelineViewManager.cpp
@@ -339,7 +339,9 @@ TimelineViewManager::toggleCameraView()
 void
 TimelineViewManager::openImageOverlay(QString mxcUrl, QString eventId) const
 {
-        if (mxcUrl.isEmpty() || mxcUrl.isNull()) { return; }
+        if (mxcUrl.isEmpty() || mxcUrl.isNull()) {
+                return;
+        }
         QQuickImageResponse *imgResponse =
           imgProvider->requestImageResponse(mxcUrl.remove("mxc://"), QSize());
         connect(imgResponse, &QQuickImageResponse::finished, this, [this, eventId, imgResponse]() {

--- a/src/timeline/TimelineViewManager.cpp
+++ b/src/timeline/TimelineViewManager.cpp
@@ -339,7 +339,7 @@ TimelineViewManager::toggleCameraView()
 void
 TimelineViewManager::openImageOverlay(QString mxcUrl, QString eventId) const
 {
-        if (mxcUrl.isEmpty() || mxcUrl.isNull()) {
+        if (mxcUrl.isEmpty()) {
                 return;
         }
         QQuickImageResponse *imgResponse =

--- a/src/timeline/TimelineViewManager.cpp
+++ b/src/timeline/TimelineViewManager.cpp
@@ -339,6 +339,7 @@ TimelineViewManager::toggleCameraView()
 void
 TimelineViewManager::openImageOverlay(QString mxcUrl, QString eventId) const
 {
+        if (mxcUrl.isEmpty() || mxcUrl.isNull()) { return; }
         QQuickImageResponse *imgResponse =
           imgProvider->requestImageResponse(mxcUrl.remove("mxc://"), QSize());
         connect(imgResponse, &QQuickImageResponse::finished, this, [this, eventId, imgResponse]() {


### PR DESCRIPTION
- Since GIFs are not really supported in Nheko due to [this bug](https://bugreports.qt.io/browse/QTBUG-30524), this currently only supports static images. 

This should resolve #241 