### PR TITLE
Fix room leaving related bugs and few minor bugs

### DIFF
--- a/src/CommunitiesList.cpp
+++ b/src/CommunitiesList.cpp
@@ -65,6 +65,7 @@ CommunitiesList::setCommunities(const mtx::responses::JoinedGroups &response)
                 addCommunity(group);
 
         communities_["world"]->setPressedState(true);
+        selectedCommunity_ = "world";
         emit communityChanged("world");
         sortEntries();
 }
@@ -74,6 +75,7 @@ CommunitiesList::syncTags(const std::map<QString, RoomInfo> &info)
 {
         for (const auto &room : info)
                 setTagsForRoom(room.first, room.second.tags);
+        emit communityChanged(selectedCommunity_);
         sortEntries();
 }
 
@@ -231,6 +233,7 @@ CommunitiesList::highlightSelectedCommunity(const QString &community_id)
                 return;
         }
 
+        selectedCommunity_ = community_id;
         emit communityChanged(community_id);
 
         for (const auto &community : communities_) {

--- a/src/CommunitiesList.h
+++ b/src/CommunitiesList.h
@@ -53,6 +53,7 @@ private:
                 return communities_.find(id) != communities_.end();
         }
 
+        QString selectedCommunity_;
         QVBoxLayout *topLayout_;
         QVBoxLayout *contentsLayout_;
         QScrollArea *scrollArea_;

--- a/src/RoomList.cpp
+++ b/src/RoomList.cpp
@@ -106,6 +106,10 @@ void
 RoomList::removeRoom(const QString &room_id, bool reset)
 {
         auto roomIt = rooms_.find(room_id);
+        if (roomIt == rooms_.end()) {
+                return;
+        }
+
         for (auto roomSortIt = rooms_sort_cache_.begin(); roomSortIt != rooms_sort_cache_.end();
              ++roomSortIt) {
                 if (roomIt->second == *roomSortIt) {
@@ -523,8 +527,11 @@ RoomList::firstRoom() const
                 auto item = qobject_cast<RoomInfoListItem *>(contentsLayout_->itemAt(i)->widget());
 
                 if (item) {
-                        return std::pair<QString, QSharedPointer<RoomInfoListItem>>(
-                          item->roomId(), rooms_.at(item->roomId()));
+                        auto topRoom = rooms_.find(item->roomId());
+                        if (topRoom != rooms_.end()) {
+                                return std::pair<QString, QSharedPointer<RoomInfoListItem>>(
+                                  item->roomId(), topRoom->second);
+                        }
                 }
         }
 

--- a/src/dialogs/InviteUsers.cpp
+++ b/src/dialogs/InviteUsers.cpp
@@ -65,6 +65,10 @@ InviteUsers::InviteUsers(QWidget *parent)
 
         connect(inviteeInput_, &TextField::returnPressed, this, &InviteUsers::addUser);
         connect(confirmBtn_, &QPushButton::clicked, [this]() {
+                if (!inviteeInput_->text().isEmpty()) {
+                        addUser();
+                }
+
                 emit sendInvites(invitedUsers());
 
                 inviteeInput_->clear();

--- a/src/dialogs/InviteUsers.cpp
+++ b/src/dialogs/InviteUsers.cpp
@@ -65,7 +65,7 @@ InviteUsers::InviteUsers(QWidget *parent)
 
         connect(inviteeInput_, &TextField::returnPressed, this, &InviteUsers::addUser);
         connect(confirmBtn_, &QPushButton::clicked, [this]() {
-                if (!inviteeInput_->text().isEmpty()) {
+                if (!inviteeInput_->text().trimmed().isEmpty()) {
                         addUser();
                 }
 


### PR DESCRIPTION
1) We don't check to see if the room was found in the removeRoom function, so we dereference the end iterator causing the crash. The removeRoom function is called twice so that's why this happens (once by clicking the remove room and another time when the ui is synced and we remove the left rooms)

2) A similar bug happens when we fetch the firstRoom, the firstRoom functions loops through elements in the contentsLayout (which still contains the removed room) and using the at function throws an exception. So added another check here.

3) Clicking invite button adds the user id text in the input field (if the input field is not empty)

4) Fixes #460 Room list does not update on adding room to hidden tag (and also does not update when you remove tag from a room). The communityChanged signal was not being emitted in the syncTags functions 