### PR TITLE
Fixed minor memleak: QShortcut instance for capturing Ctrl-Q in the m…

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -125,8 +125,8 @@ MainWindow::MainWindow(QWidget *parent)
 
         connect(register_page_, &RegisterPage::registerOk, this, &MainWindow::showChatPage);
 
-        QShortcut *quitShortcut = new QShortcut(QKeySequence::Quit, this);
-        connect(quitShortcut, &QShortcut::activated, this, QApplication::quit);
+        quitShortcut.reset(new QShortcut(QKeySequence::Quit, this));
+        connect(quitShortcut.get(), &QShortcut::activated, this, QApplication::quit);
 
         trayIcon_->setVisible(userSettings_->tray());
 

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -6,9 +6,11 @@
 #pragma once
 
 #include <functional>
+#include <memory>
 
 #include <QMainWindow>
 #include <QSharedPointer>
+#include <QShortcut>
 #include <QStackedWidget>
 #include <QSystemTrayIcon>
 
@@ -135,4 +137,7 @@ private:
         //! Overlay modal used to project other widgets.
         OverlayModal *modal_       = nullptr;
         LoadingIndicator *spinner_ = nullptr;
+
+        //! Quit keyboard shortcut
+        std::unique_ptr<QShortcut> quitShortcut;
 };


### PR DESCRIPTION
…ain window is now managed by a unique pointer.

This is a minor fix for a small issue I've stumbled upon when studying the code. Right now the `QShortcut` instance outlives the instance of the `MainWindow` class. Using smart pointer quickly fixes the bug.

Tested this by making sure, `Ctrl-Q` still works as expected and is closing the window.