### PR TITLE
Fix build: refactor variables to avoid same names in a scope

### DIFF
--- a/src/CallDevices.cpp
+++ b/src/CallDevices.cpp
@@ -111,8 +111,8 @@ addDevice(GstDevice *device)
         g_free(name);
         guint nCaps = gst_caps_get_size(gstcaps);
         for (guint i = 0; i < nCaps; ++i) {
-                GstStructure *structure = gst_caps_get_structure(gstcaps, i);
-                const gchar *struct_name       = gst_structure_get_name(structure);
+                GstStructure *structure  = gst_caps_get_structure(gstcaps, i);
+                const gchar *struct_name = gst_structure_get_name(structure);
                 if (!std::strcmp(struct_name, "video/x-raw")) {
                         gint widthpx, heightpx;
                         if (gst_structure_get(structure,

--- a/src/CallDevices.cpp
+++ b/src/CallDevices.cpp
@@ -112,8 +112,8 @@ addDevice(GstDevice *device)
         guint nCaps = gst_caps_get_size(gstcaps);
         for (guint i = 0; i < nCaps; ++i) {
                 GstStructure *structure = gst_caps_get_structure(gstcaps, i);
-                const gchar *name       = gst_structure_get_name(structure);
-                if (!std::strcmp(name, "video/x-raw")) {
+                const gchar *struct_name       = gst_structure_get_name(structure);
+                if (!std::strcmp(struct_name, "video/x-raw")) {
                         gint widthpx, heightpx;
                         if (gst_structure_get(structure,
                                               "width",
@@ -142,8 +142,8 @@ addDevice(GstDevice *device)
                                         for (guint j = 0; j < nRates; ++j) {
                                                 const GValue *rate =
                                                   gst_value_list_get_value(value, j);
-                                                if (auto fr = getFrameRate(rate); fr)
-                                                        addFrameRate(caps.frameRates, *fr);
+                                                if (auto frate = getFrameRate(rate); frate)
+                                                        addFrameRate(caps.frameRates, *frate);
                                         }
                                 }
                                 if (!caps.frameRates.empty())


### PR DESCRIPTION
```
/home/anjani/Programs/C++/nheko/src/CallDevices.cpp:115:30: error: declaration shadows a local variable [-Werror,-Wshadow]
                const gchar *name       = gst_structure_get_name(structure);
                             ^
/home/anjani/Programs/C++/nheko/src/CallDevices.cpp:91:16: note: previous declaration is here
        gchar *name  = gst_device_get_display_name(device);
               ^
/home/anjani/Programs/C++/nheko/src/CallDevices.cpp:145:58: error: declaration shadows a local variable [-Werror,-Wshadow]
                                                if (auto fr = getFrameRate(rate); fr)
                                                         ^
/home/anjani/Programs/C++/nheko/src/CallDevices.cpp:131:42: note: previous declaration is here
                                if (auto fr = getFrameRate(value); fr)
                                         ^
2 errors generated.
make[2]: *** [CMakeFiles/nheko.dir/build.make:1388: CMakeFiles/nheko.dir/src/CallDevices.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:149: CMakeFiles/nheko.dir/all] Error 2
make: *** [Makefile:136: all] Error 2

```

Fixed this build failure