### PR TITLE
Fix emoji related issues

### DIFF
--- a/resources/qml/MessageInput.qml
+++ b/resources/qml/MessageInput.qml
@@ -270,6 +270,11 @@ Rectangle {
                     target: TimelineManager.timeline
                 }
 
+                Connections {
+                    target: TimelineManager
+                    onFocusInput: messageInput.forceActiveFocus()
+                }
+
                 MouseArea {
                     // workaround for wrong cursor shape on some platforms
                     anchors.fill: parent
@@ -297,6 +302,7 @@ Rectangle {
             ToolTip.text: qsTr("Emoji")
             onClicked: emojiPopup.visible ? emojiPopup.close() : emojiPopup.show(emojiButton, function(emoji) {
                 messageInput.insert(messageInput.cursorPosition, emoji);
+                TimelineManager.focusMessageInput()
             })
         }
 

--- a/resources/qml/MessageInput.qml
+++ b/resources/qml/MessageInput.qml
@@ -163,6 +163,10 @@ Rectangle {
                         TimelineManager.timeline.input.paste(false);
                         event.accepted = true;
                     } else if (event.key == Qt.Key_Space) {
+                        // close popup if user enters space after colon
+                        if(cursorPosition == completerTriggeredAt + 1)
+                            popup.close();
+
                         if (popup.opened && popup.count <= 0)
                             popup.close();
 

--- a/resources/qml/emoji/EmojiButton.qml
+++ b/resources/qml/emoji/EmojiButton.qml
@@ -14,5 +14,6 @@ ImageButton {
     image: ":/icons/icons/ui/smile.png"
     onClicked: emojiPicker.visible ? emojiPicker.close() : emojiPicker.show(emojiButton, function(emoji) {
         TimelineManager.queueReactionMessage(event_id, emoji);
+        TimelineManager.focusMessageInput()
     })
 }

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -725,6 +725,7 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         // TODO: Is there a way to limit to just emojis, rather than
         // all emoji fonts?
         auto emojiFamilies = fontDb.families(QFontDatabase::Symbol);
+        emojiFontSelectionCombo_->addItem(QString("default"));
         for (const auto &family : emojiFamilies) {
                 emojiFontSelectionCombo_->addItem(family);
         }

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -93,7 +93,7 @@ UserSettings::load(std::optional<QString> profile)
         sortByImportance_     = settings.value("user/sort_by_unread", true).toBool();
         readReceipts_         = settings.value("user/read_receipts", true).toBool();
         theme_                = settings.value("user/theme", defaultTheme_).toString();
-        font_                 = settings.value("user/font_family", tr("Default")).toString();
+        font_                 = settings.value("user/font_family", "").toString();
         avatarCircles_        = settings.value("user/avatar_circles", true).toBool();
         decryptSidebar_       = settings.value("user/decrypt_sidebar", true).toBool();
         privacyScreen_        = settings.value("user/privacy_screen", false).toBool();
@@ -101,7 +101,7 @@ UserSettings::load(std::optional<QString> profile)
         shareKeysWithTrustedUsers_ =
           settings.value("user/share_keys_with_trusted_users", true).toBool();
         mobileMode_        = settings.value("user/mobile_mode", false).toBool();
-        emojiFont_         = settings.value("user/emoji_font_family", tr("Default")).toString();
+        emojiFont_         = settings.value("user/emoji_font_family", "Default").toString();
         baseFontSize_      = settings.value("user/font_size", QFont().pointSizeF()).toDouble();
         auto tempPresence  = settings.value("user/presence", "").toString().toStdString();
         auto presenceValue = QMetaEnum::fromType<Presence>().keyToValue(tempPresence.c_str());
@@ -341,7 +341,13 @@ UserSettings::setEmojiFontFamily(QString family)
 {
         if (family == emojiFont_)
                 return;
-        emojiFont_ = family;
+
+        if (family == tr("Default")) {
+                emojiFont_ = "Default";
+        } else {
+                emojiFont_ = family;
+        }
+
         emit emojiFontChanged(family);
         save();
 }
@@ -730,7 +736,14 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
                 emojiFontSelectionCombo_->addItem(family);
         }
 
-        fontSelectionCombo_->setCurrentIndex(fontSelectionCombo_->findText(settings_->font()));
+        QString currentFont = settings_->font();
+        if (currentFont == "Default") {
+                fontSelectionCombo_->setCurrentIndex(
+                  fontSelectionCombo_->findText(tr(currentFont.toStdString().c_str())));
+        } else {
+                fontSelectionCombo_->setCurrentIndex(
+                  fontSelectionCombo_->findText(currentFont));
+        }
 
         emojiFontSelectionCombo_->setCurrentIndex(
           emojiFontSelectionCombo_->findText(settings_->emojiFont()));

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -93,7 +93,7 @@ UserSettings::load(std::optional<QString> profile)
         sortByImportance_     = settings.value("user/sort_by_unread", true).toBool();
         readReceipts_         = settings.value("user/read_receipts", true).toBool();
         theme_                = settings.value("user/theme", defaultTheme_).toString();
-        font_                 = settings.value("user/font_family", "default").toString();
+        font_                 = settings.value("user/font_family", tr("Default")).toString();
         avatarCircles_        = settings.value("user/avatar_circles", true).toBool();
         decryptSidebar_       = settings.value("user/decrypt_sidebar", true).toBool();
         privacyScreen_        = settings.value("user/privacy_screen", false).toBool();
@@ -101,7 +101,7 @@ UserSettings::load(std::optional<QString> profile)
         shareKeysWithTrustedUsers_ =
           settings.value("user/share_keys_with_trusted_users", true).toBool();
         mobileMode_        = settings.value("user/mobile_mode", false).toBool();
-        emojiFont_         = settings.value("user/emoji_font_family", "default").toString();
+        emojiFont_         = settings.value("user/emoji_font_family", tr("Default")).toString();
         baseFontSize_      = settings.value("user/font_size", QFont().pointSizeF()).toDouble();
         auto tempPresence  = settings.value("user/presence", "").toString().toStdString();
         auto presenceValue = QMetaEnum::fromType<Presence>().keyToValue(tempPresence.c_str());
@@ -725,7 +725,7 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
         // TODO: Is there a way to limit to just emojis, rather than
         // all emoji fonts?
         auto emojiFamilies = fontDb.families(QFontDatabase::Symbol);
-        emojiFontSelectionCombo_->addItem(QString("default"));
+        emojiFontSelectionCombo_->addItem(tr("Default"));
         for (const auto &family : emojiFamilies) {
                 emojiFontSelectionCombo_->addItem(family);
         }

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -741,8 +741,7 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
                 fontSelectionCombo_->setCurrentIndex(
                   fontSelectionCombo_->findText(tr(currentFont.toStdString().c_str())));
         } else {
-                fontSelectionCombo_->setCurrentIndex(
-                  fontSelectionCombo_->findText(currentFont));
+                fontSelectionCombo_->setCurrentIndex(fontSelectionCombo_->findText(currentFont));
         }
 
         emojiFontSelectionCombo_->setCurrentIndex(

--- a/src/UserSettingsPage.h
+++ b/src/UserSettingsPage.h
@@ -177,12 +177,13 @@ public:
         int timelineMaxWidth() const { return timelineMaxWidth_; }
         double fontSize() const { return baseFontSize_; }
         QString font() const { return font_; }
-        QString emojiFont() const {
+        QString emojiFont() const
+        {
                 if (emojiFont_ == "Default") {
                         return tr("Default");
                 }
 
-                return emojiFont_; 
+                return emojiFont_;
         }
         Presence presence() const { return presence_; }
         QString ringtone() const { return ringtone_; }

--- a/src/UserSettingsPage.h
+++ b/src/UserSettingsPage.h
@@ -177,7 +177,13 @@ public:
         int timelineMaxWidth() const { return timelineMaxWidth_; }
         double fontSize() const { return baseFontSize_; }
         QString font() const { return font_; }
-        QString emojiFont() const { return emojiFont_; }
+        QString emojiFont() const {
+                if (emojiFont_ == "Default") {
+                        return tr("Default");
+                }
+
+                return emojiFont_; 
+        }
         Presence presence() const { return presence_; }
         QString ringtone() const { return ringtone_; }
         QString microphone() const { return microphone_; }

--- a/src/timeline/TimelineViewManager.cpp
+++ b/src/timeline/TimelineViewManager.cpp
@@ -545,3 +545,9 @@ TimelineViewManager::queueCallMessage(const QString &roomid,
 {
         models.value(roomid)->sendMessageEvent(callHangUp, mtx::events::EventType::CallHangUp);
 }
+
+void
+TimelineViewManager::focusMessageInput()
+{
+        emit focusInput();
+}

--- a/src/timeline/TimelineViewManager.h
+++ b/src/timeline/TimelineViewManager.h
@@ -66,6 +66,7 @@ public:
 
         Q_INVOKABLE void openLink(QString link) const;
 
+        Q_INVOKABLE void focusMessageInput();
         Q_INVOKABLE void openInviteUsersDialog();
         Q_INVOKABLE void openMemberListDialog() const;
         Q_INVOKABLE void openLeaveRoomDialog() const;
@@ -87,6 +88,7 @@ signals:
         void showRoomList();
         void narrowViewChanged();
         void focusChanged();
+        void focusInput();
 
 public slots:
         void updateReadReceipts(const QString &room_id, const std::vector<QString> &event_ids);


### PR DESCRIPTION
1) Add default option for emoji font family in settings
2) Fixes #441 input field is focussed after reacting to a message
3) Fixes #433 closes emoji autocompleter if space is pressed after colon
4) Fixes #438 focus input field after selection from emoji picker