### PR TITLE
Right-click tap handler for replies

### DIFF
--- a/resources/qml/MessageView.qml
+++ b/resources/qml/MessageView.qml
@@ -648,4 +648,38 @@ ScrollView {
 
     }
 
+    Platform.Menu {
+        id: replyContextMenu
+
+        property string text
+        property string link
+
+        function show(text_, link_) {
+            text = text_;
+            link = link_;
+            open();
+        }
+
+        Platform.MenuItem {
+            visible: replyContextMenu.text
+            enabled: visible
+            text: qsTr("&Copy")
+            onTriggered: Clipboard.text = replyContextMenu.text
+        }
+
+        Platform.MenuItem {
+            visible: replyContextMenu.link
+            enabled: visible
+            text: qsTr("Copy &link location")
+            onTriggered: Clipboard.text = replyContextMenu.link
+        }
+
+        Platform.MenuItem {
+            visible: true
+            enabled: visible
+            text: qsTr("&Go to reply")
+            onTriggered: chat.model.showEvent(eventId)
+        }
+    }
+
 }

--- a/resources/qml/delegates/Reply.qml
+++ b/resources/qml/delegates/Reply.qml
@@ -7,6 +7,7 @@ import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.2
 import QtQuick.Window 2.13
 import im.nheko 1.0
+import Qt.labs.platform 1.1 as Platform
 
 Item {
     id: r
@@ -36,11 +37,6 @@ Item {
     width: parent.width
     height: replyContainer.height
 
-    TapHandler {
-        onSingleTapped: chat.model.showEvent(eventId)
-        gesturePolicy: TapHandler.ReleaseWithinBounds
-    }
-
     CursorShape {
         anchors.fill: parent
         cursorShape: Qt.PointingHandCursor
@@ -62,6 +58,25 @@ Item {
         anchors.leftMargin: 4
         width: parent.width - 8
 
+        TapHandler {
+            acceptedButtons: Qt.LeftButton
+            onSingleTapped: chat.model.showEvent(r.eventId)
+            gesturePolicy: TapHandler.ReleaseWithinBounds
+        }
+
+        TapHandler {
+            acceptedButtons: Qt.RightButton
+            onLongPressed: replyContextMenu.show(
+              reply.child.copyText,
+              reply.child.linkAt(eventPoint.position.x, eventPoint.position.y - userName_.implicitHeight)
+            )
+            onSingleTapped: replyContextMenu.show(
+              reply.child.copyText,
+              reply.child.linkAt(eventPoint.position.x, eventPoint.position.y - userName_.implicitHeight)
+            )
+            gesturePolicy: TapHandler.ReleaseWithinBounds
+        }
+
         Text {
             id: userName_
 
@@ -73,7 +88,6 @@ Item {
                 onSingleTapped: chat.model.openUserProfile(userId)
                 gesturePolicy: TapHandler.ReleaseWithinBounds
             }
-
         }
 
         MessageDelegate {
@@ -99,11 +113,11 @@ Item {
             callType: r.callType
             relatedEventCacheBuster: r.relatedEventCacheBuster
             encryptionError: r.encryptionError
+            // This is disabled so that left clicking the reply goes to its location
             enabled: false
             width: parent.width
             isReply: true
         }
-
     }
 
     Rectangle {

--- a/resources/qml/delegates/TextMessage.qml
+++ b/resources/qml/delegates/TextMessage.qml
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import ".."
+import QtQuick.Controls 2.3
 import im.nheko 1.0
 
 MatrixText {
@@ -35,4 +36,10 @@ MatrixText {
     clip: isReply
     selectByMouse: !Settings.mobileMode && !isReply
     font.pointSize: (Settings.enlargeEmojiOnlyMessages && isOnlyEmoji > 0 && isOnlyEmoji < 4) ? Settings.fontSize * 3 : Settings.fontSize
+
+    CursorShape {
+        enabled: isReply
+        anchors.fill: parent
+        cursorShape: Qt.PointingHandCursor
+    }
 }


### PR DESCRIPTION
This is an attempt at fixing https://github.com/Nheko-Reborn/nheko/issues/695, but it doesn't actually work fully. I was unable to make more progress than this because I don't know anything about QML.

The intention for this PR is to support only "copy" and "copy link" actions, but there are problems with this code:

- The context menu gets open in a weird position
- `reply.child.hoveredLink` does not actually work, apparently; `reply.child.copyText` does

Feel free to disregard any part of the code which looks nonsensical, as aforementioned I don't know anything about QML. Also feel free to take over this PR and push the remaining code to this branch.