### PR TITLE
Fixes issue 462

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ and mtxclient (needs to be build separately).
 ```bash
 sudo apt install cmake gcc make automake liblmdb-dev \
     qt5-default libssl-dev libqt5multimedia5-plugins libqt5multimediagsttools5 libqt5multimediaquick5 libqt5svg5-dev \
-    qml-module-qtgstreamer qtmultimedia5-dev qtquickcontrols2-5-dev qttools5-dev qttools5-dev-tools \
+    qml-module-qtgstreamer qtmultimedia5-dev qtquickcontrols2-5-dev qttools5-dev qttools5-dev-tools qtdeclarative5-dev \
     qml-module-qtgraphicaleffects qml-module-qtmultimedia qml-module-qtquick-controls2 qml-module-qtquick-layouts \
     qt5keychain-dev
 ```


### PR DESCRIPTION
Installation description for debian (buster) misses package qtdeclarative5-dev

	modified:   README.md

fixes #462 