### PR TITLE
Improvements for linking to events

### DIFF
--- a/resources/qml/MessageView.qml
+++ b/resources/qml/MessageView.qml
@@ -20,6 +20,9 @@ ScrollView {
 
     ListView {
         id: chat
+        
+        displayMarginBeginning: height/2
+        displayMarginEnd: height/2
 
         property int delegateMaxWidth: ((Settings.timelineMaxWidth > 100 && Settings.timelineMaxWidth < parent.availableWidth) ? Settings.timelineMaxWidth : parent.availableWidth) - parent.padding * 2
 
@@ -276,7 +279,7 @@ ScrollView {
                         }
 
                         function onScrollToIndex(index) {
-                            chat.positionViewAtIndex(index, ListView.Visible);
+                            chat.positionViewAtIndex(index, ListView.Center);
                         }
 
                         target: chat.model

--- a/src/ChatPage.h
+++ b/src/ChatPage.h
@@ -78,8 +78,8 @@ public:
         QString currentRoom() const;
 
 public slots:
-        void handleMatrixUri(const QByteArray &uri);
-        void handleMatrixUri(const QUrl &uri);
+        bool handleMatrixUri(const QByteArray &uri);
+        bool handleMatrixUri(const QUrl &uri);
 
         void startChat(QString userid);
         void leaveRoom(const QString &room_id);

--- a/src/timeline/InputBar.cpp
+++ b/src/timeline/InputBar.cpp
@@ -630,6 +630,23 @@ InputBar::command(QString command, QString args)
                 notice(args, false);
         } else if (command == "rainbownotice") {
                 notice(args, true);
+        } else if (command == "goto") {
+                // Goto has three different modes:
+                // 1 - Going directly to a given event ID
+                if (args[0] == '$') {
+                        room->showEvent(args);
+                        return;
+                }
+                // 2 - Going directly to a given message index
+                if (args[0] >= '0' && args[0] <= '9') {
+                        room->showEvent(args);
+                        return;
+                }
+                // 3 - Matrix URI handler, as if you clicked the URI
+                if (ChatPage::instance()->handleMatrixUri(args)) {
+                        return;
+                }
+                nhlog::net()->error("Could not resolve goto: {}", args.toStdString());
         }
 }
 

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -1534,11 +1534,25 @@ void
 TimelineModel::showEvent(QString eventId)
 {
         using namespace std::chrono_literals;
-        if (idToIndex(eventId) != -1) {
+        // Direct to eventId
+        if (eventId[0] == '$') {
+                int idx = idToIndex(eventId);
+                if (idx == -1) {
+                        nhlog::ui()->warn("Scrolling to event id {}, failed - no known index",
+                                          eventId.toStdString());
+                        return;
+                }
                 eventIdToShow = eventId;
                 emit scrollTargetChanged();
                 showEventTimer.start(50ms);
+                return;
         }
+        // to message index
+        eventId       = indexToId(eventId.toInt());
+        eventIdToShow = eventId;
+        emit scrollTargetChanged();
+        showEventTimer.start(50ms);
+        return;
 }
 
 void

--- a/src/ui/NhekoGlobalObject.cpp
+++ b/src/ui/NhekoGlobalObject.cpp
@@ -57,48 +57,8 @@ void
 Nheko::openLink(QString link) const
 {
         QUrl url(link);
-        if (url.scheme() == "https" && url.host() == "matrix.to") {
-                // handle matrix.to links internally
-                QString p = url.fragment(QUrl::FullyEncoded);
-                if (p.startsWith("/"))
-                        p.remove(0, 1);
-
-                auto temp = p.split("?");
-                QString query;
-                if (temp.size() >= 2)
-                        query = QUrl::fromPercentEncoding(temp.takeAt(1).toUtf8());
-
-                temp            = temp.first().split("/");
-                auto identifier = QUrl::fromPercentEncoding(temp.takeFirst().toUtf8());
-                QString eventId = QUrl::fromPercentEncoding(temp.join('/').toUtf8());
-                if (!identifier.isEmpty()) {
-                        if (identifier.startsWith("@")) {
-                                QByteArray uri =
-                                  "matrix:u/" + QUrl::toPercentEncoding(identifier.remove(0, 1));
-                                if (!query.isEmpty())
-                                        uri.append("?" + query.toUtf8());
-                                ChatPage::instance()->handleMatrixUri(QUrl::fromEncoded(uri));
-                        } else if (identifier.startsWith("#")) {
-                                QByteArray uri =
-                                  "matrix:r/" + QUrl::toPercentEncoding(identifier.remove(0, 1));
-                                if (!eventId.isEmpty())
-                                        uri.append("/e/" +
-                                                   QUrl::toPercentEncoding(eventId.remove(0, 1)));
-                                if (!query.isEmpty())
-                                        uri.append("?" + query.toUtf8());
-                                ChatPage::instance()->handleMatrixUri(QUrl::fromEncoded(uri));
-                        } else if (identifier.startsWith("!")) {
-                                QByteArray uri = "matrix:roomid/" +
-                                                 QUrl::toPercentEncoding(identifier.remove(0, 1));
-                                if (!eventId.isEmpty())
-                                        uri.append("/e/" +
-                                                   QUrl::toPercentEncoding(eventId.remove(0, 1)));
-                                if (!query.isEmpty())
-                                        uri.append("?" + query.toUtf8());
-                                ChatPage::instance()->handleMatrixUri(QUrl::fromEncoded(uri));
-                        }
-                }
-        } else {
+        // Open externally if we couldn't handle it internally
+        if (!ChatPage::instance()->handleMatrixUri(url)) {
                 QDesktopServices::openUrl(url);
         }
 }


### PR DESCRIPTION
**- Fixes scrolling to an event not being reliable**

The main fix here is the addition of:
```
         displayMarginBeginning: height/2
         displayMarginEnd: height/2
```
in MessageView.qml. This causes Qt to load half a screen of extra elements in both directions, "fixing" the calculation for offsets of items near the screen edges.
I also noticed using ListView.Center instead of ListView.Visible made things a bit more accurate, plus it just feels better from a usability perspective to get the message you wanted to see in the middle of your screen IMHO.

**- Adds new /goto command that can open URLs, go to events, or go to message indexes.**

This was added mostly to make it easier for me to test things. I ended up really liking it.

**- Refactored ChatPage::handleMatrixUri() to contain the handling originally in Nheko::openLink(), and makes it return a boolean based on whether the URL was handled internally or not.**

This just kinda made sense. It was either refactor this or duplicate the code for handling matrix.to URLs internally.