### PR TITLE
Write database to the DataLocation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -93,9 +93,9 @@ screenCenter(int width, int height)
 }
 
 void
-createCacheDirectory()
+createStandardDirectory(QStandardPaths::StandardLocation path)
 {
-        auto dir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+        auto dir = QStandardPaths::writableLocation(path);
 
         if (!QDir().mkpath(dir)) {
                 throw std::runtime_error(
@@ -188,7 +188,8 @@ main(int argc, char *argv[])
 
         http::init();
 
-        createCacheDirectory();
+        createStandardDirectory(QStandardPaths::CacheLocation);
+        createStandardDirectory(QStandardPaths::AppDataLocation);
 
         registerSignalHandlers();
 


### PR DESCRIPTION
This should fix issue https://github.com/Nheko-Reborn/nheko/issues/226 (in a non-breaking way).

Note: I've built nheko with this patch and tested that

1. nheko builds and runs fine with the database in the new location
1. if there is an old directory it gets renamed and nheko works correctly
2. if the migration fails (when new location is read only) the error message is printed
