### PR TITLE
add notice and rainbownotice commands

### DIFF
--- a/src/timeline/InputBar.h
+++ b/src/timeline/InputBar.h
@@ -68,6 +68,7 @@ signals:
 
 private:
         void emote(QString body, bool rainbowify);
+        void notice(QString body, bool rainbowify);
         void command(QString name, QString args);
         void image(const QString &filename,
                    const std::optional<mtx::crypto::EncryptedFile> &file,


### PR DESCRIPTION
This PR adds commands for sending messages with the `m.notice` type.