### PR TITLE
Add note about secret server to Arch installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ can be found in the [GitHub releases](https://github.com/Nheko-Reborn/nheko/rele
 pacaur -S nheko # nheko-git
 ```
 
+Nheko requires a secret server to run, so you'll need to install and configure a service such as [KDE Wallet](https://wiki.archlinux.org/title/KDE_Wallet) or [GNOME Keyring](https://wiki.archlinux.org/title/GNOME/Keyring) if not provided by your desktop environment.
+
 #### Debian (10 and above) / Ubuntu (18.04 and above)
 
 ```bash


### PR DESCRIPTION
As mentioned in #705. I didn't include KeepassXC mainly because the current Arch-provided version is still 2.6.6.