### PR TITLE
Allow editing unsent messages

### DIFF
--- a/src/Cache_p.h
+++ b/src/Cache_p.h
@@ -184,6 +184,9 @@ public:
         void storeEvent(const std::string &room_id,
                         const std::string &event_id,
                         const mtx::events::collections::TimelineEvent &event);
+        void replaceEvent(const std::string &room_id,
+                          const std::string &event_id,
+                          const mtx::events::collections::TimelineEvent &event);
         std::vector<std::string> relatedEvents(const std::string &room_id,
                                                const std::string &event_id);
 

--- a/src/timeline/EventStore.cpp
+++ b/src/timeline/EventStore.cpp
@@ -186,7 +186,11 @@ EventStore::EventStore(std::string room_id, QObject *)
                   nhlog::ui()->debug("sent {}", txn_id);
 
                   // Replace the event_id in pending edits/replies/redactions with the actual
-                  // event_id of this event
+                  // event_id of this event. This allows one to edit and reply to events that are
+                  // currently pending.
+
+                  // FIXME (introduced by balsoft): this doesn't work for encrypted events, but
+                  // allegedly it's hard to fix so I'll leave my first contribution at that
                   for (auto related_event_id : cache::client()->relatedEvents(room_id_, txn_id)) {
                           if (cache::client()->getEvent(room_id_, related_event_id)) {
                                   auto related_event =

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -375,6 +375,8 @@ TimelineModel::TimelineModel(TimelineViewManager *manager, QString room_id, QObj
         connect(&events, &EventStore::updateFlowEventId, this, [this](std::string event_id) {
                 this->updateFlowEventId(event_id);
         });
+        // When a message is sent, check if the current edit/reply relates to that message,
+        // and update the event_id so that it points to the sent message and not the pending one.
         connect(&events,
                 &EventStore::messageSent,
                 this,

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -383,6 +383,9 @@ TimelineModel::TimelineModel(TimelineViewManager *manager, QString room_id, QObj
                                 edit_ = QString::fromStdString(event_id);
                                 emit editChanged(edit_);
                         }
+                        if (reply_.toStdString() == txn_id) {
+                                reply_ = QString::fromStdString(event_id);
+                        }
                 });
 
         showEventTimer.callOnTimeout(this, &TimelineModel::scrollTimerEvent);

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -385,6 +385,7 @@ TimelineModel::TimelineModel(TimelineViewManager *manager, QString room_id, QObj
                         }
                         if (reply_.toStdString() == txn_id) {
                                 reply_ = QString::fromStdString(event_id);
+                                emit replyChanged(reply_);
                         }
                 });
 

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -375,6 +375,15 @@ TimelineModel::TimelineModel(TimelineViewManager *manager, QString room_id, QObj
         connect(&events, &EventStore::updateFlowEventId, this, [this](std::string event_id) {
                 this->updateFlowEventId(event_id);
         });
+        connect(&events,
+                &EventStore::messageSent,
+                this,
+                [this](std::string txn_id, std::string event_id) {
+                        if (edit_.toStdString() == txn_id) {
+                                edit_ = QString::fromStdString(event_id);
+                                emit editChanged(edit_);
+                        }
+                });
 
         showEventTimer.callOnTimeout(this, &TimelineModel::scrollTimerEvent);
 }
@@ -568,10 +577,8 @@ TimelineModel::data(const mtx::events::collections::TimelineEvents &event, int r
         case IsEdited:
                 return QVariant(relations(event).replaces().has_value());
         case IsEditable:
-                return QVariant(!is_state_event(event) &&
-                                mtx::accessors::sender(event) ==
-                                  http::client()->user_id().to_string() &&
-                                !event_id(event).empty() && event_id(event).front() == '$');
+                return QVariant(!is_state_event(event) && mtx::accessors::sender(event) ==
+                                                            http::client()->user_id().to_string());
         case IsEncrypted: {
                 auto id              = event_id(event);
                 auto encrypted_event = events.get(id, "", false);
@@ -1796,9 +1803,6 @@ TimelineModel::formatMemberEvent(QString id)
 void
 TimelineModel::setEdit(QString newEdit)
 {
-        if (edit_.startsWith('m'))
-                return;
-
         if (newEdit.isEmpty()) {
                 resetEdit();
                 return;


### PR DESCRIPTION
As of 0db4d71ec2483c7ac5a7b536737fee8fc53a76d7 (Prevent edits of
unsent messages), messages that are edits of (or replies to) unsent
messages were not allowed. This change was made because otherwise
the edits were discarded due to use of txnid rather than mxid in the
"m.relates_to" object. Remove this restriction and fix the issue by
replacing txnid with mxid in all related events when the message is
sent (and we obtain mxid from the server).
