### PR TITLE
Prevent EventType::Unsupported events to be saved in statesdb (BugFix)

### DIFF
--- a/src/Cache_p.h
+++ b/src/Cache_p.h
@@ -381,7 +381,7 @@ private:
 
                 std::visit(
                   [&txn, &statesdb](auto e) {
-                          if constexpr (isStateEvent(e))
+                          if (isStateEvent(e) && e.type != EventType::Unsupported)
                                   statesdb.put(txn, to_string(e.type), json(e).dump());
                   },
                   event);


### PR DESCRIPTION
Added a check to prevent unsupported events to be saved from db. Now able to login successfully.