### PR TITLE
Display notifications for emote messages properly

### DIFF
--- a/src/ChatPage.cpp
+++ b/src/ChatPage.cpp
@@ -691,13 +691,20 @@ ChatPage::sendNotifications(const mtx::responses::Notifications &res)
                                           this,
                                           [this, room_id, event_id, item, user_id, info](
                                             QPixmap image) {
+                                                  bool isEmote = false;
+                                                  auto ev      = cache::client()->getEvent(
+                                                    room_id.toStdString(), event_id);
+                                                  if (ev && mtx::accessors::msg_type(ev->data) ==
+                                                              mtx::events::MessageType::Emote)
+                                                          isEmote = true;
                                                   notificationsManager.postNotification(
                                                     room_id,
                                                     QString::fromStdString(event_id),
                                                     QString::fromStdString(info.name),
                                                     cache::displayName(room_id, user_id),
                                                     utils::event_body(item.event),
-                                                    image.toImage());
+                                                    image.toImage(),
+                                                    isEmote);
                                           });
                                 }
                         }

--- a/src/ChatPage.cpp
+++ b/src/ChatPage.cpp
@@ -668,8 +668,6 @@ ChatPage::sendNotifications(const mtx::responses::Notifications &res)
 
                         if (!cache::isNotificationSent(event_id)) {
                                 const auto room_id = QString::fromStdString(item.room_id);
-                                const auto user_id =
-                                  QString::fromStdString(mtx::accessors::sender(item.event));
 
                                 // We should only sent one notification per event.
                                 cache::markSentNotification(event_id);
@@ -689,22 +687,9 @@ ChatPage::sendNotifications(const mtx::responses::Notifications &res)
                                           QString::fromStdString(info.avatar_url),
                                           96,
                                           this,
-                                          [this, room_id, event_id, item, user_id, info](
-                                            QPixmap image) {
-                                                  bool isEmote = false;
-                                                  auto ev      = cache::client()->getEvent(
-                                                    room_id.toStdString(), event_id);
-                                                  if (ev && mtx::accessors::msg_type(ev->data) ==
-                                                              mtx::events::MessageType::Emote)
-                                                          isEmote = true;
+                                          [this, item](QPixmap image) {
                                                   notificationsManager.postNotification(
-                                                    room_id,
-                                                    QString::fromStdString(event_id),
-                                                    QString::fromStdString(info.name),
-                                                    cache::displayName(room_id, user_id),
-                                                    utils::event_body(item.event),
-                                                    image.toImage(),
-                                                    isEmote);
+                                                    item, image.toImage());
                                           });
                                 }
                         }

--- a/src/notifications/Manager.h
+++ b/src/notifications/Manager.h
@@ -4,7 +4,7 @@
 #include <QObject>
 #include <QString>
 
-#include <mtx/responses.hpp>
+#include <mtx/responses/notifications.hpp>
 
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(Q_OS_HAIKU)
 #include <QtDBus/QDBusArgument>

--- a/src/notifications/Manager.h
+++ b/src/notifications/Manager.h
@@ -4,6 +4,8 @@
 #include <QObject>
 #include <QString>
 
+#include <mtx/responses.hpp>
+
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(Q_OS_HAIKU)
 #include <QtDBus/QDBusArgument>
 #include <QtDBus/QDBusInterface>
@@ -27,13 +29,7 @@ class NotificationsManager : public QObject
 public:
         NotificationsManager(QObject *parent = nullptr);
 
-        void postNotification(const QString &roomId,
-                              const QString &eventId,
-                              const QString &roomName,
-                              const QString &senderName,
-                              const QString &text,
-                              const QImage &icon,
-                              const bool &isEmoteMsg = false);
+        void postNotification(const mtx::responses::Notification &notification, const QImage &icon);
 
 signals:
         void notificationClicked(const QString roomId, const QString eventId);

--- a/src/notifications/Manager.h
+++ b/src/notifications/Manager.h
@@ -32,7 +32,8 @@ public:
                               const QString &roomName,
                               const QString &senderName,
                               const QString &text,
-                              const QImage &icon);
+                              const QImage &icon,
+                              const bool &isEmoteMsg = false);
 
 signals:
         void notificationClicked(const QString roomId, const QString eventId);

--- a/src/notifications/ManagerLinux.cpp
+++ b/src/notifications/ManagerLinux.cpp
@@ -12,7 +12,7 @@
 #include "EventAccessors.h"
 #include "MatrixClient.h"
 #include "Utils.h"
-#include <mtx/responses.hpp>
+#include <mtx/responses/notifications.hpp>
 
 NotificationsManager::NotificationsManager(QObject *parent)
   : QObject(parent)

--- a/src/notifications/ManagerLinux.cpp
+++ b/src/notifications/ManagerLinux.cpp
@@ -8,6 +8,12 @@
 #include <QDebug>
 #include <QImage>
 
+#include "Cache.h"
+#include "EventAccessors.h"
+#include "MatrixClient.h"
+#include "Utils.h"
+#include <mtx/responses.hpp>
+
 NotificationsManager::NotificationsManager(QObject *parent)
   : QObject(parent)
   , dbus("org.freedesktop.Notifications",
@@ -45,28 +51,31 @@ NotificationsManager::NotificationsManager(QObject *parent)
  * Licensed under the GNU General Public License, version 3
  */
 void
-NotificationsManager::postNotification(const QString &roomid,
-                                       const QString &eventid,
-                                       const QString &roomname,
-                                       const QString &sender,
-                                       const QString &text,
-                                       const QImage &icon,
-                                       const bool &isEmoteMessage)
+NotificationsManager::postNotification(const mtx::responses::Notification &notification,
+                                       const QImage &icon)
 {
+        const auto room_id  = QString::fromStdString(notification.room_id);
+        const auto event_id = QString::fromStdString(mtx::accessors::event_id(notification.event));
+        const auto sender   = cache::displayName(
+          room_id, QString::fromStdString(mtx::accessors::sender(notification.event)));
+        const auto text = utils::event_body(notification.event);
+
         QVariantMap hints;
         hints["image-data"] = icon;
         hints["sound-name"] = "message-new-instant";
         QList<QVariant> argumentList;
-        argumentList << "nheko";  // app_name
-        argumentList << (uint)0;  // replace_id
-        argumentList << "";       // app_icon
-        argumentList << roomname; // summary
+        argumentList << "nheko"; // app_name
+        argumentList << (uint)0; // replace_id
+        argumentList << "";      // app_icon
+        argumentList << QString::fromStdString(
+          cache::singleRoomInfo(notification.room_id).name); // summary
 
         // body
-        if (isEmoteMessage)
+        if (mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Emote)
                 argumentList << "* " + sender + " " + text;
         else
                 argumentList << sender + ": " + text;
+
         // The list of actions has always the action name and then a localized version of that
         // action. Currently we just use an empty string for that.
         // TODO(Nico): Look into what to actually put there.
@@ -82,12 +91,12 @@ NotificationsManager::postNotification(const QString &roomid,
         QDBusPendingCall call = notifyApp.asyncCallWithArgumentList("Notify", argumentList);
         auto watcher          = new QDBusPendingCallWatcher{call, this};
         connect(
-          watcher, &QDBusPendingCallWatcher::finished, this, [watcher, this, roomid, eventid]() {
+          watcher, &QDBusPendingCallWatcher::finished, this, [watcher, this, room_id, event_id]() {
                   if (watcher->reply().type() == QDBusMessage::ErrorMessage)
                           qDebug() << "D-Bus Error:" << watcher->reply().errorMessage();
                   else
                           notificationIds[watcher->reply().arguments().first().toUInt()] =
-                            roomEventId{roomid, eventid};
+                            roomEventId{room_id, event_id};
                   watcher->deleteLater();
           });
 }

--- a/src/notifications/ManagerLinux.cpp
+++ b/src/notifications/ManagerLinux.cpp
@@ -50,17 +50,23 @@ NotificationsManager::postNotification(const QString &roomid,
                                        const QString &roomname,
                                        const QString &sender,
                                        const QString &text,
-                                       const QImage &icon)
+                                       const QImage &icon,
+                                       const bool &isEmoteMessage)
 {
         QVariantMap hints;
         hints["image-data"] = icon;
         hints["sound-name"] = "message-new-instant";
         QList<QVariant> argumentList;
-        argumentList << "nheko";              // app_name
-        argumentList << (uint)0;              // replace_id
-        argumentList << "";                   // app_icon
-        argumentList << roomname;             // summary
-        argumentList << sender + ": " + text; // body
+        argumentList << "nheko";  // app_name
+        argumentList << (uint)0;  // replace_id
+        argumentList << "";       // app_icon
+        argumentList << roomname; // summary
+
+        // body
+        if (isEmoteMessage)
+                argumentList << "* " + sender + " " + text;
+        else
+                argumentList << sender + ": " + text;
         // The list of actions has always the action name and then a localized version of that
         // action. Currently we just use an empty string for that.
         // TODO(Nico): Look into what to actually put there.

--- a/src/notifications/ManagerMac.mm
+++ b/src/notifications/ManagerMac.mm
@@ -3,6 +3,12 @@
 #include <Foundation/Foundation.h>
 #include <QtMac>
 
+#include "Cache.h"
+#include "EventAccessors.h"
+#include "MatrixClient.h"
+#include "Utils.h"
+#include <mtx/responses.hpp>
+
 @interface NSUserNotification (CFIPrivate)
 - (void)set_identityImage:(NSImage *)image;
 @end
@@ -13,25 +19,20 @@ NotificationsManager::NotificationsManager(QObject *parent): QObject(parent)
 }
 
 void
-NotificationsManager::postNotification(
-                const QString &roomId,
-                const QString &eventId,
-                const QString &roomName,
-                const QString &senderName,
-                const QString &text,
-                const QImage &icon,
-                const bool &isEmoteMessage)
+NotificationsManager::postNotification(const mtx::responses::Notification &notification,
+                                       const QImage &icon)
 {
-    Q_UNUSED(roomId);
-    Q_UNUSED(eventId);
     Q_UNUSED(icon);
+
+    const auto sender   = cache::displayName(QString::fromStdString(notification.room_id), QString::fromStdString(mtx::accessors::sender(notification.event)));
+    const auto text     = utils::event_body(notification.event);
 
     NSUserNotification * notif = [[NSUserNotification alloc] init];
 
-    notif.title           = roomName.toNSString();
-    notif.subtitle        = QString("%1 sent a message").arg(senderName).toNSString();
-    if (isEmoteMessage)
-            notif.informativeText = QString("* ").append(senderName).append(" ").append(text).toNSString();
+    notif.title           = QString::fromStdString(cache::singleRoomInfo(notification.room_id).name).toNSString();
+    notif.subtitle        = QString("%1 sent a message").arg(sender).toNSString();
+    if (mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Emote)
+            notif.informativeText = QString("* ").append(sender).append(" ").append(text).toNSString();
     else
             notif.informativeText = text.toNSString();
     notif.soundName       = NSUserNotificationDefaultSoundName;

--- a/src/notifications/ManagerMac.mm
+++ b/src/notifications/ManagerMac.mm
@@ -19,7 +19,8 @@ NotificationsManager::postNotification(
                 const QString &roomName,
                 const QString &senderName,
                 const QString &text,
-                const QImage &icon)
+                const QImage &icon,
+                const bool &isEmoteMessage)
 {
     Q_UNUSED(roomId);
     Q_UNUSED(eventId);
@@ -29,7 +30,10 @@ NotificationsManager::postNotification(
 
     notif.title           = roomName.toNSString();
     notif.subtitle        = QString("%1 sent a message").arg(senderName).toNSString();
-    notif.informativeText = text.toNSString();
+    if (isEmoteMessage)
+            notif.informativeText = QString("* ").append(senderName).append(" ").append(text).toNSString();
+    else
+            notif.informativeText = text.toNSString();
     notif.soundName       = NSUserNotificationDefaultSoundName;
 
     [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification: notif];

--- a/src/notifications/ManagerMac.mm
+++ b/src/notifications/ManagerMac.mm
@@ -7,7 +7,7 @@
 #include "EventAccessors.h"
 #include "MatrixClient.h"
 #include "Utils.h"
-#include <mtx/responses.hpp>
+#include <mtx/responses/notifications.hpp>
 
 @interface NSUserNotification (CFIPrivate)
 - (void)set_identityImage:(NSImage *)image;

--- a/src/notifications/ManagerWin.cpp
+++ b/src/notifications/ManagerWin.cpp
@@ -37,7 +37,8 @@ NotificationsManager::postNotification(const QString &room_id,
                                        const QString &room_name,
                                        const QString &sender,
                                        const QString &text,
-                                       const QImage &icon)
+                                       const QImage &icon,
+                                       const bool &isEmoteMessage)
 {
         Q_UNUSED(room_id)
         Q_UNUSED(event_id)
@@ -53,7 +54,13 @@ NotificationsManager::postNotification(const QString &room_id,
         else
                 templ.setTextField(QString("%1").arg(sender).toStdWString(),
                                    WinToastTemplate::FirstLine);
-        templ.setTextField(QString("%1").arg(text).toStdWString(), WinToastTemplate::SecondLine);
+        if (isEmoteMessage)
+                templ.setTextField(
+                  QString("* ").append(sender).append(" ").append(text).toStdWString(),
+                  WinToastTemplate::SecondLine);
+        else
+                templ.setTextField(QString("%1").arg(text).toStdWString(),
+                                   WinToastTemplate::SecondLine);
         // TODO: implement room or user avatar
         // templ.setImagePath(L"C:/example.png");
 

--- a/src/notifications/ManagerWin.cpp
+++ b/src/notifications/ManagerWin.cpp
@@ -5,7 +5,7 @@
 #include "EventAccessors.h"
 #include "MatrixClient.h"
 #include "Utils.h"
-#include <mtx/responses.hpp>
+#include <mtx/responses/notifications.hpp>
 
 using namespace WinToastLib;
 

--- a/src/notifications/ManagerWin.cpp
+++ b/src/notifications/ManagerWin.cpp
@@ -23,7 +23,7 @@ init()
         WinToast::instance()->setAppName(L"Nheko");
         WinToast::instance()->setAppUserModelId(WinToast::configureAUMI(L"nheko", L"nheko"));
         if (!WinToast::instance()->initialize())
-                std::wcout << "Your system in not compatible with toast notifications\n";
+                std::wcout << "Your system is not compatible with toast notifications\n";
 }
 }
 


### PR DESCRIPTION
![clipboard](https://user-images.githubusercontent.com/55629213/107794755-d33add80-6d25-11eb-8c05-353249e829ce.png)
How it looks now. Formerly, it would have been "LorenDB: is testing" instead of "* LorenDB is testing".