### PR TITLE
Add specific powerlevel messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,7 +401,7 @@ if(USE_BUNDLED_MTXCLIENT)
 	FetchContent_Declare(
 		MatrixClient
 		GIT_REPOSITORY https://github.com/Nheko-Reborn/mtxclient.git
-		GIT_TAG        888601932b876c9a8bb8e1f3b198ce1a5f1252fa
+		GIT_TAG        c5e8def06f0fc64aa150f30d5c9c366e876120e1
 		)
 	set(BUILD_LIB_EXAMPLES OFF CACHE INTERNAL "")
 	set(BUILD_LIB_TESTS OFF CACHE INTERNAL "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,7 +401,7 @@ if(USE_BUNDLED_MTXCLIENT)
 	FetchContent_Declare(
 		MatrixClient
 		GIT_REPOSITORY https://github.com/Nheko-Reborn/mtxclient.git
-		GIT_TAG        a083b98975d19b7d553c19960ee0ba3702e922d3
+		GIT_TAG        288f585725ecdf2e5e04c5985fdbf658a7fe8a1b
 		)
 	set(BUILD_LIB_EXAMPLES OFF CACHE INTERNAL "")
 	set(BUILD_LIB_TESTS OFF CACHE INTERNAL "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,7 +401,7 @@ if(USE_BUNDLED_MTXCLIENT)
 	FetchContent_Declare(
 		MatrixClient
 		GIT_REPOSITORY https://github.com/Nheko-Reborn/mtxclient.git
-		GIT_TAG        c5e8def06f0fc64aa150f30d5c9c366e876120e1
+		GIT_TAG        8781d1a13b8ac3771d39d402449c5c06bf68b73a
 		)
 	set(BUILD_LIB_EXAMPLES OFF CACHE INTERNAL "")
 	set(BUILD_LIB_TESTS OFF CACHE INTERNAL "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,7 +401,7 @@ if(USE_BUNDLED_MTXCLIENT)
 	FetchContent_Declare(
 		MatrixClient
 		GIT_REPOSITORY https://github.com/Nheko-Reborn/mtxclient.git
-		GIT_TAG        8781d1a13b8ac3771d39d402449c5c06bf68b73a
+		GIT_TAG        a083b98975d19b7d553c19960ee0ba3702e922d3
 		)
 	set(BUILD_LIB_EXAMPLES OFF CACHE INTERNAL "")
 	set(BUILD_LIB_TESTS OFF CACHE INTERNAL "")

--- a/io.github.NhekoReborn.Nheko.yaml
+++ b/io.github.NhekoReborn.Nheko.yaml
@@ -176,7 +176,7 @@ modules:
     buildsystem: cmake-ninja
     name: mtxclient
     sources:
-      - commit: 888601932b876c9a8bb8e1f3b198ce1a5f1252fa
+      - commit: c5e8def06f0fc64aa150f30d5c9c366e876120e1
         #tag: v0.7.0
         type: git
         url: https://github.com/Nheko-Reborn/mtxclient.git

--- a/io.github.NhekoReborn.Nheko.yaml
+++ b/io.github.NhekoReborn.Nheko.yaml
@@ -176,7 +176,7 @@ modules:
     buildsystem: cmake-ninja
     name: mtxclient
     sources:
-      - commit: 8781d1a13b8ac3771d39d402449c5c06bf68b73a
+      - commit: a083b98975d19b7d553c19960ee0ba3702e922d3
         #tag: v0.7.0
         type: git
         url: https://github.com/Nheko-Reborn/mtxclient.git

--- a/io.github.NhekoReborn.Nheko.yaml
+++ b/io.github.NhekoReborn.Nheko.yaml
@@ -176,7 +176,7 @@ modules:
     buildsystem: cmake-ninja
     name: mtxclient
     sources:
-      - commit: a083b98975d19b7d553c19960ee0ba3702e922d3
+      - commit: 288f585725ecdf2e5e04c5985fdbf658a7fe8a1b
         #tag: v0.7.0
         type: git
         url: https://github.com/Nheko-Reborn/mtxclient.git

--- a/io.github.NhekoReborn.Nheko.yaml
+++ b/io.github.NhekoReborn.Nheko.yaml
@@ -176,7 +176,7 @@ modules:
     buildsystem: cmake-ninja
     name: mtxclient
     sources:
-      - commit: c5e8def06f0fc64aa150f30d5c9c366e876120e1
+      - commit: 8781d1a13b8ac3771d39d402449c5c06bf68b73a
         #tag: v0.7.0
         type: git
         url: https://github.com/Nheko-Reborn/mtxclient.git

--- a/resources/langs/nheko_fi.ts
+++ b/resources/langs/nheko_fi.ts
@@ -40,9 +40,9 @@
     <message numerus="yes">
         <location filename="../../src/Cache.cpp" line="+2512"/>
         <source>%1 and %n other(s)</source>
-        <translation type="unfinished">
-            <numerusform>%1 ja %n toinen</numerusform>
-            <numerusform>%1 and %n toista</numerusform>
+        <translation>
+            <numerusform>%1 ja %n muu</numerusform>
+            <numerusform>%1 and %n muuta</numerusform>
         </translation>
     </message>
     <message>
@@ -2544,17 +2544,17 @@ If you choose verify, you need to have the other device available. If you choose
     <message>
         <location line="+29"/>
         <source>Removed by %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Poistanut %1</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>%1 (%2) removed this message at %3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 (%2) poisti tämän viestin %3</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Removed by %1 because: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Poistanut %1 syystä: %2</translation>
     </message>
     <message>
         <location line="+1"/>

--- a/resources/qml/Root.qml
+++ b/resources/qml/Root.qml
@@ -288,7 +288,9 @@ Pane {
             var dialog = imageOverlay.createObject(timelineRoot, {
                 "room": room,
                 "eventId": eventId,
-                "url": url
+                "url": url,
+                "originalWidth": originalWidth ?? 0,
+                "proportionalHeight": proportionalHeight ?? 0
             });
             dialog.showFullScreen();
             destroyOnClose(dialog);

--- a/src/Cache.cpp
+++ b/src/Cache.cpp
@@ -609,9 +609,10 @@ Cache::exportSessionKeys()
                 if (!data.sender_claimed_ed25519_key.empty())
                     exported.sender_claimed_keys["ed25519"] = data.sender_claimed_ed25519_key;
                 exported.forwarding_curve25519_key_chain = data.forwarding_curve25519_key_chain;
+            } else {
+                continue;
             }
 
-            continue;
         } catch (std::exception &e) {
             nhlog::db()->error("Failed to retrieve Megolm Session Data: {}", e.what());
             continue;

--- a/src/CacheCryptoStructs.h
+++ b/src/CacheCryptoStructs.h
@@ -53,6 +53,9 @@ struct GroupSessionData
     // TODO(Nico): What about forwards? They might come from key backup?
     bool trusted = true;
 
+    // the original 25519 key
+    std::string sender_key;
+
     std::string sender_claimed_ed25519_key;
     std::vector<std::string> forwarding_curve25519_key_chain;
 
@@ -93,15 +96,12 @@ struct MegolmSessionIndex
     MegolmSessionIndex(std::string room_id_, const mtx::events::msg::Encrypted &e)
       : room_id(std::move(room_id_))
       , session_id(e.session_id)
-      , sender_key(e.sender_key)
     {}
 
     //! The room in which this session exists.
     std::string room_id;
     //! The session_id of the megolm session.
     std::string session_id;
-    //! The curve25519 public key of the sender.
-    std::string sender_key;
 };
 
 void

--- a/src/Cache_p.h
+++ b/src/Cache_p.h
@@ -317,6 +317,7 @@ signals:
     void roomReadStatus(const std::map<QString, bool> &status);
     void removeNotification(const QString &room_id, const QString &event_id);
     void userKeysUpdate(const std::string &sync_token, const mtx::responses::QueryKeys &keyQuery);
+    void userKeysUpdateFinalize(const std::string &user_id);
     void verificationStatusChanged(const std::string &userid);
     void selfVerificationStatusChanged();
     void secretChanged(const std::string name);

--- a/src/timeline/EventStore.cpp
+++ b/src/timeline/EventStore.cpp
@@ -691,17 +691,15 @@ EventStore::decryptEvent(const IdIndex &idx,
             break;
         }
         case olm::DecryptionErrorCode::DbError:
-            nhlog::db()->critical("failed to retrieve megolm session with index ({}, {}, {})",
+            nhlog::db()->critical("failed to retrieve megolm session with index ({}, {})",
                                   index.room_id,
                                   index.session_id,
-                                  index.sender_key,
                                   decryptionResult.error_message.value_or(""));
             break;
         case olm::DecryptionErrorCode::DecryptionFailed:
-            nhlog::crypto()->critical("failed to decrypt message with index ({}, {}, {}): {}",
+            nhlog::crypto()->critical("failed to decrypt message with index ({},  {}): {}",
                                       index.room_id,
                                       index.session_id,
-                                      index.sender_key,
                                       decryptionResult.error_message.value_or(""));
             break;
         case olm::DecryptionErrorCode::ParsingFailed:
@@ -710,7 +708,7 @@ EventStore::decryptEvent(const IdIndex &idx,
             nhlog::crypto()->critical("Reply attack while decryptiong event {} in room {} from {}!",
                                       e.event_id,
                                       room_id_,
-                                      index.sender_key);
+                                      e.sender);
             break;
         case olm::DecryptionErrorCode::NoError:
             // unreachable

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -1989,7 +1989,7 @@ TimelineModel::formatPowerLevelEvent(const QString &id)
                 if (number_of_affected > 1) {
                     resultingMessage.append(
                       default_message + QStringLiteral(" ") +
-                      tr("%n member(s) can now kick room members.").arg(true_affected_rest));
+                      tr("%n member(s) can now kick room members.", nullptr, true_affected_rest));
                 } else if (number_of_affected == 1) {
                     resultingMessage.append(
                       default_message + QStringLiteral(" ") +
@@ -2020,7 +2020,7 @@ TimelineModel::formatPowerLevelEvent(const QString &id)
                 if (number_of_affected > 1) {
                     resultingMessage.append(
                       default_message + QStringLiteral(" ") +
-                      tr("%n member(s) can now redact room messages.").arg(true_affected_rest));
+                      tr("%n member(s) can now redact room messages.", nullptr, true_affected_rest));
                 } else if (number_of_affected == 1) {
                     resultingMessage.append(
                       default_message + QStringLiteral(" ") +
@@ -2051,7 +2051,7 @@ TimelineModel::formatPowerLevelEvent(const QString &id)
                 if (number_of_affected > 1) {
                     resultingMessage.append(
                       default_message + QStringLiteral(" ") +
-                      tr("%n member(s) can now ban room members.").arg(true_affected_rest));
+                      tr("%n member(s) can now ban room members.", nullptr, true_affected_rest));
                 } else if (number_of_affected == 1) {
                     resultingMessage.append(
                       default_message + QStringLiteral(" ") +
@@ -2083,7 +2083,7 @@ TimelineModel::formatPowerLevelEvent(const QString &id)
                 if (number_of_affected > 1) {
                     resultingMessage.append(
                       default_message + QStringLiteral(" ") +
-                      tr("%n member(s) can now send state events.").arg(true_affected_rest));
+                      tr("%n member(s) can now send state events.", nullptr, true_affected_rest));
                 } else if (number_of_affected == 1) {
                     resultingMessage.append(
                       default_message + QStringLiteral(" ") +


### PR DESCRIPTION
Notes: This is my first journey to C++. This is also my first time QT. And last but not least, this is very WIP still.

This adds multiple specific strings for the powerlevel changes based upon the request from https://github.com/Nheko-Reborn/nheko/issues/136

# How it looks like currently

![image](https://user-images.githubusercontent.com/1374914/147159295-da7b7b50-17ff-4b7d-91ba-4f163985e76c.png)
![image](https://user-images.githubusercontent.com/1374914/147178717-b6aa375a-8655-4801-943a-b03419ada42e.png)


# TODOs

- [x] Properly display user PL changes and their effects.
- [x] Cleaning up code
- [x] Improving some strings from this