### PR TITLE
Use system icon where applicable

### DIFF
--- a/src/WelcomePage.cpp
+++ b/src/WelcomePage.cpp
@@ -37,8 +37,7 @@ WelcomePage::WelcomePage(QWidget *parent)
         QFont subTitleFont;
         subTitleFont.setPointSizeF(subTitleFont.pointSizeF() * 1.5);
 
-        QIcon icon;
-        icon.addFile(":/logos/splash.png");
+        QIcon icon{QIcon::fromTheme("nheko", QIcon{":/logos/splash.png"})};
 
         auto logo_ = new QLabel(this);
         logo_->setPixmap(icon.pixmap(256));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -174,7 +174,7 @@ main(int argc, char *argv[])
 
         parser.process(app);
 
-        app.setWindowIcon(QIcon(":/logos/nheko.png"));
+        app.setWindowIcon(QIcon::fromTheme("nheko", QIcon{":/logos/nheko.png"}));
 
         http::init();
 


### PR DESCRIPTION
It's always annoying to have an app not follow the system icon scheme, so I fixed it.

This works fine on my Linux system.