### PR TITLE
Fix notifications in narrow view when content is hidden

### DIFF
--- a/src/ChatPage.cpp
+++ b/src/ChatPage.cpp
@@ -1197,6 +1197,12 @@ ChatPage::getProfileInfo()
           });
 }
 
+bool
+ChatPage::isRoomActive(const QString &room_id)
+{
+        return isActiveWindow() && content_->isVisible() && currentRoom() == room_id;
+}
+
 void
 ChatPage::hideSideBars()
 {

--- a/src/ChatPage.h
+++ b/src/ChatPage.h
@@ -207,10 +207,7 @@ private:
         void getProfileInfo();
 
         //! Check if the given room is currently open.
-        bool isRoomActive(const QString &room_id)
-        {
-                return isActiveWindow() && currentRoom() == room_id;
-        }
+        bool isRoomActive(const QString &room_id);
 
         using UserID      = QString;
         using Membership  = mtx::events::StateEvent<mtx::events::state::Member>;


### PR DESCRIPTION
In narrow view, a room can be selected even if the view currently only
shows the room list and the timeline is hidden.
This commit ensures that in this case, notifications are not suppressed.