### PR TITLE
Added window role to image overlay

### DIFF
--- a/src/dialogs/ImageOverlay.cpp
+++ b/src/dialogs/ImageOverlay.cpp
@@ -23,6 +23,7 @@ ImageOverlay::ImageOverlay(QPixmap image, QWidget *parent)
     setParent(nullptr);
 
     setWindowFlags(windowFlags() | Qt::FramelessWindowHint);
+    setWindowRole("imageoverlay");
 
     setAttribute(Qt::WA_NoSystemBackground, true);
     setAttribute(Qt::WA_TranslucentBackground, true);


### PR DESCRIPTION
Resubmitted on Nico's request

---

This is a tiny 1-line edit, that adds an "imageoverlay" X11 window role to the image overlay window.
Why? Well, window managers can use this role to distinguish windows from each other. This allows users to apply different rules to the image overlay compared to the other Nheko window(s).

As an example of why this is useful:
I have my window manager set to make the Nheko window(s) 95% opacity, so that my desktop background is slightly visible through it. However, when viewing an image, this partial transparency becomes annoying. Having a special window role allows me to exclude the image overlays from the opacity rule, making these windows fully opaque.

This is just how I personally use it, naturally others can and will of course apply whatever window rules they like themselves. To somebody that doesn't know or care about this stuff, this change is entirely invisible, so it shouldn't hurt anyone ^_^