### PR TITLE
Update `brew` install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ guix install nheko
 with [homebrew](https://brew.sh/):
 
 ```sh
-brew cask install nheko
+brew install --cask nheko
 ```
 
 ### Build Requirements


### PR DESCRIPTION
Brew has moved away from using the `brew cask` command, so either `brew install nheko` or `brew install --cask nheko` should probably be reccomended instead.

They are trying to combine casks and formulas into the same commands, where you can specify `--formula` or `--cask` to get the old behavior.