### PR TITLE
Fix minor display bugs with emoji completer

### DIFF
--- a/resources/qml/MessageInput.qml
+++ b/resources/qml/MessageInput.qml
@@ -165,13 +165,13 @@ Rectangle {
                     } else if (event.modifiers == Qt.ControlModifier && event.key == Qt.Key_N) {
                         messageInput.text = room.input.nextText();
                     } else if (event.key == Qt.Key_At) {
-                        messageInput.openCompleter(cursorPosition, "user");
+                        messageInput.openCompleter(selectionStart, "user");
                         popup.open();
                     } else if (event.key == Qt.Key_Colon) {
-                        messageInput.openCompleter(cursorPosition, "emoji");
+                        messageInput.openCompleter(selectionStart, "emoji");
                         popup.open();
                     } else if (event.key == Qt.Key_NumberSign) {
-                        messageInput.openCompleter(cursorPosition, "roomAliases");
+                        messageInput.openCompleter(selectionStart, "roomAliases");
                         popup.open();
                     } else if (event.key == Qt.Key_Escape && popup.opened) {
                         completerTriggeredAt = -1;

--- a/resources/qml/MessageInput.qml
+++ b/resources/qml/MessageInput.qml
@@ -93,7 +93,7 @@ Rectangle {
             TextArea {
                 id: messageInput
 
-                property int completerTriggeredAt: -1
+                property int completerTriggeredAt: 0
 
                 function insertCompletion(completion) {
                     messageInput.remove(completerTriggeredAt, cursorPosition);
@@ -134,8 +134,7 @@ Rectangle {
                         return ;
 
                     room.input.updateState(selectionStart, selectionEnd, cursorPosition, text);
-                    if (cursorPosition <= completerTriggeredAt) {
-                        completerTriggeredAt = -1;
+                    if (popup.opened && cursorPosition <= completerTriggeredAt) {
                         popup.close();
                     }
                     if (popup.opened)
@@ -145,7 +144,7 @@ Rectangle {
                 onSelectionStartChanged: room.input.updateState(selectionStart, selectionEnd, cursorPosition, text)
                 onSelectionEndChanged: room.input.updateState(selectionStart, selectionEnd, cursorPosition, text)
                 // Ensure that we get escape key press events first.
-                Keys.onShortcutOverride: event.accepted = (completerTriggeredAt != -1 && (event.key === Qt.Key_Escape || event.key === Qt.Key_Tab || event.key === Qt.Key_Enter))
+                Keys.onShortcutOverride: event.accepted = (popup.opened && (event.key === Qt.Key_Escape || event.key === Qt.Key_Tab || event.key === Qt.Key_Enter))
                 Keys.onPressed: {
                     if (event.matches(StandardKey.Paste)) {
                         room.input.paste(false);
@@ -174,12 +173,10 @@ Rectangle {
                         messageInput.openCompleter(selectionStart, "roomAliases");
                         popup.open();
                     } else if (event.key == Qt.Key_Escape && popup.opened) {
-                        completerTriggeredAt = -1;
                         popup.completerName = "";
                         popup.close();
                         event.accepted = true;
                     } else if (event.matches(StandardKey.SelectAll) && popup.opened) {
-                        completerTriggeredAt = -1;
                         popup.completerName = "";
                         popup.close();
                     } else if (event.matches(StandardKey.InsertParagraphSeparator)) {
@@ -270,7 +267,6 @@ Rectangle {
                         if (room)
                             messageInput.append(room.input.text());
 
-                        messageInput.completerTriggeredAt = -1;
                         popup.completerName = "";
                         messageInput.forceActiveFocus();
                     }
@@ -289,8 +285,8 @@ Rectangle {
                 Completer {
                     id: popup
 
-                    x: messageInput.completerTriggeredAt >= 0 ? messageInput.positionToRectangle(messageInput.completerTriggeredAt).x : 0
-                    y: messageInput.completerTriggeredAt >= 0 ? messageInput.positionToRectangle(messageInput.completerTriggeredAt).y - height : 0
+                    x: messageInput.positionToRectangle(messageInput.completerTriggeredAt).x
+                    y: messageInput.positionToRectangle(messageInput.completerTriggeredAt).y - height
                 }
 
                 Connections {

--- a/resources/qml/MessageInput.qml
+++ b/resources/qml/MessageInput.qml
@@ -176,7 +176,11 @@ Rectangle {
                     } else if (event.key == Qt.Key_Escape && popup.opened) {
                         completerTriggeredAt = -1;
                         popup.completerName = "";
+                        popup.close();
                         event.accepted = true;
+                    } else if (event.matches(StandardKey.SelectAll) && popup.opened) {
+                        completerTriggeredAt = -1;
+                        popup.completerName = "";
                         popup.close();
                     } else if (event.matches(StandardKey.InsertParagraphSeparator)) {
                         if (popup.opened) {


### PR DESCRIPTION
I left this in one branch since they're kind of related. The commits are separate so we can split it out if you prefer.

## 1. Ctrl-A then typing doesn't clear the open emoji completer

**Current behaviour**
1.
![s-all-ex-1](https://user-images.githubusercontent.com/5511175/130310173-456ff4df-2131-469f-8a6b-9655a7f50a15.png)
2.
![s-all-ex-2](https://user-images.githubusercontent.com/5511175/130310174-71dc2dee-559f-4e0b-84d8-f238621ce253.png)
3.
![s-all-ex-3](https://user-images.githubusercontent.com/5511175/130310176-85b37eaf-b3c1-4680-8ac3-2e87e0a08f59.png)

**Fixed behaviour**
2.
![s-all-new-2](https://user-images.githubusercontent.com/5511175/130310189-129f286d-5439-4478-8fa1-abab7f1eac26.png)
3.
![s-all-new-3](https://user-images.githubusercontent.com/5511175/130310193-26b1e4a8-2c20-49b7-b5a2-8aa98ceafdfd.png)

For a while I contemplated tracking that the colon inside the selection has been overwritten. I think it's cleaner to handle this a step earlier - it's not logical to keep the completion open after hitting Ctrl-A. Then it's already gone when we type the next character.

## 2. Ctrl-A then typing a `:` doesn't open the emoji completer

**Current behaviour**
1.
![first-colon-ex-1](https://user-images.githubusercontent.com/5511175/130310207-0eea7911-489d-4119-aa64-bb9484430081.png)
2.
![first-colon-ex-2](https://user-images.githubusercontent.com/5511175/130310210-0a11b44c-fa3c-4e0a-b82c-dd50b913dc13.png)
3.
![first-colon-ex-3](https://user-images.githubusercontent.com/5511175/130310212-77d3f70f-f89c-4767-b5f6-b804b406c23d.png)

**Fixed behaviour**
3.
![first-colon-new-3](https://user-images.githubusercontent.com/5511175/130310239-31dc44e0-4898-477f-b6d5-70d229fa5bc4.png)

This one is a little weird - when you have the text selected and type colon, the cursor position is captured _before_ the selected text gets replaced. This means the new cursor position is earlier than the `completerTriggeredAt` and it immediately gets closed. `selectionStart` happens to be the correct value both for normal typing and when you have text selected.

## 3. Emoji completer flickers/jumps around if you type `:` then backspace it

This is hard to screenshot but it's easy to reproduce. The `x` and `y` are set to 0 when `completerTriggeredAt` is reset to -1, so you see it move to a strange position for a fraction of a second before it gets closed. Now -1 is no longer a sentinel value and `popup.opened` is used in its place.