### PR TITLE
Request inline images in the right size and anti-alias them

### DIFF
--- a/src/MxcImageProvider.cpp
+++ b/src/MxcImageProvider.cpp
@@ -124,8 +124,11 @@ MxcImageProvider::download(const QString &id,
         if (fileInfo.exists()) {
             QImage image = utils::readImageFromFile(fileInfo.absoluteFilePath());
             if (!image.isNull()) {
-                if (requestedSize != image.size()) {
+                if (requestedSize.width() <= 0) {
                     image = image.scaledToHeight(requestedSize.height(), Qt::SmoothTransformation);
+                } else {
+                    image =
+                      image.scaled(requestedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
                 }
 
                 if (radius != 0) {
@@ -157,9 +160,12 @@ MxcImageProvider::download(const QString &id,
               auto data    = QByteArray(res.data(), (int)res.size());
               QImage image = utils::readImage(data);
               if (!image.isNull()) {
-                  if (requestedSize != image.size()) {
+                  if (requestedSize.width() <= 0) {
                       image =
                         image.scaledToHeight(requestedSize.height(), Qt::SmoothTransformation);
+                  } else {
+                      image =
+                        image.scaled(requestedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
                   }
 
                   if (radius != 0) {


### PR DESCRIPTION
- If an inline image has specified a height, add parameters to the
  image:// URI.
- Add scaled to the parameters, because Qt would use the width as a
  reference otherwise and the images would be too tall.
- Extract the parameters and use them for requestSize.
- If the requested width is 0 (normal for custom emojis), use the
  image's width.

----

Umm, I'm not 100% sure if I understand anything I did but it works. 😄