### PR TITLE
add avatar changed event support issue #550

### DIFF
--- a/resources/qml/delegates/MessageDelegate.qml
+++ b/resources/qml/delegates/MessageDelegate.qml
@@ -149,6 +149,14 @@ Item {
         }
 
         DelegateChoice {
+            roleValue: MtxEvent.Avatar
+
+            NoticeMessage {
+                text: qsTr("%1 changed the room avatar").arg(model.data.userName)
+            }
+        }
+
+        DelegateChoice {
             roleValue: MtxEvent.RoomCreate
 
             NoticeMessage {


### PR DESCRIPTION
display "{user} changed the room avatar" when a rooms avatar has been changed
issue #550 