### PR TITLE
Decrease margins on blockquotes.

### DIFF
--- a/resources/qml/delegates/TextMessage.qml
+++ b/resources/qml/delegates/TextMessage.qml
@@ -29,6 +29,7 @@ MatrixText {
         border-collapse: collapse;
         border: 1px solid " + Nheko.colors.text + ";
     }
+    blockquote { margin-left: 1em; }
     </style>
     " + formatted.replace("<pre>", "<pre style='white-space: pre-wrap; background-color: " + Nheko.colors.alternateBase + "'>").replace("<del>", "<s>").replace("</del>", "</s>").replace("<strike>", "<s>").replace("</strike>", "</s>")
     width: parent ? parent.width : undefined


### PR DESCRIPTION
Reduce margin-left to 1em, remove margin between blockquotes (but not
between quote and answer).

It is intentionally impossible to add borders to blockquotes via CSS:
<https://bugreports.qt.io/browse/QTBUG-23244>.

Bug: https://github.com/Nheko-Reborn/nheko/issues/704

----
Before: ![screenshot_2021-09-04T14:26:35](https://user-images.githubusercontent.com/3681516/132095272-1a81d2d5-4693-415f-b6cc-5bc1a28b7815.png)
After: ![screenshot_2021-09-04T14:26:01](https://user-images.githubusercontent.com/3681516/132095270-ff00d63f-38cb-425b-a897-01702ada1593.png)

Using this example:

``` markdown
>> Here is the link: […]

> That is the wrong link.

>> And here is the other link:

> That link is wrong, too!

No it isn't.
```

Before: ![screenshot_2021-09-04T14:48:40](https://user-images.githubusercontent.com/3681516/132095275-cdfa694e-377f-41de-912e-b8f4fb6fa158.png)

After: ![screenshot_2021-09-04T14:47:21](https://user-images.githubusercontent.com/3681516/132095274-26856dcd-fdfa-4735-be6a-4660cd177e73.png)

