### PR TITLE
Better notifications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,6 +297,9 @@ set(SRC_FILES
 	src/ui/UserProfile.cpp
 	src/ui/RoomSettings.cpp
 
+    # Generic notification stuff
+    src/notifications/Manager.cpp
+
 	src/AvatarProvider.cpp
 	src/BlurhashProvider.cpp
 	src/Cache.cpp
@@ -557,7 +560,7 @@ set(TRANSLATION_DEPS ${LANG_QRC} ${QRC} ${QM_SRC})
 
 if (APPLE)
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -framework Foundation -framework Cocoa")
-	set(SRC_FILES ${SRC_FILES} src/notifications/ManagerMac.mm src/emoji/MacHelper.mm)
+	set(SRC_FILES ${SRC_FILES} src/notifications/ManagerMac.mm src/notifications/ManagerMac.cpp src/emoji/MacHelper.mm)
 	if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0")
 		set_source_files_properties( src/notifications/ManagerMac.mm src/emoji/MacHelper.mm PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
 	endif()

--- a/src/AvatarProvider.cpp
+++ b/src/AvatarProvider.cpp
@@ -5,6 +5,7 @@
 
 #include <QBuffer>
 #include <QPixmapCache>
+#include <QPointer>
 #include <memory>
 #include <unordered_map>
 

--- a/src/AvatarProvider.cpp
+++ b/src/AvatarProvider.cpp
@@ -12,13 +12,14 @@
 #include "Cache.h"
 #include "Logging.h"
 #include "MatrixClient.h"
+#include "MxcImageProvider.h"
 #include "Utils.h"
 
 static QPixmapCache avatar_cache;
 
 namespace AvatarProvider {
 void
-resolve(const QString &avatarUrl, int size, QObject *receiver, AvatarCallback callback)
+resolve(QString avatarUrl, int size, QObject *receiver, AvatarCallback callback)
 {
         const auto cacheKey = QString("%1_size_%2").arg(avatarUrl).arg(size);
 
@@ -33,44 +34,32 @@ resolve(const QString &avatarUrl, int size, QObject *receiver, AvatarCallback ca
                 return;
         }
 
-        auto data = cache::image(cacheKey);
-        if (!data.isNull()) {
-                pixmap = QPixmap::fromImage(utils::readImage(data));
-                avatar_cache.insert(cacheKey, pixmap);
-                callback(pixmap);
-                return;
-        }
+        MxcImageProvider::download(avatarUrl.remove(QStringLiteral("mxc://")),
+                                   QSize(size, size),
+                                   [callback, cacheKey, recv = QPointer<QObject>(receiver)](
+                                     QString, QSize, QImage img, QString) {
+                                           if (!recv)
+                                                   return;
 
-        auto proxy = std::make_shared<AvatarProxy>();
-        QObject::connect(proxy.get(),
-                         &AvatarProxy::avatarDownloaded,
-                         receiver,
-                         [callback, cacheKey](QByteArray data) {
-                                 QPixmap pm = QPixmap::fromImage(utils::readImage(data));
-                                 avatar_cache.insert(cacheKey, pm);
-                                 callback(pm);
-                         });
+                                           auto proxy = std::make_shared<AvatarProxy>();
+                                           QObject::connect(proxy.get(),
+                                                            &AvatarProxy::avatarDownloaded,
+                                                            recv,
+                                                            [callback, cacheKey](QPixmap pm) {
+                                                                    if (!pm.isNull())
+                                                                            avatar_cache.insert(
+                                                                              cacheKey, pm);
+                                                                    callback(pm);
+                                                            });
 
-        mtx::http::ThumbOpts opts;
-        opts.width   = size;
-        opts.height  = size;
-        opts.mxc_url = avatarUrl.toStdString();
+                                           if (img.isNull()) {
+                                                   emit proxy->avatarDownloaded(QPixmap{});
+                                                   return;
+                                           }
 
-        http::client()->get_thumbnail(
-          opts,
-          [opts, cacheKey, proxy = std::move(proxy)](const std::string &res,
-                                                     mtx::http::RequestErr err) {
-                  if (err) {
-                          nhlog::net()->warn("failed to download avatar: {} - ({} {})",
-                                             opts.mxc_url,
-                                             mtx::errors::to_string(err->matrix_error.errcode),
-                                             err->matrix_error.error);
-                  } else {
-                          cache::saveImage(cacheKey.toStdString(), res);
-                  }
-
-                  emit proxy->avatarDownloaded(QByteArray(res.data(), (int)res.size()));
-          });
+                                           auto pm = QPixmap::fromImage(std::move(img));
+                                           emit proxy->avatarDownloaded(pm);
+                                   });
 }
 
 void
@@ -80,8 +69,8 @@ resolve(const QString &room_id,
         QObject *receiver,
         AvatarCallback callback)
 {
-        const auto avatarUrl = cache::avatarUrl(room_id, user_id);
+        auto avatarUrl = cache::avatarUrl(room_id, user_id);
 
-        resolve(avatarUrl, size, receiver, callback);
+        resolve(std::move(avatarUrl), size, receiver, callback);
 }
 }

--- a/src/AvatarProvider.cpp
+++ b/src/AvatarProvider.cpp
@@ -35,7 +35,7 @@ resolve(const QString &avatarUrl, int size, QObject *receiver, AvatarCallback ca
 
         auto data = cache::image(cacheKey);
         if (!data.isNull()) {
-                pixmap = QPixmap::fromImage(utils::readImage(&data));
+                pixmap = QPixmap::fromImage(utils::readImage(data));
                 avatar_cache.insert(cacheKey, pixmap);
                 callback(pixmap);
                 return;
@@ -46,7 +46,7 @@ resolve(const QString &avatarUrl, int size, QObject *receiver, AvatarCallback ca
                          &AvatarProxy::avatarDownloaded,
                          receiver,
                          [callback, cacheKey](QByteArray data) {
-                                 QPixmap pm = QPixmap::fromImage(utils::readImage(&data));
+                                 QPixmap pm = QPixmap::fromImage(utils::readImage(data));
                                  avatar_cache.insert(cacheKey, pm);
                                  callback(pm);
                          });

--- a/src/AvatarProvider.h
+++ b/src/AvatarProvider.h
@@ -8,19 +8,19 @@
 #include <QPixmap>
 #include <functional>
 
+using AvatarCallback = std::function<void(QPixmap)>;
+
 class AvatarProxy : public QObject
 {
         Q_OBJECT
 
 signals:
-        void avatarDownloaded(const QByteArray &data);
+        void avatarDownloaded(QPixmap pm);
 };
-
-using AvatarCallback = std::function<void(QPixmap)>;
 
 namespace AvatarProvider {
 void
-resolve(const QString &avatarUrl, int size, QObject *receiver, AvatarCallback cb);
+resolve(QString avatarUrl, int size, QObject *receiver, AvatarCallback cb);
 void
 resolve(const QString &room_id,
         const QString &user_id,

--- a/src/Cache.h
+++ b/src/Cache.h
@@ -6,8 +6,6 @@
 #pragma once
 
 #include <QDateTime>
-#include <QDir>
-#include <QImage>
 #include <QString>
 
 #if __has_include(<lmdbxx/lmdb++.h>)
@@ -135,12 +133,6 @@ hasEnoughPowerLevel(const std::vector<mtx::events::EventType> &eventTypes,
                     const std::string &room_id,
                     const std::string &user_id);
 
-//! Retrieves the saved room avatar.
-QImage
-getRoomAvatar(const QString &id);
-QImage
-getRoomAvatar(const std::string &id);
-
 //! Adds a user to the read list for the given event.
 //!
 //! There should be only one user id present in a receipt list per room.
@@ -161,20 +153,6 @@ std::optional<uint64_t>
 getEventIndex(const std::string &room_id, std::string_view event_id);
 std::optional<std::pair<uint64_t, std::string>>
 lastInvisibleEventAfter(const std::string &room_id, std::string_view event_id);
-
-QByteArray
-image(const QString &url);
-QByteArray
-image(lmdb::txn &txn, const std::string &url);
-inline QByteArray
-image(const std::string &url)
-{
-        return image(QString::fromStdString(url));
-}
-void
-saveImage(const std::string &url, const std::string &data);
-void
-saveImage(const QString &url, const QByteArray &data);
 
 RoomInfo
 singleRoomInfo(const std::string &room_id);

--- a/src/CacheStructs.h
+++ b/src/CacheStructs.h
@@ -25,7 +25,6 @@ struct RoomMember
 {
         QString user_id;
         QString display_name;
-        QImage avatar;
 };
 
 //! Used to uniquely identify a list of read receipts.

--- a/src/Cache_p.h
+++ b/src/Cache_p.h
@@ -118,10 +118,6 @@ public:
                                  const std::string &room_id,
                                  const std::string &user_id);
 
-        //! Retrieves the saved room avatar.
-        QImage getRoomAvatar(const QString &id);
-        QImage getRoomAvatar(const std::string &id);
-
         //! Adds a user to the read list for the given event.
         //!
         //! There should be only one user id present in a receipt list per room.
@@ -136,11 +132,6 @@ public:
         //! Returns a map of user ids and the time of the read receipt in milliseconds.
         using UserReceipts = std::multimap<uint64_t, std::string, std::greater<uint64_t>>;
         UserReceipts readReceipts(const QString &event_id, const QString &room_id);
-
-        QByteArray image(const QString &url);
-        QByteArray image(lmdb::txn &txn, const std::string &url);
-        void saveImage(const std::string &url, const std::string &data);
-        void saveImage(const QString &url, const QByteArray &data);
 
         RoomInfo singleRoomInfo(const std::string &room_id);
         std::vector<std::string> roomsWithStateUpdates(const mtx::responses::Sync &res);
@@ -528,7 +519,6 @@ private:
         lmdb::dbi syncStateDb_;
         lmdb::dbi roomsDb_;
         lmdb::dbi invitesDb_;
-        lmdb::dbi mediaDb_;
         lmdb::dbi readReceiptsDb_;
         lmdb::dbi notificationsDb_;
 

--- a/src/MxcImageProvider.cpp
+++ b/src/MxcImageProvider.cpp
@@ -128,10 +128,11 @@ MxcImageProvider::download(const QString &id,
                                         f.open(QIODevice::ReadOnly);
 
                                         QByteArray fileData = f.readAll();
-                                        auto temp =
+                                        auto tempData =
                                           mtx::crypto::to_string(mtx::crypto::decrypt_file(
                                             fileData.toStdString(), encryptionInfo.value()));
-                                        auto data    = QByteArray(temp.data(), (int)temp.size());
+                                        auto data =
+                                          QByteArray(tempData.data(), (int)tempData.size());
                                         QImage image = utils::readImage(data);
                                         image.setText("mxc url", "mxc://" + id);
                                         if (!image.isNull()) {
@@ -165,19 +166,21 @@ MxcImageProvider::download(const QString &id,
                                           return;
                                   }
 
-                                  auto temp = res;
+                                  auto tempData = res;
                                   QFile f(fileInfo.absoluteFilePath());
                                   if (!f.open(QIODevice::Truncate | QIODevice::WriteOnly)) {
                                           then(id, QSize(), {}, "");
                                           return;
                                   }
-                                  f.write(temp.data(), temp.size());
+                                  f.write(tempData.data(), tempData.size());
                                   f.close();
 
                                   if (encryptionInfo) {
-                                          temp = mtx::crypto::to_string(mtx::crypto::decrypt_file(
-                                            temp, encryptionInfo.value()));
-                                          auto data    = QByteArray(temp.data(), (int)temp.size());
+                                          tempData =
+                                            mtx::crypto::to_string(mtx::crypto::decrypt_file(
+                                              tempData, encryptionInfo.value()));
+                                          auto data =
+                                            QByteArray(tempData.data(), (int)tempData.size());
                                           QImage image = utils::readImage(data);
                                           image.setText("original filename",
                                                         QString::fromStdString(originalFilename));

--- a/src/MxcImageProvider.cpp
+++ b/src/MxcImageProvider.cpp
@@ -22,7 +22,7 @@ MxcImageResponse::run()
 
                 auto data = cache::image(fileName);
                 if (!data.isNull()) {
-                        m_image = utils::readImage(&data);
+                        m_image = utils::readImage(data);
 
                         if (!m_image.isNull()) {
                                 m_image = m_image.scaled(
@@ -54,7 +54,7 @@ MxcImageResponse::run()
 
                           auto data = QByteArray(res.data(), (int)res.size());
                           cache::saveImage(fileName, data);
-                          m_image = utils::readImage(&data);
+                          m_image = utils::readImage(data);
                           if (!m_image.isNull()) {
                                   m_image = m_image.scaled(
                                     m_requestedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
@@ -67,7 +67,7 @@ MxcImageResponse::run()
                 auto data = cache::image(m_id);
 
                 if (!data.isNull()) {
-                        m_image = utils::readImage(&data);
+                        m_image = utils::readImage(data);
                         m_image.setText("mxc url", "mxc://" + m_id);
 
                         if (!m_image.isNull()) {
@@ -98,7 +98,7 @@ MxcImageResponse::run()
 
                           auto data = QByteArray(temp.data(), (int)temp.size());
                           cache::saveImage(m_id, data);
-                          m_image = utils::readImage(&data);
+                          m_image = utils::readImage(data);
                           m_image.setText("original filename",
                                           QString::fromStdString(originalFilename));
                           m_image.setText("mxc url", "mxc://" + m_id);

--- a/src/MxcImageProvider.cpp
+++ b/src/MxcImageProvider.cpp
@@ -4,106 +4,192 @@
 
 #include "MxcImageProvider.h"
 
+#include <optional>
+
 #include <mtxclient/crypto/client.hpp>
+
+#include <QByteArray>
+#include <QFileInfo>
+#include <QStandardPaths>
 
 #include "Cache.h"
 #include "Logging.h"
 #include "MatrixClient.h"
 #include "Utils.h"
 
+QHash<QString, mtx::crypto::EncryptedFile> infos;
+
+QQuickImageResponse *
+MxcImageProvider::requestImageResponse(const QString &id, const QSize &requestedSize)
+{
+        MxcImageResponse *response = new MxcImageResponse(id, requestedSize);
+        pool.start(response);
+        return response;
+}
+
+void
+MxcImageProvider::addEncryptionInfo(mtx::crypto::EncryptedFile info)
+{
+        infos.insert(QString::fromStdString(info.url), info);
+}
 void
 MxcImageResponse::run()
 {
-        if (m_requestedSize.isValid() && !m_encryptionInfo) {
-                QString fileName = QString("%1_%2x%3_crop")
-                                     .arg(m_id)
-                                     .arg(m_requestedSize.width())
-                                     .arg(m_requestedSize.height());
+        MxcImageProvider::download(
+          m_id, m_requestedSize, [this](QString, QSize, QImage image, QString) {
+                  if (image.isNull()) {
+                          m_error = "Failed to download image.";
+                  } else {
+                          m_image = image;
+                  }
+                  emit finished();
+          });
+}
 
-                auto data = cache::image(fileName);
-                if (!data.isNull()) {
-                        m_image = utils::readImage(data);
+void
+MxcImageProvider::download(const QString &id,
+                           const QSize &requestedSize,
+                           std::function<void(QString, QSize, QImage, QString)> then)
+{
+        std::optional<mtx::crypto::EncryptedFile> encryptionInfo;
+        auto temp = infos.find("mxc://" + id);
+        if (temp != infos.end())
+                encryptionInfo = *temp;
 
-                        if (!m_image.isNull()) {
-                                m_image = m_image.scaled(
-                                  m_requestedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-                                m_image.setText("mxc url", "mxc://" + m_id);
+        if (requestedSize.isValid() && !encryptionInfo) {
+                QString fileName =
+                  QString("%1_%2x%3_crop")
+                    .arg(QString::fromUtf8(id.toUtf8().toBase64(QByteArray::Base64UrlEncoding |
+                                                                QByteArray::OmitTrailingEquals)),
+                         requestedSize.width(),
+                         requestedSize.height());
+                QFileInfo fileInfo(QStandardPaths::writableLocation(QStandardPaths::CacheLocation) +
+                                     "/media_cache",
+                                   fileName);
 
-                                if (!m_image.isNull()) {
-                                        emit finished();
+                if (fileInfo.exists()) {
+                        QImage image(fileInfo.absoluteFilePath());
+                        if (!image.isNull()) {
+                                image = image.scaled(
+                                  requestedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+
+                                if (!image.isNull()) {
+                                        then(id, requestedSize, image, fileInfo.absoluteFilePath());
                                         return;
                                 }
                         }
                 }
 
                 mtx::http::ThumbOpts opts;
-                opts.mxc_url = "mxc://" + m_id.toStdString();
-                opts.width   = m_requestedSize.width() > 0 ? m_requestedSize.width() : -1;
-                opts.height  = m_requestedSize.height() > 0 ? m_requestedSize.height() : -1;
+                opts.mxc_url = "mxc://" + id.toStdString();
+                opts.width   = requestedSize.width() > 0 ? requestedSize.width() : -1;
+                opts.height  = requestedSize.height() > 0 ? requestedSize.height() : -1;
                 opts.method  = "crop";
                 http::client()->get_thumbnail(
-                  opts, [this, fileName](const std::string &res, mtx::http::RequestErr err) {
+                  opts,
+                  [fileInfo, requestedSize, then, id](const std::string &res,
+                                                      mtx::http::RequestErr err) {
                           if (err || res.empty()) {
-                                  nhlog::net()->error("Failed to download image {}",
-                                                      m_id.toStdString());
-                                  m_error = "Failed download";
-                                  emit finished();
+                                  then(id, QSize(), {}, "");
 
                                   return;
                           }
 
-                          auto data = QByteArray(res.data(), (int)res.size());
-                          cache::saveImage(fileName, data);
-                          m_image = utils::readImage(data);
-                          if (!m_image.isNull()) {
-                                  m_image = m_image.scaled(
-                                    m_requestedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+                          auto data    = QByteArray(res.data(), (int)res.size());
+                          QImage image = utils::readImage(data);
+                          if (!image.isNull()) {
+                                  image = image.scaled(
+                                    requestedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
                           }
-                          m_image.setText("mxc url", "mxc://" + m_id);
+                          image.setText("mxc url", "mxc://" + id);
+                          image.save(fileInfo.absoluteFilePath());
 
-                          emit finished();
+                          then(id, requestedSize, image, fileInfo.absoluteFilePath());
                   });
         } else {
-                auto data = cache::image(m_id);
+                try {
+                        QString fileName = QString::fromUtf8(id.toUtf8().toBase64(
+                          QByteArray::Base64UrlEncoding | QByteArray::OmitTrailingEquals));
+                        QFileInfo fileInfo(
+                          QStandardPaths::writableLocation(QStandardPaths::CacheLocation) +
+                            "/media_cache",
+                          fileName);
 
-                if (!data.isNull()) {
-                        m_image = utils::readImage(data);
-                        m_image.setText("mxc url", "mxc://" + m_id);
+                        if (fileInfo.exists()) {
+                                if (encryptionInfo) {
+                                        QFile f(fileInfo.absoluteFilePath());
+                                        f.open(QIODevice::ReadOnly);
 
-                        if (!m_image.isNull()) {
-                                emit finished();
-                                return;
+                                        QByteArray fileData = f.readAll();
+                                        auto temp =
+                                          mtx::crypto::to_string(mtx::crypto::decrypt_file(
+                                            fileData.toStdString(), encryptionInfo.value()));
+                                        auto data    = QByteArray(temp.data(), (int)temp.size());
+                                        QImage image = utils::readImage(data);
+                                        image.setText("mxc url", "mxc://" + id);
+                                        if (!image.isNull()) {
+                                                then(id,
+                                                     requestedSize,
+                                                     image,
+                                                     fileInfo.absoluteFilePath());
+                                                return;
+                                        }
+                                } else {
+                                        QImage image(fileInfo.absoluteFilePath());
+                                        if (!image.isNull()) {
+                                                then(id,
+                                                     requestedSize,
+                                                     image,
+                                                     fileInfo.absoluteFilePath());
+                                                return;
+                                        }
+                                }
                         }
+                        auto data = cache::image(id);
+
+                        http::client()->download(
+                          "mxc://" + id.toStdString(),
+                          [fileInfo, requestedSize, then, id, encryptionInfo](
+                            const std::string &res,
+                            const std::string &,
+                            const std::string &originalFilename,
+                            mtx::http::RequestErr err) {
+                                  if (err) {
+                                          then(id, QSize(), {}, "");
+                                          return;
+                                  }
+
+                                  auto temp = res;
+                                  QFile f(fileInfo.absoluteFilePath());
+                                  if (!f.open(QIODevice::Truncate | QIODevice::WriteOnly)) {
+                                          then(id, QSize(), {}, "");
+                                          return;
+                                  }
+                                  f.write(temp.data(), temp.size());
+                                  f.close();
+
+                                  if (encryptionInfo) {
+                                          temp = mtx::crypto::to_string(mtx::crypto::decrypt_file(
+                                            temp, encryptionInfo.value()));
+                                          auto data    = QByteArray(temp.data(), (int)temp.size());
+                                          QImage image = utils::readImage(data);
+                                          image.setText("original filename",
+                                                        QString::fromStdString(originalFilename));
+                                          image.setText("mxc url", "mxc://" + id);
+                                          then(
+                                            id, requestedSize, image, fileInfo.absoluteFilePath());
+                                          return;
+                                  }
+
+                                  QImage image(fileInfo.absoluteFilePath());
+                                  image.setText("original filename",
+                                                QString::fromStdString(originalFilename));
+                                  image.setText("mxc url", "mxc://" + id);
+                                  image.save(fileInfo.absoluteFilePath());
+                                  then(id, requestedSize, image, fileInfo.absoluteFilePath());
+                          });
+                } catch (std::exception &e) {
+                        nhlog::net()->error("Exception while downloading media: {}", e.what());
                 }
-
-                http::client()->download(
-                  "mxc://" + m_id.toStdString(),
-                  [this](const std::string &res,
-                         const std::string &,
-                         const std::string &originalFilename,
-                         mtx::http::RequestErr err) {
-                          if (err) {
-                                  nhlog::net()->error("Failed to download image {}",
-                                                      m_id.toStdString());
-                                  m_error = "Failed download";
-                                  emit finished();
-
-                                  return;
-                          }
-
-                          auto temp = res;
-                          if (m_encryptionInfo)
-                                  temp = mtx::crypto::to_string(
-                                    mtx::crypto::decrypt_file(temp, m_encryptionInfo.value()));
-
-                          auto data = QByteArray(temp.data(), (int)temp.size());
-                          cache::saveImage(m_id, data);
-                          m_image = utils::readImage(data);
-                          m_image.setText("original filename",
-                                          QString::fromStdString(originalFilename));
-                          m_image.setText("mxc url", "mxc://" + m_id);
-
-                          emit finished();
-                  });
         }
 }

--- a/src/RoomInfoListItem.cpp
+++ b/src/RoomInfoListItem.cpp
@@ -8,7 +8,6 @@
 #include <QMenu>
 #include <QMouseEvent>
 #include <QPainter>
-#include <QSettings>
 #include <QtGlobal>
 
 #include "AvatarProvider.h"

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -689,10 +689,10 @@ utils::restoreCombobox(QComboBox *combo, const QString &value)
 }
 
 QImage
-utils::readImage(const QByteArray *data)
+utils::readImage(const QByteArray &data)
 {
         QBuffer buf;
-        buf.setData(*data);
+        buf.setData(data);
         QImageReader reader(&buf);
         reader.setAutoTransform(true);
         return reader.read();

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -24,6 +24,7 @@
 
 #include "Cache.h"
 #include "Config.h"
+#include "EventAccessors.h"
 #include "MatrixClient.h"
 #include "UserSettingsPage.h"
 
@@ -695,4 +696,10 @@ utils::readImage(const QByteArray *data)
         QImageReader reader(&buf);
         reader.setAutoTransform(true);
         return reader.read();
+}
+
+bool
+utils::isReply(const mtx::events::collections::TimelineEvents &e)
+{
+        return mtx::accessors::relations(e).reply_to().has_value();
 }

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -51,6 +51,35 @@ createDescriptionInfo(const Event &event, const QString &localUser, const QStrin
                         ts};
 }
 
+RelatedInfo
+utils::stripReplyFallbacks(const TimelineEvent &event, std::string id, QString room_id_)
+{
+        RelatedInfo related   = {};
+        related.quoted_user   = QString::fromStdString(mtx::accessors::sender(event));
+        related.related_event = std::move(id);
+        related.type          = mtx::accessors::msg_type(event);
+
+        // get body, strip reply fallback, then transform the event to text, if it is a media event
+        // etc
+        related.quoted_body = QString::fromStdString(mtx::accessors::body(event));
+        QRegularExpression plainQuote("^>.*?$\n?", QRegularExpression::MultilineOption);
+        while (related.quoted_body.startsWith(">"))
+                related.quoted_body.remove(plainQuote);
+        if (related.quoted_body.startsWith("\n"))
+                related.quoted_body.remove(0, 1);
+        related.quoted_body = utils::getQuoteBody(related);
+        related.quoted_body.replace("@room", QString::fromUtf8("@\u2060room"));
+
+        // get quoted body and strip reply fallback
+        related.quoted_formatted_body = mtx::accessors::formattedBodyWithFallback(event);
+        related.quoted_formatted_body.remove(QRegularExpression(
+          "<mx-reply>.*</mx-reply>", QRegularExpression::DotMatchesEverythingOption));
+        related.quoted_formatted_body.replace("@room", "@\u2060aroom");
+        related.room = room_id_;
+
+        return related;
+}
+
 QString
 utils::localUser()
 {

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -309,7 +309,7 @@ restoreCombobox(QComboBox *combo, const QString &value);
 
 //! Read image respecting exif orientation
 QImage
-readImage(const QByteArray *data);
+readImage(const QByteArray &data);
 
 bool
 isReply(const mtx::events::collections::TimelineEvents &e);

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -40,6 +40,9 @@ namespace utils {
 
 using TimelineEvent = mtx::events::collections::TimelineEvents;
 
+RelatedInfo
+stripReplyFallbacks(const TimelineEvent &event, std::string id, QString room_id_);
+
 bool
 codepointIsEmoji(uint code);
 

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -310,4 +310,7 @@ restoreCombobox(QComboBox *combo, const QString &value);
 //! Read image respecting exif orientation
 QImage
 readImage(const QByteArray *data);
+
+bool
+isReply(const mtx::events::collections::TimelineEvents &e);
 }

--- a/src/notifications/Manager.cpp
+++ b/src/notifications/Manager.cpp
@@ -24,7 +24,7 @@ NotificationsManager::cacheImage(const mtx::events::collections::TimelineEvents 
 
         http::client()->download(
           url,
-          [path, url, encryptionInfo](const std::string &data,
+          [&path, url, encryptionInfo](const std::string &data,
                                       const std::string &,
                                       const std::string &,
                                       mtx::http::RequestErr err) {
@@ -53,10 +53,11 @@ NotificationsManager::cacheImage(const mtx::events::collections::TimelineEvents 
                           // resize the image
                           QImage img{utils::readImage(QByteArray{temp.data()})};
 
-                          // make sure to save as PNG (because Plasma doesn't do JPEG in
-                          // notifications)
-                          //                          if (!file.fileName().endsWith(".png"))
-                          //                                  file.rename(file.fileName() + ".png");
+                          if (img.isNull())
+                          {
+                              path.clear();
+                              return;
+                          }
 
 #ifdef NHEKO_DBUS_SYS // the images in D-Bus notifications are to be 200x100 max
                           img.scaled(200, 100, Qt::KeepAspectRatio, Qt::SmoothTransformation)

--- a/src/notifications/Manager.cpp
+++ b/src/notifications/Manager.cpp
@@ -21,7 +21,7 @@ NotificationsManager::postNotification(const mtx::responses::Notification &notif
                 text =
                   "* " + sender + " " + formatNotification(utils::event_body(notification.event));
         else
-                text = sender + ":" + formatNotification(utils::event_body(notification.event));
+                text = sender + ": " + formatNotification(utils::event_body(notification.event));
 
         systemPostNotification(room_id, event_id, room_name, sender, text, icon);
 }

--- a/src/notifications/Manager.cpp
+++ b/src/notifications/Manager.cpp
@@ -1,0 +1,27 @@
+#include "notifications/Manager.h"
+
+#include "Cache.h"
+#include "EventAccessors.h"
+#include "Utils.h"
+#include <mtx/responses/notifications.hpp>
+
+void
+NotificationsManager::postNotification(const mtx::responses::Notification &notification,
+                                       const QImage &icon)
+{
+        const auto room_id  = QString::fromStdString(notification.room_id);
+        const auto event_id = QString::fromStdString(mtx::accessors::event_id(notification.event));
+        const auto room_name =
+          QString::fromStdString(cache::singleRoomInfo(notification.room_id).name);
+        const auto sender = cache::displayName(
+          room_id, QString::fromStdString(mtx::accessors::sender(notification.event)));
+
+        QString text;
+        if (mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Emote)
+                text =
+                  "* " + sender + " " + formatNotification(utils::event_body(notification.event));
+        else
+                text = sender + ":" + formatNotification(utils::event_body(notification.event));
+
+        systemPostNotification(room_id, event_id, room_name, sender, text, icon);
+}

--- a/src/notifications/Manager.cpp
+++ b/src/notifications/Manager.cpp
@@ -27,7 +27,7 @@ NotificationsManager::postNotification(const mtx::responses::Notification &notif
           ((mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Emote)
              ? "* " + sender + " "
              : sender + reply + ": ") +
-          formatNotification(mtx::accessors::formattedBodyWithFallback(notification.event));
+          formatNotification(notification.event);
 
         systemPostNotification(room_id, event_id, room_name, sender, text, icon);
 }

--- a/src/notifications/Manager.cpp
+++ b/src/notifications/Manager.cpp
@@ -16,14 +16,11 @@ NotificationsManager::postNotification(const mtx::responses::Notification &notif
         const auto sender = cache::displayName(
           room_id, QString::fromStdString(mtx::accessors::sender(notification.event)));
 
-        QString text;
-        if (mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Emote)
-                text =
-                  formatNotification("* " + sender + " " +
-                                     mtx::accessors::formattedBodyWithFallback(notification.event));
-        else
-                text = formatNotification(
-                  sender + ": " + mtx::accessors::formattedBodyWithFallback(notification.event));
+        QString text =
+          ((mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Emote)
+             ? "* " + sender + " "
+             : sender + ": ") +
+          formatNotification(mtx::accessors::formattedBodyWithFallback(notification.event));
 
         systemPostNotification(room_id, event_id, room_name, sender, text, icon);
 }

--- a/src/notifications/Manager.cpp
+++ b/src/notifications/Manager.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 Nheko Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #include "notifications/Manager.h"
 
 #include "Cache.h"

--- a/src/notifications/Manager.cpp
+++ b/src/notifications/Manager.cpp
@@ -49,22 +49,22 @@ NotificationsManager::cacheImage(const mtx::events::collections::TimelineEvents 
 
                           // delete any existing file content
                           file.resize(0);
-                          file.write(QByteArray(temp.data(), (int)temp.size()));
 
-                          // resize the image (really inefficient, I know, but I can't find any
-                          // better way right off
-                          QImage img{path};
-
-                          // delete existing contents
-                          file.resize(0);
+                          // resize the image
+                          QImage img{utils::readImage(QByteArray{temp.data()})};
 
                           // make sure to save as PNG (because Plasma doesn't do JPEG in
                           // notifications)
                           //                          if (!file.fileName().endsWith(".png"))
                           //                                  file.rename(file.fileName() + ".png");
 
+#ifdef NHEKO_DBUS_SYS // the images in D-Bus notifications are to be 200x100 max
                           img.scaled(200, 100, Qt::KeepAspectRatio, Qt::SmoothTransformation)
                             .save(&file);
+#else
+                          img.save(&file);
+#endif // NHEKO_DBUS_SYS
+
                           file.close();
 
                           return;

--- a/src/notifications/Manager.cpp
+++ b/src/notifications/Manager.cpp
@@ -17,10 +17,10 @@ NotificationsManager::postNotification(const mtx::responses::Notification &notif
           room_id, QString::fromStdString(mtx::accessors::sender(notification.event)));
 
         const QString reply = (utils::isReply(notification.event)
-                                 ? ""
-                                 : tr(" replied",
+                                 ? tr(" replied",
                                       "Used to denote that this message is a reply to another "
-                                      "message. Displayed as 'foo replied: message'."));
+                                      "message. Displayed as 'foo replied: message'.")
+                                 : "");
 
         // the "replied" is only added if this message is not an emote message
         QString text =

--- a/src/notifications/Manager.cpp
+++ b/src/notifications/Manager.cpp
@@ -2,89 +2,35 @@
 
 #include "Cache.h"
 #include "EventAccessors.h"
-#include "Logging.h"
-#include "MatrixClient.h"
 #include "Utils.h"
 
-#include <QFile>
-#include <QImage>
-#include <QStandardPaths>
-
-#include <mtxclient/crypto/client.hpp>
-
 QString
-NotificationsManager::cacheImage(const mtx::events::collections::TimelineEvents &event)
+NotificationsManager::getMessageTemplate(const mtx::responses::Notification &notification)
 {
-        const auto url      = mtx::accessors::url(event);
-        auto encryptionInfo = mtx::accessors::file(event);
+        const auto sender =
+          cache::displayName(QString::fromStdString(notification.room_id),
+                             QString::fromStdString(mtx::accessors::sender(notification.event)));
 
-        auto filename = QString::fromStdString(mtx::accessors::body(event));
-        QString path{QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/" +
-                     filename};
+        // TODO: decrypt this message if the decryption setting is on in the UserSettings
+        if (auto msg = std::get_if<mtx::events::EncryptedEvent<mtx::events::msg::Encrypted>>(
+              &notification.event);
+            msg != nullptr) {
+                return tr("%1 sent an encrypted message").arg(sender);
+        }
 
-        bool downloadComplete = false;
-
-        http::client()->download(
-          url,
-          [&downloadComplete, &path, url, encryptionInfo](const std::string &data,
-                                                          const std::string &,
-                                                          const std::string &,
-                                                          mtx::http::RequestErr err) {
-                  if (err) {
-                          nhlog::net()->warn("failed to retrieve image {}: {} {}",
-                                             url,
-                                             err->matrix_error.error,
-                                             static_cast<int>(err->status_code));
-                          // the image doesn't exist, so delete the path
-                          path.clear();
-                          downloadComplete = true;
-                          return;
-                  }
-
-                  try {
-                          auto temp = data;
-                          if (encryptionInfo)
-                                  temp = mtx::crypto::to_string(
-                                    mtx::crypto::decrypt_file(temp, encryptionInfo.value()));
-
-                          QFile file{path};
-
-                          if (!file.open(QIODevice::WriteOnly)) {
-                                  path.clear();
-                                  downloadComplete = true;
-                                  return;
-                          }
-
-                          // delete any existing file content
-                          file.resize(0);
-
-                          // resize the image
-                          QImage img{utils::readImage(QByteArray{temp.data()})};
-
-                          if (img.isNull()) {
-                                  path.clear();
-                                  downloadComplete = true;
-                                  return;
-                          }
-
-#ifdef NHEKO_DBUS_SYS // the images in D-Bus notifications are to be 200x100 max
-                          img.scaled(200, 100, Qt::KeepAspectRatio, Qt::SmoothTransformation)
-                            .save(&file);
-#else
-                          img.save(&file);
-#endif // NHEKO_DBUS_SYS
-
-                          file.close();
-
-                          downloadComplete = true;
-                          return;
-                  } catch (const std::exception &e) {
-                          nhlog::ui()->warn("Error while caching file to: {}", e.what());
-                  }
-          });
-
-        while (!downloadComplete)
-                continue;
-
-        return path.toHtmlEscaped();
+        if (mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Emote) {
+                return tr("* %1 %2",
+                          "Format an emote message in a notification, %1 is the sender, %2 the "
+                          "message")
+                  .arg(sender);
+        } else if (utils::isReply(notification.event)) {
+                return tr("%1 replied: %2",
+                          "Format a reply in a notification. %1 is the sender, %2 the message")
+                  .arg(sender);
+        } else {
+                return tr("%1: %2",
+                          "Format a normal message in a notification. %1 is the sender, %2 the "
+                          "message")
+                  .arg(sender);
+        }
 }

--- a/src/notifications/Manager.cpp
+++ b/src/notifications/Manager.cpp
@@ -19,9 +19,11 @@ NotificationsManager::postNotification(const mtx::responses::Notification &notif
         QString text;
         if (mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Emote)
                 text =
-                  "* " + sender + " " + formatNotification(utils::event_body(notification.event));
+                  formatNotification("* " + sender + " " +
+                                     mtx::accessors::formattedBodyWithFallback(notification.event));
         else
-                text = sender + ": " + formatNotification(utils::event_body(notification.event));
+                text = formatNotification(
+                  sender + ": " + mtx::accessors::formattedBodyWithFallback(notification.event));
 
         systemPostNotification(room_id, event_id, room_name, sender, text, icon);
 }

--- a/src/notifications/Manager.cpp
+++ b/src/notifications/Manager.cpp
@@ -16,10 +16,17 @@ NotificationsManager::postNotification(const mtx::responses::Notification &notif
         const auto sender = cache::displayName(
           room_id, QString::fromStdString(mtx::accessors::sender(notification.event)));
 
+        const QString reply = (utils::isReply(notification.event)
+                                 ? ""
+                                 : tr(" replied",
+                                      "Used to denote that this message is a reply to another "
+                                      "message. Displayed as 'foo replied: message'."));
+
+        // the "replied" is only added if this message is not an emote message
         QString text =
           ((mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Emote)
              ? "* " + sender + " "
-             : sender + ": ") +
+             : sender + reply + ": ") +
           formatNotification(mtx::accessors::formattedBodyWithFallback(notification.event));
 
         systemPostNotification(room_id, event_id, room_name, sender, text, icon);

--- a/src/notifications/Manager.h
+++ b/src/notifications/Manager.h
@@ -42,6 +42,16 @@ signals:
 public slots:
         void removeNotification(const QString &roomId, const QString &eventId);
 
+private:
+        void systemPostNotification(const QString &room_id,
+                                    const QString &event_id,
+                                    const QString &roomName,
+                                    const QString &sender,
+                                    const QString &text,
+                                    const QImage &icon);
+
+        QString formatNotification(const QString &text);
+
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(Q_OS_HAIKU)
 public:
         void closeNotifications(QString roomId);

--- a/src/notifications/Manager.h
+++ b/src/notifications/Manager.h
@@ -43,13 +43,14 @@ public:
 signals:
         void notificationClicked(const QString roomId, const QString eventId);
         void sendNotificationReply(const QString roomId, const QString eventId, const QString body);
+        void systemPostNotificationCb(const QString &room_id,
+                                      const QString &event_id,
+                                      const QString &roomName,
+                                      const QString &text,
+                                      const QImage &icon);
 
 public slots:
         void removeNotification(const QString &roomId, const QString &eventId);
-
-private:
-        QString cacheImage(const mtx::events::collections::TimelineEvents &event);
-        QString formatNotification(const mtx::responses::Notification &notification);
 
 #if defined(NHEKO_DBUS_SYS)
 public:
@@ -95,6 +96,9 @@ private slots:
         void actionInvoked(uint id, QString action);
         void notificationClosed(uint id, uint reason);
         void notificationReplied(uint id, QString reply);
+
+private:
+        QString getMessageTemplate(const mtx::responses::Notification &notification);
 };
 
 #if defined(NHEKO_DBUS_SYS)

--- a/src/notifications/Manager.h
+++ b/src/notifications/Manager.h
@@ -50,7 +50,7 @@ private:
                                     const QString &text,
                                     const QImage &icon);
 
-        QString formatNotification(const QString &text);
+        QString formatNotification(const mtx::events::collections::TimelineEvents &e);
 
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(Q_OS_HAIKU)
 public:

--- a/src/notifications/Manager.h
+++ b/src/notifications/Manager.h
@@ -79,9 +79,7 @@ private:
         void objCxxPostNotification(const QString &title,
                                     const QString &subtitle,
                                     const QString &informativeText,
-                                    const QImage *bodyImage);
-
-        QImage *getImgOrNullptr(const QString &path);
+                                    const QImage &bodyImage);
 #endif
 
 #if defined(Q_OS_WINDOWS)

--- a/src/notifications/Manager.h
+++ b/src/notifications/Manager.h
@@ -84,10 +84,9 @@ private:
 
 #if defined(Q_OS_WINDOWS)
 private:
-        void systemPostNotification(const QString &roomName,
-                                    const QString &sender,
-                                    const QString &text,
-                                    const QImage &icon);
+        void systemPostNotification(const QString &line1,
+                                    const QString &line2,
+                                    const QString &iconPath);
 #endif
 
         // these slots are platform specific (D-Bus only)

--- a/src/notifications/Manager.h
+++ b/src/notifications/Manager.h
@@ -80,6 +80,8 @@ private:
                                     const QString &subtitle,
                                     const QString &informativeText,
                                     const QImage *bodyImage);
+
+        QImage *getImgOrNullptr(const QString &path);
 #endif
 
 #if defined(Q_OS_WINDOWS)

--- a/src/notifications/ManagerLinux.cpp
+++ b/src/notifications/ManagerLinux.cpp
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2012 Roland Hieber <rohieb@rohieb.name>
+// SPDX-FileCopyrightText: 2021 Nheko Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #include "notifications/Manager.h"
 
 #include <QDBusConnection>

--- a/src/notifications/ManagerLinux.cpp
+++ b/src/notifications/ManagerLinux.cpp
@@ -154,11 +154,12 @@ NotificationsManager::notificationClosed(uint id, uint reason)
 QString
 NotificationsManager::formatNotification(const QString &text)
 {
-        static auto capabilites = dbus.call("GetCapabilites");
-        if (capabilites.arguments().contains("body-markup"))
-                return text;
-        else
-                return QTextDocumentFragment::fromHtml(text).toPlainText();
+        static auto capabilites = dbus.call("GetCapabilities").arguments();
+        for (auto x : capabilites)
+                if (x.toStringList().contains("body-markup"))
+                        return utils::markdownToHtml(text);
+
+        return QTextDocumentFragment::fromHtml(utils::markdownToHtml(text)).toPlainText();
 }
 
 /**

--- a/src/notifications/ManagerLinux.cpp
+++ b/src/notifications/ManagerLinux.cpp
@@ -11,6 +11,7 @@
 
 #include <functional>
 
+#include "EventAccessors.h"
 #include "Utils.h"
 
 NotificationsManager::NotificationsManager(QObject *parent)
@@ -161,7 +162,7 @@ NotificationsManager::notificationClosed(uint id, uint reason)
  * specified at https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/Markup/
  */
 QString
-NotificationsManager::formatNotification(const QString &text)
+NotificationsManager::formatNotification(const mtx::events::collections::TimelineEvents &e)
 {
         static const auto hasMarkup = std::invoke([this]() -> bool {
                 for (auto x : dbus.call("GetCapabilities").arguments())
@@ -169,14 +170,16 @@ NotificationsManager::formatNotification(const QString &text)
                                 return true;
                 return false;
         });
+
         if (hasMarkup)
-                return QString(text)
+                return mtx::accessors::formattedBodyWithFallback(e)
                   .replace("<em>", "<i>")
                   .replace("</em>", "</i>")
                   .replace("<strong>", "<b>")
                   .replace("</strong>", "</b>");
 
-        return QTextDocumentFragment::fromHtml(text).toPlainText();
+        return QTextDocumentFragment::fromHtml(mtx::accessors::formattedBodyWithFallback(e))
+          .toPlainText();
 }
 
 /**

--- a/src/notifications/ManagerLinux.cpp
+++ b/src/notifications/ManagerLinux.cpp
@@ -214,19 +214,18 @@ NotificationsManager::formatNotification(const mtx::responses::Notification &not
                  ": ");
 
         if (hasMarkup_) {
-                if (hasImages_ &&
-                    mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Image)
-                {
-                    QString imgPath = cacheImage(notification.event);
-                    if (imgPath.isNull())
-                        return mtx::accessors::formattedBodyWithFallback(notification.event).prepend(messageLeadIn);
-                    else
-                        return QString(
-                                 "<img src=\"file:///" + imgPath +
-                                 "\" alt=\"" +
-                                 mtx::accessors::formattedBodyWithFallback(notification.event) +
-                                 "\">")
-                          .prepend(messageLeadIn);
+                if (hasImages_ && mtx::accessors::msg_type(notification.event) ==
+                                    mtx::events::MessageType::Image) {
+                        QString imgPath = cacheImage(notification.event);
+                        if (imgPath.isNull())
+                                return mtx::accessors::formattedBodyWithFallback(notification.event)
+                                  .prepend(messageLeadIn);
+                        else
+                                return QString("<img src=\"file:///" + imgPath + "\" alt=\"" +
+                                               mtx::accessors::formattedBodyWithFallback(
+                                                 notification.event) +
+                                               "\">")
+                                  .prepend(messageLeadIn);
                 }
 
                 return mtx::accessors::formattedBodyWithFallback(notification.event)

--- a/src/notifications/ManagerLinux.cpp
+++ b/src/notifications/ManagerLinux.cpp
@@ -7,6 +7,7 @@
 #include <QDBusPendingReply>
 #include <QDebug>
 #include <QImage>
+#include <QRegularExpression>
 #include <QTextDocumentFragment>
 
 #include <functional>
@@ -176,9 +177,12 @@ NotificationsManager::formatNotification(const mtx::events::collections::Timelin
                   .replace("<em>", "<i>")
                   .replace("</em>", "</i>")
                   .replace("<strong>", "<b>")
-                  .replace("</strong>", "</b>");
+                  .replace("</strong>", "</b>")
+                  .replace(QRegularExpression("(<mx-reply>.+\\<\\/mx-reply\\>)"), "");
 
-        return QTextDocumentFragment::fromHtml(mtx::accessors::formattedBodyWithFallback(e))
+        return QTextDocumentFragment::fromHtml(
+                 mtx::accessors::formattedBodyWithFallback(e).replace(
+                   QRegularExpression("(<mx-reply>.+\\<\\/mx-reply\\>)"), ""))
           .toPlainText();
 }
 

--- a/src/notifications/ManagerLinux.cpp
+++ b/src/notifications/ManagerLinux.cpp
@@ -216,12 +216,18 @@ NotificationsManager::formatNotification(const mtx::responses::Notification &not
         if (hasMarkup_) {
                 if (hasImages_ &&
                     mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Image)
+                {
+                    QString imgPath = cacheImage(notification.event);
+                    if (imgPath.isNull())
+                        return mtx::accessors::formattedBodyWithFallback(notification.event).prepend(messageLeadIn);
+                    else
                         return QString(
-                                 "<img src=\"file:///" + cacheImage(notification.event) +
+                                 "<img src=\"file:///" + imgPath +
                                  "\" alt=\"" +
                                  mtx::accessors::formattedBodyWithFallback(notification.event) +
                                  "\">")
                           .prepend(messageLeadIn);
+                }
 
                 return mtx::accessors::formattedBodyWithFallback(notification.event)
                   .prepend(messageLeadIn)

--- a/src/notifications/ManagerLinux.cpp
+++ b/src/notifications/ManagerLinux.cpp
@@ -13,6 +13,7 @@
 #include "MatrixClient.h"
 #include "Utils.h"
 #include <mtx/responses/notifications.hpp>
+#include <cmark.h>
 
 NotificationsManager::NotificationsManager(QObject *parent)
   : QObject(parent)
@@ -58,6 +59,7 @@ NotificationsManager::postNotification(const mtx::responses::Notification &notif
         const auto sender   = cache::displayName(
           room_id, QString::fromStdString(mtx::accessors::sender(notification.event)));
         const auto text = utils::event_body(notification.event);
+        const auto formattedText = cmark_markdown_to_html(text.toStdString().c_str(), text.length(), CMARK_OPT_UNSAFE);
 
         QVariantMap hints;
         hints["image-data"] = icon;
@@ -71,9 +73,9 @@ NotificationsManager::postNotification(const mtx::responses::Notification &notif
 
         // body
         if (mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Emote)
-                argumentList << "* " + sender + " " + text;
+                argumentList << "* " + sender + " " + formattedText;
         else
-                argumentList << sender + ": " + text;
+                argumentList << sender + ": " + formattedText;
 
         // The list of actions has always the action name and then a localized version of that
         // action. Currently we just use an empty string for that.

--- a/src/notifications/ManagerLinux.cpp
+++ b/src/notifications/ManagerLinux.cpp
@@ -156,9 +156,9 @@ NotificationsManager::formatNotification(const QString &text)
 {
         static auto capabilites = dbus.call("GetCapabilites");
         if (capabilites.arguments().contains("body-markup"))
-                return utils::markdownToHtml(text);
+                return text;
         else
-                return QTextDocumentFragment::fromHtml(utils::markdownToHtml(text)).toPlainText();
+                return QTextDocumentFragment::fromHtml(text).toPlainText();
 }
 
 /**

--- a/src/notifications/ManagerLinux.cpp
+++ b/src/notifications/ManagerLinux.cpp
@@ -151,15 +151,26 @@ NotificationsManager::notificationClosed(uint id, uint reason)
         notificationIds.remove(id);
 }
 
+/**
+ * @param text This should be an HTML-formatted string.
+ *
+ * If D-Bus says that notifications can have body markup, this function will
+ * automatically format the notification to follow the supported HTML subset
+ * specified at https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/Markup/
+ */
 QString
 NotificationsManager::formatNotification(const QString &text)
 {
         static auto capabilites = dbus.call("GetCapabilities").arguments();
         for (auto x : capabilites)
                 if (x.toStringList().contains("body-markup"))
-                        return utils::markdownToHtml(text);
+                        return QString(text)
+                          .replace("<em>", "<i>")
+                          .replace("</em>", "</i>")
+                          .replace("<strong>", "<b>")
+                          .replace("</strong>", "</b>");
 
-        return QTextDocumentFragment::fromHtml(utils::markdownToHtml(text)).toPlainText();
+        return QTextDocumentFragment::fromHtml(text).toPlainText();
 }
 
 /**

--- a/src/notifications/ManagerLinux.cpp
+++ b/src/notifications/ManagerLinux.cpp
@@ -234,7 +234,7 @@ NotificationsManager::formatNotification(const mtx::responses::Notification &not
 
         return QTextDocumentFragment::fromHtml(
                  mtx::accessors::formattedBodyWithFallback(notification.event)
-                   .replace(QRegularExpression("(<mx-reply>.+\\<\\/mx-reply\\>)"), ""))
+                   .replace(QRegularExpression("<mx-reply>.+</mx-reply>"), ""))
           .toPlainText()
           .prepend(messageLeadIn);
 }

--- a/src/notifications/ManagerLinux.cpp
+++ b/src/notifications/ManagerLinux.cpp
@@ -11,6 +11,7 @@
 #include <QTextDocumentFragment>
 
 #include <functional>
+#include <variant>
 
 #include <mtx/responses/notifications.hpp>
 
@@ -194,6 +195,13 @@ NotificationsManager::formatNotification(const mtx::responses::Notification &not
         const auto sender =
           cache::displayName(QString::fromStdString(notification.room_id),
                              QString::fromStdString(mtx::accessors::sender(notification.event)));
+
+        // TODO: decrypt this message if the decryption setting is on in the UserSettings
+        if (auto msg = std::get_if<mtx::events::EncryptedEvent<mtx::events::msg::Encrypted>>(
+              &notification.event);
+            msg != nullptr)
+                return tr("%1 sent an encrypted message").arg(sender);
+
         const auto messageLeadIn =
           ((mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Emote)
              ? "* " + sender + " "

--- a/src/notifications/ManagerMac.cpp
+++ b/src/notifications/ManagerMac.cpp
@@ -65,10 +65,7 @@ NotificationsManager::postNotification(const mtx::responses::Notification &notif
 QImage *
 NotificationsManager::getImgOrNullptr(const QString &path)
 {
-        auto img = new QImage{path};
-        if (img->isNull()) {
-                delete img;
+        if (QFile::exists(path))
                 return nullptr;
-        }
-        return img;
+        return new QImage{path};
 }

--- a/src/notifications/ManagerMac.cpp
+++ b/src/notifications/ManagerMac.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2021 Nheko Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #include "Manager.h"
 
 #include <QRegularExpression>

--- a/src/notifications/ManagerMac.cpp
+++ b/src/notifications/ManagerMac.cpp
@@ -58,6 +58,6 @@ NotificationsManager::postNotification(const mtx::responses::Notification &notif
                 const QString messageInfo =
                   (isReply ? tr("%1 replied to a message") : tr("%1 sent a message")).arg(sender);
                 objCxxPostNotification(
-                  room_name, messageInfo, formatNotification(notification), image);
+                  room_name, messageInfo, formatNotification(notification), (image != nullptr && !image->isNull()) ? image : nullptr);
         }
 }

--- a/src/notifications/ManagerMac.cpp
+++ b/src/notifications/ManagerMac.cpp
@@ -39,9 +39,9 @@ NotificationsManager::postNotification(const mtx::responses::Notification &notif
           cache::displayName(QString::fromStdString(notification.room_id),
                              QString::fromStdString(mtx::accessors::sender(notification.event)));
 
-        QImage *image = nullptr;
+        QImage image;
         if (mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Image)
-                image = getImgOrNullptr(cacheImage(notification.event));
+                image = QImage{cacheImage(notification.event)};
 
         const auto isEncrypted =
           std::get_if<mtx::events::EncryptedEvent<mtx::events::msg::Encrypted>>(
@@ -60,12 +60,4 @@ NotificationsManager::postNotification(const mtx::responses::Notification &notif
                 objCxxPostNotification(
                   room_name, messageInfo, formatNotification(notification), image);
         }
-}
-
-QImage *
-NotificationsManager::getImgOrNullptr(const QString &path)
-{
-        if (QFile::exists(path))
-                return nullptr;
-        return new QImage{path};
 }

--- a/src/notifications/ManagerMac.cpp
+++ b/src/notifications/ManagerMac.cpp
@@ -7,5 +7,5 @@
 QString
 NotificationsManager::formatNotification(const QString &text)
 {
-        return QTextDocumentFragment::fromHtml(utils::markdownToHtml(text)).toPlainText();
+        return QTextDocumentFragment::fromHtml(text).toPlainText();
 }

--- a/src/notifications/ManagerMac.cpp
+++ b/src/notifications/ManagerMac.cpp
@@ -1,5 +1,6 @@
 #include "Manager.h"
 
+#include <QRegularExpression>
 #include <QTextDocumentFragment>
 
 #include "EventAccessors.h"
@@ -8,5 +9,8 @@
 QString
 NotificationsManager::formatNotification(const mtx::events::collections::TimelineEvents &e)
 {
-        return QTextDocumentFragment::fromHtml(mtx::accessors::formattedBodyWithFallback(e)).toPlainText();
+        return QTextDocumentFragment::fromHtml(
+                 mtx::accessors::formattedBodyWithFallback(e).replace(
+                   QRegularExpression("(<mx-reply>.+\\<\\/mx-reply\\>)"), ""))
+          .toPlainText();
 }

--- a/src/notifications/ManagerMac.cpp
+++ b/src/notifications/ManagerMac.cpp
@@ -7,5 +7,5 @@
 QString
 NotificationsManager::formatNotification(const QString &text)
 {
-        return utils::markdownToHtml(text);
+        return QTextDocumentFragment::fromHtml(utils::markdownToHtml(text)).toPlainText();
 }

--- a/src/notifications/ManagerMac.cpp
+++ b/src/notifications/ManagerMac.cpp
@@ -3,14 +3,56 @@
 #include <QRegularExpression>
 #include <QTextDocumentFragment>
 
+#include "Cache.h"
 #include "EventAccessors.h"
 #include "Utils.h"
 
+#include <mtx/responses/notifications.hpp>
+
 QString
-NotificationsManager::formatNotification(const mtx::events::collections::TimelineEvents &e)
+NotificationsManager::formatNotification(const mtx::responses::Notification &notification)
 {
+        const auto sender =
+          cache::displayName(QString::fromStdString(notification.room_id),
+                             QString::fromStdString(mtx::accessors::sender(notification.event)));
+
         return QTextDocumentFragment::fromHtml(
-                 mtx::accessors::formattedBodyWithFallback(e).replace(
-                   QRegularExpression("(<mx-reply>.+\\<\\/mx-reply\\>)"), ""))
-          .toPlainText();
+                 mtx::accessors::formattedBodyWithFallback(notification.event)
+                   .replace(QRegularExpression("(<mx-reply>.+\\<\\/mx-reply\\>)"), ""))
+          .toPlainText()
+          .prepend((mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Emote)
+                     ? "* " + sender + " "
+                     : "");
+}
+
+void
+NotificationsManager::postNotification(const mtx::responses::Notification &notification,
+                                       const QImage &icon)
+{
+        Q_UNUSED(icon)
+
+        const auto room_name =
+          QString::fromStdString(cache::singleRoomInfo(notification.room_id).name);
+        const auto sender =
+          cache::displayName(QString::fromStdString(notification.room_id),
+                             QString::fromStdString(mtx::accessors::sender(notification.event)));
+
+        const QString messageInfo =
+          QString("%1 %2 a message")
+            .arg(sender)
+            .arg((utils::isReply(notification.event)
+                    ? tr("replied to",
+                         "Used to denote that this message is a reply to another "
+                         "message. Displayed as 'foo replied to a message'.")
+                    : tr("sent",
+                         "Used to denote that this message is a normal message. Displayed as 'foo "
+                         "sent a message'.")));
+
+        QString text = formatNotification(notification);
+
+        QImage *image = nullptr;
+        if (mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Image)
+                image = new QImage{cacheImage(notification.event)};
+
+        objCxxPostNotification(room_name, messageInfo, text, image);
 }

--- a/src/notifications/ManagerMac.cpp
+++ b/src/notifications/ManagerMac.cpp
@@ -1,0 +1,11 @@
+#include "Manager.h"
+
+#include <QTextDocumentFragment>
+
+#include "Utils.h"
+
+QString
+NotificationsManager::formatNotification(const QString &text)
+{
+        return utils::markdownToHtml(text);
+}

--- a/src/notifications/ManagerMac.cpp
+++ b/src/notifications/ManagerMac.cpp
@@ -20,7 +20,7 @@ NotificationsManager::formatNotification(const mtx::responses::Notification &not
 
         return QTextDocumentFragment::fromHtml(
                  mtx::accessors::formattedBodyWithFallback(notification.event)
-                   .replace(QRegularExpression("(<mx-reply>.+\\<\\/mx-reply\\>)"), ""))
+                   .replace(QRegularExpression("<mx-reply>.+</mx-reply>"), ""))
           .toPlainText()
           .prepend((mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Emote)
                      ? "* " + sender + " "

--- a/src/notifications/ManagerMac.cpp
+++ b/src/notifications/ManagerMac.cpp
@@ -41,7 +41,7 @@ NotificationsManager::postNotification(const mtx::responses::Notification &notif
 
         QImage *image = nullptr;
         if (mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Image)
-                image = new QImage{cacheImage(notification.event)};
+                image = getImgOrNullptr(cacheImage(notification.event));
 
         const auto isEncrypted =
           std::get_if<mtx::events::EncryptedEvent<mtx::events::msg::Encrypted>>(
@@ -58,6 +58,17 @@ NotificationsManager::postNotification(const mtx::responses::Notification &notif
                 const QString messageInfo =
                   (isReply ? tr("%1 replied to a message") : tr("%1 sent a message")).arg(sender);
                 objCxxPostNotification(
-                  room_name, messageInfo, formatNotification(notification), (image != nullptr && !image->isNull()) ? image : nullptr);
+                  room_name, messageInfo, formatNotification(notification), image);
         }
+}
+
+QImage *
+NotificationsManager::getImgOrNullptr(const QString &path)
+{
+        auto img = new QImage{path};
+        if (img->isNull()) {
+                delete img;
+                return nullptr;
+        }
+        return img;
 }

--- a/src/notifications/ManagerMac.cpp
+++ b/src/notifications/ManagerMac.cpp
@@ -5,6 +5,7 @@
 
 #include "Cache.h"
 #include "EventAccessors.h"
+#include "MxcImageProvider.h"
 #include "Utils.h"
 
 #include <mtx/responses/notifications.hpp>
@@ -14,17 +15,7 @@
 QString
 NotificationsManager::formatNotification(const mtx::responses::Notification &notification)
 {
-        const auto sender =
-          cache::displayName(QString::fromStdString(notification.room_id),
-                             QString::fromStdString(mtx::accessors::sender(notification.event)));
-
-        return QTextDocumentFragment::fromHtml(
-                 mtx::accessors::formattedBodyWithFallback(notification.event)
-                   .replace(QRegularExpression("<mx-reply>.+</mx-reply>"), ""))
-          .toPlainText()
-          .prepend((mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Emote)
-                     ? "* " + sender + " "
-                     : "");
+        return utils::stripReplyFallbacks(notification.event, {}, {}).quoted_body;
 }
 
 void
@@ -39,25 +30,33 @@ NotificationsManager::postNotification(const mtx::responses::Notification &notif
           cache::displayName(QString::fromStdString(notification.room_id),
                              QString::fromStdString(mtx::accessors::sender(notification.event)));
 
-        QImage image;
-        if (mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Image)
-                image = QImage{cacheImage(notification.event)};
-
         const auto isEncrypted =
           std::get_if<mtx::events::EncryptedEvent<mtx::events::msg::Encrypted>>(
             &notification.event) != nullptr;
         const auto isReply = utils::isReply(notification.event);
-
         if (isEncrypted) {
                 // TODO: decrypt this message if the decryption setting is on in the UserSettings
                 const QString messageInfo = (isReply ? tr("%1 replied with an encrypted message")
                                                      : tr("%1 sent an encrypted message"))
                                               .arg(sender);
-                objCxxPostNotification(room_name, messageInfo, "", image);
+                objCxxPostNotification(room_name, messageInfo, "", QImage());
         } else {
                 const QString messageInfo =
                   (isReply ? tr("%1 replied to a message") : tr("%1 sent a message")).arg(sender);
-                objCxxPostNotification(
-                  room_name, messageInfo, formatNotification(notification), image);
+                if (mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Image)
+                        MxcImageProvider::download(
+                          QString::fromStdString(mtx::accessors::url(notification.event))
+                            .remove("mxc://"),
+                          QSize(200, 80),
+                          [this, notification, room_name, messageInfo](
+                            QString, QSize, QImage image, QString) {
+                                  objCxxPostNotification(room_name,
+                                                         messageInfo,
+                                                         formatNotification(notification),
+                                                         image);
+                          });
+                else
+                        objCxxPostNotification(
+                          room_name, messageInfo, formatNotification(notification), QImage());
         }
 }

--- a/src/notifications/ManagerMac.cpp
+++ b/src/notifications/ManagerMac.cpp
@@ -2,10 +2,11 @@
 
 #include <QTextDocumentFragment>
 
+#include "EventAccessors.h"
 #include "Utils.h"
 
 QString
-NotificationsManager::formatNotification(const QString &text)
+NotificationsManager::formatNotification(const mtx::events::collections::TimelineEvents &e)
 {
-        return QTextDocumentFragment::fromHtml(text).toPlainText();
+        return QTextDocumentFragment::fromHtml(mtx::accessors::formattedBodyWithFallback(e)).toPlainText();
 }

--- a/src/notifications/ManagerMac.cpp
+++ b/src/notifications/ManagerMac.cpp
@@ -16,8 +16,8 @@
 
 #include <variant>
 
-QString
-NotificationsManager::formatNotification(const mtx::responses::Notification &notification)
+static QString
+formatNotification(const mtx::responses::Notification &notification)
 {
         return utils::stripReplyFallbacks(notification.event, {}, {}).quoted_body;
 }

--- a/src/notifications/ManagerMac.mm
+++ b/src/notifications/ManagerMac.mm
@@ -8,6 +8,7 @@
 #include "MatrixClient.h"
 #include "Utils.h"
 #include <mtx/responses/notifications.hpp>
+#include <cmark.h>
 
 @interface NSUserNotification (CFIPrivate)
 - (void)set_identityImage:(NSImage *)image;
@@ -26,15 +27,16 @@ NotificationsManager::postNotification(const mtx::responses::Notification &notif
 
     const auto sender   = cache::displayName(QString::fromStdString(notification.room_id), QString::fromStdString(mtx::accessors::sender(notification.event)));
     const auto text     = utils::event_body(notification.event);
+    const auto formattedText = cmark_markdown_to_html(text.toStdString().c_str(), text.length(), CMARK_OPT_UNSAFE);
 
     NSUserNotification * notif = [[NSUserNotification alloc] init];
 
     notif.title           = QString::fromStdString(cache::singleRoomInfo(notification.room_id).name).toNSString();
     notif.subtitle        = QString("%1 sent a message").arg(sender).toNSString();
     if (mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Emote)
-            notif.informativeText = QString("* ").append(sender).append(" ").append(text).toNSString();
+            notif.informativeText = QString("* ").append(sender).append(" ").append(formattedText).toNSString();
     else
-            notif.informativeText = text.toNSString();
+            notif.informativeText = formattedText.toNSString();
     notif.soundName       = NSUserNotificationDefaultSoundName;
 
     [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification: notif];

--- a/src/notifications/ManagerMac.mm
+++ b/src/notifications/ManagerMac.mm
@@ -19,7 +19,7 @@ void
 NotificationsManager::objCxxPostNotification(const QString &title,
                                              const QString &subtitle,
                                              const QString &informativeText,
-                                             const QImage *bodyImage)
+                                             const QImage &bodyImage)
 {
 
     NSUserNotification *notif = [[NSUserNotification alloc] init];
@@ -29,8 +29,8 @@ NotificationsManager::objCxxPostNotification(const QString &title,
     notif.informativeText = informativeText.toNSString();
     notif.soundName       = NSUserNotificationDefaultSoundName;
 
-    if (bodyImage != nullptr)
-        notif.contentImage = [[NSImage alloc] initWithCGImage: bodyImage->toCGImage() size: NSZeroSize];
+    if (!bodyImage.isNull())
+        notif.contentImage = [[NSImage alloc] initWithCGImage: bodyImage.toCGImage() size: NSZeroSize];
 
     [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification: notif];
     [notif autorelease];

--- a/src/notifications/ManagerMac.mm
+++ b/src/notifications/ManagerMac.mm
@@ -3,13 +3,6 @@
 #include <Foundation/Foundation.h>
 #include <QtMac>
 
-#include "Cache.h"
-#include "EventAccessors.h"
-#include "MatrixClient.h"
-#include "Utils.h"
-#include <mtx/responses/notifications.hpp>
-#include <cmark.h>
-
 @interface NSUserNotification (CFIPrivate)
 - (void)set_identityImage:(NSImage *)image;
 @end
@@ -20,23 +13,22 @@ NotificationsManager::NotificationsManager(QObject *parent): QObject(parent)
 }
 
 void
-NotificationsManager::postNotification(const mtx::responses::Notification &notification,
-                                       const QImage &icon)
+NotificationsManager::systemPostNotification(const QString &room_id,
+                                             const QString &event_id,
+                                             const QString &roomName,
+                                             const QString &sender,
+                                             const QString &text,
+                                             const QImage &icon)
 {
-    Q_UNUSED(icon);
-
-    const auto sender   = cache::displayName(QString::fromStdString(notification.room_id), QString::fromStdString(mtx::accessors::sender(notification.event)));
-    const auto text     = utils::event_body(notification.event);
-    const auto formattedText = cmark_markdown_to_html(text.toStdString().c_str(), text.length(), CMARK_OPT_UNSAFE);
+    Q_UNUSED(room_id)
+    Q_UNUSED(event_id)
+    Q_UNUSED(icon)
 
     NSUserNotification * notif = [[NSUserNotification alloc] init];
 
-    notif.title           = QString::fromStdString(cache::singleRoomInfo(notification.room_id).name).toNSString();
+    notif.title           = roomName.toNSString();
     notif.subtitle        = QString("%1 sent a message").arg(sender).toNSString();
-    if (mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Emote)
-            notif.informativeText = QString("* ").append(sender).append(" ").append(formattedText).toNSString();
-    else
-            notif.informativeText = formattedText.toNSString();
+    notif.informativeText = text.toNSString();
     notif.soundName       = NSUserNotificationDefaultSoundName;
 
     [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification: notif];

--- a/src/notifications/ManagerMac.mm
+++ b/src/notifications/ManagerMac.mm
@@ -1,7 +1,10 @@
 #include "notifications/Manager.h"
 
-#include <Foundation/Foundation.h>
+#import <Foundation/Foundation.h>
+#import <AppKit/NSImage.h>
+
 #include <QtMac>
+#include <QImage>
 
 @interface NSUserNotification (CFIPrivate)
 - (void)set_identityImage:(NSImage *)image;
@@ -13,23 +16,21 @@ NotificationsManager::NotificationsManager(QObject *parent): QObject(parent)
 }
 
 void
-NotificationsManager::systemPostNotification(const QString &room_id,
-                                             const QString &event_id,
-                                             const QString &roomName,
-                                             const QString &sender,
-                                             const QString &text,
-                                             const QImage &icon)
+NotificationsManager::objCxxPostNotification(const QString &title,
+                                             const QString &subtitle,
+                                             const QString &informativeText,
+                                             const QImage *bodyImage)
 {
-    Q_UNUSED(room_id)
-    Q_UNUSED(event_id)
-    Q_UNUSED(icon)
 
-    NSUserNotification * notif = [[NSUserNotification alloc] init];
+    NSUserNotification *notif = [[NSUserNotification alloc] init];
 
-    notif.title           = roomName.toNSString();
-    notif.subtitle        = QString("%1 sent a message").arg(sender).toNSString();
-    notif.informativeText = text.toNSString();
+    notif.title           = title.toNSString();
+    notif.subtitle        = subtitle.toNSString();
+    notif.informativeText = informativeText.toNSString();
     notif.soundName       = NSUserNotificationDefaultSoundName;
+
+    if (bodyImage != nullptr)
+        notif.contentImage = [[NSImage alloc] initWithCGImage: bodyImage->toCGImage() size: NSZeroSize];
 
     [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification: notif];
     [notif autorelease];
@@ -39,7 +40,7 @@ NotificationsManager::systemPostNotification(const QString &room_id,
 void
 NotificationsManager::actionInvoked(uint, QString)
 {
-    }
+}
 
 void
 NotificationsManager::notificationReplied(uint, QString)

--- a/src/notifications/ManagerWin.cpp
+++ b/src/notifications/ManagerWin.cpp
@@ -79,5 +79,5 @@ NotificationsManager::removeNotification(const QString &, const QString &)
 QString
 NotificationsManager::formatNotification(const QString &text)
 {
-        return QTextDocumentFragment::fromHtml(utils::markdownToHtml(text)).toPlainText();
+        return QTextDocumentFragment::fromHtml(text).toPlainText();
 }

--- a/src/notifications/ManagerWin.cpp
+++ b/src/notifications/ManagerWin.cpp
@@ -5,6 +5,8 @@
 #include "notifications/Manager.h"
 #include "wintoastlib.h"
 
+#include <QTextDocumentFragment>
+
 #include "Cache.h"
 #include "EventAccessors.h"
 #include "MatrixClient.h"
@@ -54,7 +56,7 @@ NotificationsManager::postNotification(const mtx::responses::Notification &notif
           cache::displayName(QString::fromStdString(notification.room_id),
                              QString::fromStdString(mtx::accessors::sender(notification.event)));
         const auto text = utils::event_body(notification.event);
-        const auto formattedText = cmark_markdown_to_html(text.toStdString().c_str(), text.length(), CMARK_OPT_UNSAFE);
+        const auto formattedText = QTextDocumentFragment::fromHtml(utils::markdownToHtml(text)).toPlainText();
 
         if (!isInitialized)
                 init();

--- a/src/notifications/ManagerWin.cpp
+++ b/src/notifications/ManagerWin.cpp
@@ -60,11 +60,23 @@ NotificationsManager::postNotification(const mtx::responses::Notification &notif
             &notification.event) != nullptr;
         const auto isReply = utils::isReply(notification.event);
 
+        auto formatNotification = [this, notification, sender] {
+                const auto template_ = getMessageTemplate(notification);
+                if (std::holds_alternative<
+                      mtx::events::EncryptedEvent<mtx::events::msg::Encrypted>>(
+                      notification.event)) {
+                        return template_;
+                }
+
+                return template_.arg(
+                  utils::stripReplyFallbacks(notification.event, {}, {}).quoted_body);
+        };
+
         const auto line1 =
           (room_name == sender) ? sender : QString("%1 - %2").arg(sender).arg(room_name);
         const auto line2 = (isEncrypted ? (isReply ? tr("%1 replied with an encrypted message")
                                                    : tr("%1 sent an encrypted message"))
-                                        : formatNotification(notification));
+                                        : formatNotification());
 
         auto iconPath = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) +
                         room_name + "-room-avatar.png";
@@ -100,19 +112,3 @@ void NotificationsManager::notificationClosed(uint, uint) {}
 void
 NotificationsManager::removeNotification(const QString &, const QString &)
 {}
-
-QString
-NotificationsManager::formatNotification(const mtx::responses::Notification &notification)
-{
-        const auto sender =
-          cache::displayName(QString::fromStdString(notification.room_id),
-                             QString::fromStdString(mtx::accessors::sender(notification.event)));
-
-        const auto template_ = getMessageTemplate(notification);
-        if (std::holds_alternative<mtx::events::EncryptedEvent<mtx::events::msg::Encrypted>>(
-              notification.event)) {
-                return template_;
-        }
-
-        return template_.arg(utils::stripReplyFallbacks(notification.event, {}, {}).quoted_body);
-}

--- a/src/notifications/ManagerWin.cpp
+++ b/src/notifications/ManagerWin.cpp
@@ -10,6 +10,7 @@
 #include "MatrixClient.h"
 #include "Utils.h"
 #include <mtx/responses/notifications.hpp>
+#include <cmark.h>
 
 using namespace WinToastLib;
 
@@ -53,6 +54,7 @@ NotificationsManager::postNotification(const mtx::responses::Notification &notif
           cache::displayName(QString::fromStdString(notification.room_id),
                              QString::fromStdString(mtx::accessors::sender(notification.event)));
         const auto text = utils::event_body(notification.event);
+        const auto formattedText = cmark_markdown_to_html(text.toStdString().c_str(), text.length(), CMARK_OPT_UNSAFE);
 
         if (!isInitialized)
                 init();
@@ -66,10 +68,10 @@ NotificationsManager::postNotification(const mtx::responses::Notification &notif
                                    WinToastTemplate::FirstLine);
         if (mtx::accessors::msg_type(notification.event) == mtx::events::MessageType::Emote)
                 templ.setTextField(
-                  QString("* ").append(sender).append(" ").append(text).toStdWString(),
+                  QString("* ").append(sender).append(" ").append(formattedText).toStdWString(),
                   WinToastTemplate::SecondLine);
         else
-                templ.setTextField(QString("%1").arg(text).toStdWString(),
+                templ.setTextField(QString("%1").arg(formattedText).toStdWString(),
                                    WinToastTemplate::SecondLine);
         // TODO: implement room or user avatar
         // templ.setImagePath(L"C:/example.png");

--- a/src/notifications/ManagerWin.cpp
+++ b/src/notifications/ManagerWin.cpp
@@ -7,6 +7,7 @@
 
 #include <QTextDocumentFragment>
 
+#include "EventAccessors.h"
 #include "Utils.h"
 
 using namespace WinToastLib;
@@ -77,7 +78,8 @@ NotificationsManager::removeNotification(const QString &, const QString &)
 {}
 
 QString
-NotificationsManager::formatNotification(const QString &text)
+NotificationsManager::formatNotification(const mtx::events::collections::TimelineEvents &e)
 {
-        return QTextDocumentFragment::fromHtml(text).toPlainText();
+        return QTextDocumentFragment::fromHtml(mtx::accessors::formattedBodyWithFallback(e)).toPlainText();
 }
+

--- a/src/notifications/ManagerWin.cpp
+++ b/src/notifications/ManagerWin.cpp
@@ -5,6 +5,7 @@
 #include "notifications/Manager.h"
 #include "wintoastlib.h"
 
+#include <QRegularExpression>
 #include <QTextDocumentFragment>
 
 #include "EventAccessors.h"
@@ -80,6 +81,8 @@ NotificationsManager::removeNotification(const QString &, const QString &)
 QString
 NotificationsManager::formatNotification(const mtx::events::collections::TimelineEvents &e)
 {
-        return QTextDocumentFragment::fromHtml(mtx::accessors::formattedBodyWithFallback(e)).toPlainText();
+        return QTextDocumentFragment::fromHtml(
+                 mtx::accessors::formattedBodyWithFallback(e).replace(
+                   QRegularExpression("(<mx-reply>.+\\<\\/mx-reply\\>)"), ""))
+          .toPlainText();
 }
-

--- a/src/notifications/ManagerWin.cpp
+++ b/src/notifications/ManagerWin.cpp
@@ -121,7 +121,7 @@ NotificationsManager::formatNotification(const mtx::responses::Notification &not
 
         return QTextDocumentFragment::fromHtml(
                  mtx::accessors::formattedBodyWithFallback(notification.event)
-                   .replace(QRegularExpression("(<mx-reply>.+\\<\\/mx-reply\\>)"), ""))
+                   .replace(QRegularExpression("<mx-reply>.+</mx-reply>"), ""))
           .toPlainText()
           .prepend(messageLeadIn);
 }

--- a/src/timeline/InputBar.cpp
+++ b/src/timeline/InputBar.cpp
@@ -303,8 +303,8 @@ InputBar::message(QString msg, MarkdownOverride useMarkdown)
                 // NOTE(Nico): rich replies always need a formatted_body!
                 text.format = "org.matrix.custom.html";
                 if ((ChatPage::instance()->userSettings()->markdown() &&
-                        useMarkdown == MarkdownOverride::NOT_SPECIFIED) ||
-                       useMarkdown == MarkdownOverride::ON)
+                     useMarkdown == MarkdownOverride::NOT_SPECIFIED) ||
+                    useMarkdown == MarkdownOverride::ON)
                         text.formatted_body =
                           utils::getFormattedQuoteBody(related, utils::markdownToHtml(msg))
                             .toStdString();

--- a/src/timeline/InputBar.cpp
+++ b/src/timeline/InputBar.cpp
@@ -302,7 +302,9 @@ InputBar::message(QString msg, MarkdownOverride useMarkdown)
 
                 // NOTE(Nico): rich replies always need a formatted_body!
                 text.format = "org.matrix.custom.html";
-                if (ChatPage::instance()->userSettings()->markdown())
+                if ((ChatPage::instance()->userSettings()->markdown() &&
+                        useMarkdown == MarkdownOverride::NOT_SPECIFIED) ||
+                       useMarkdown == MarkdownOverride::ON)
                         text.formatted_body =
                           utils::getFormattedQuoteBody(related, utils::markdownToHtml(msg))
                             .toStdString();

--- a/src/timeline/InputBar.cpp
+++ b/src/timeline/InputBar.cpp
@@ -574,7 +574,7 @@ InputBar::showPreview(const QMimeData &source, QString path, const QStringList &
                   auto mimeClass = mime.split("/")[0];
                   nhlog::ui()->debug("Mime: {}", mime.toStdString());
                   if (mimeClass == "image") {
-                          QImage img = utils::readImage(&data);
+                          QImage img = utils::readImage(data);
 
                           dimensions = img.size();
                           if (img.height() > 200 && img.width() > 360)

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -870,30 +870,7 @@ TimelineModel::relatedInfo(QString id)
         if (!event)
                 return {};
 
-        RelatedInfo related   = {};
-        related.quoted_user   = QString::fromStdString(mtx::accessors::sender(*event));
-        related.related_event = id.toStdString();
-        related.type          = mtx::accessors::msg_type(*event);
-
-        // get body, strip reply fallback, then transform the event to text, if it is a media event
-        // etc
-        related.quoted_body = QString::fromStdString(mtx::accessors::body(*event));
-        QRegularExpression plainQuote("^>.*?$\n?", QRegularExpression::MultilineOption);
-        while (related.quoted_body.startsWith(">"))
-                related.quoted_body.remove(plainQuote);
-        if (related.quoted_body.startsWith("\n"))
-                related.quoted_body.remove(0, 1);
-        related.quoted_body = utils::getQuoteBody(related);
-        related.quoted_body.replace("@room", QString::fromUtf8("@\u2060room"));
-
-        // get quoted body and strip reply fallback
-        related.quoted_formatted_body = mtx::accessors::formattedBodyWithFallback(*event);
-        related.quoted_formatted_body.remove(QRegularExpression(
-          "<mx-reply>.*</mx-reply>", QRegularExpression::DotMatchesEverythingOption));
-        related.quoted_formatted_body.replace("@room", "@\u2060aroom");
-        related.room = room_id_;
-
-        return related;
+        return utils::stripReplyFallbacks(*event, id.toStdString(), room_id_);
 }
 
 void

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -369,7 +369,7 @@ TimelineModel::data(const mtx::events::collections::TimelineEvents &event, int r
 
                 auto ascent = QFontMetrics(UserSettings::instance()->font()).ascent();
 
-                bool isReply = relations(event).reply_to().has_value();
+                bool isReply = utils::isReply(event);
 
                 auto formattedBody_ = QString::fromStdString(formatted_body(event));
                 if (formattedBody_.isEmpty()) {


### PR DESCRIPTION
I've tested this on KDE Plasma, and it works to a certain extent (meaning that while the message doesn't actually get rendered with bold and italics, it does at least remove the Markdown symbols from the notification, which makes replies completely visible instead of showing "sender: >"). However, I'd like confirmation that this works properly on Windows, macOS, and possibly other Linux DEs/WMs.