### PR TITLE
Added a text field that allows choosing custom homeserver in "Room directory" dialog.

### DIFF
--- a/resources/qml/RoomDirectory.qml
+++ b/resources/qml/RoomDirectory.qml
@@ -181,18 +181,6 @@ ApplicationWindow {
         implicitHeight: roomSearch.height
 
         MatrixTextField {
-            id: chooseServer
-
-            Layout.fillWidth: true
-            selectByMouse: true
-            font.pixelSize: fontMetrics.font.pixelSize
-            padding: Nheko.paddingMedium
-            color: Nheko.colors.text
-            placeholderText: qsTr("Choose custom homeserver")
-            onTextChanged: publicRooms.setMatrixServer(text)
-        }
-
-        MatrixTextField {
             id: roomSearch
 
             Layout.fillWidth: true
@@ -202,6 +190,17 @@ ApplicationWindow {
             color: Nheko.colors.text
             placeholderText: qsTr("Search for public rooms")
             onTextChanged: searchTimer.restart()
+        }
+
+        MatrixTextField {
+            id: chooseServer
+            Layout.minimumWidth: 0.3 * header.width
+            Layout.maximumWidth: 0.3 * header.width
+
+            padding: Nheko.paddingMedium
+            color: Nheko.colors.text
+            placeholderText: qsTr("Choose custom homeserver")
+            onTextChanged: publicRooms.setMatrixServer(text)
         }
 
         Timer {

--- a/resources/qml/RoomDirectory.qml
+++ b/resources/qml/RoomDirectory.qml
@@ -181,6 +181,18 @@ ApplicationWindow {
         implicitHeight: roomSearch.height
 
         MatrixTextField {
+            id: chooseServer
+
+            Layout.fillWidth: true
+            selectByMouse: true
+            font.pixelSize: fontMetrics.font.pixelSize
+            padding: Nheko.paddingMedium
+            color: Nheko.colors.text
+            placeholderText: qsTr("Choose custom homeserver")
+            onTextChanged: publicRooms.setMatrixServer(text)
+        }
+
+        MatrixTextField {
             id: roomSearch
 
             Layout.fillWidth: true

--- a/src/RoomDirectoryModel.cpp
+++ b/src/RoomDirectoryModel.cpp
@@ -104,7 +104,7 @@ RoomDirectoryModel::getViasForRoom(const std::vector<std::string> &aliases)
         // request. For more details consult the specs:
         // https://matrix.org/docs/spec/client_server/r0.6.1#post-matrix-client-r0-join-roomidoralias
         if (!server_.empty()) {
-            vias.push_back(server_);
+                vias.push_back(server_);
         }
 
         return vias;

--- a/src/RoomDirectoryModel.cpp
+++ b/src/RoomDirectoryModel.cpp
@@ -98,6 +98,15 @@ RoomDirectoryModel::getViasForRoom(const std::vector<std::string> &aliases)
                        std::back_inserter(vias),
                        [](const auto &alias) { return alias.substr(alias.find(":") + 1); });
 
+        // When joining a room hosted on a homeserver other than the one the
+        // account has been registered on, the room's server has to be explicitly
+        // specified in the "server_name=..." URL parameter of the Matrix Join Room
+        // request. For more details consult the specs:
+        // https://matrix.org/docs/spec/client_server/r0.6.1#post-matrix-client-r0-join-roomidoralias
+        if (!server_.empty()) {
+            vias.push_back(server_);
+        }
+
         return vias;
 }
 


### PR DESCRIPTION
As I'm using my own self-hosted homeserver, I'm unable to browse public rooms on other servers (e.g. `matrix.org`). This simple change adds the ability to do just that. Tested and working. :) A screenshot before choosing server:
https://people.debian.org/~patryk/tmp/nheko/screenshots/choose_server_default.png

And after specifying the server:
https://people.debian.org/~patryk/tmp/nheko/screenshots/choose_server_custom.png

Please, let me know, what you think.