### PR TITLE
Pressing return on image upload dialog sends the message

### DIFF
--- a/src/dialogs/PreviewUploadOverlay.cpp
+++ b/src/dialogs/PreviewUploadOverlay.cpp
@@ -48,6 +48,12 @@ PreviewUploadOverlay::PreviewUploadOverlay(QWidget *parent)
                 emit confirmUpload(data_, mediaType_, fileName_.text());
                 close();
         });
+
+        connect(&fileName_, &QLineEdit::returnPressed, this, [this]() {
+                emit confirmUpload(data_, mediaType_, fileName_.text());
+                close();
+        });
+
         connect(&cancel_, &QPushButton::clicked, this, [this]() {
                 emit aborted();
                 close();


### PR DESCRIPTION
fixes #515 

It was such a pain to click the upload button manually to send an image, so I said why don't I just fix it myself and it actually worked.

thanks to @deepbluev7 for helping me to fix and create this pull request