### PR TITLE
Fix and enhance man page

### DIFF
--- a/man/nheko.1.adoc.in
+++ b/man/nheko.1.adoc.in
@@ -1,6 +1,6 @@
 = nheko(1)
 :doctype:       manpage
-:Date:          2021-12-22
+:Date:          2022-01-01
 :Revision:      @PROJECT_VERSION@
 :man source:    nheko
 :man manual:    General Commands Manual
@@ -37,7 +37,7 @@ Enables debug output.
 Creates a unique profile, which allows you to log into several accounts at the
 same time and start multiple instances of nheko.
 
-== Keyboard shortcuts
+== KEYBOARD SHORTCUTS
 
 === Room list
 
@@ -82,7 +82,7 @@ Insert line break.
 *Enter*::
 Submit message.
 
-== Commands
+== COMMANDS
 
 === Custom messages
 
@@ -161,10 +161,10 @@ Rotates the encryption key used to send encrypted messages in a room.
 _address_ can be one of:
 
     _<event ID>_;;
-    Jumpd to event with the specified ID and highlights it.
+    Jumps to event with the specified ID and highlights it.
 
     _<message index>_;;
-    Jumpd to the message with the specified index and highlights it.
+    Jumps to the message with the specified index and highlights it.
 
     _<Matrix URI>_;;
     Handles Matrix URI as if you clicked on it.

--- a/man/nheko.1.adoc.in
+++ b/man/nheko.1.adoc.in
@@ -118,25 +118,25 @@ Join a room.
 */part*, */leave*::
 Leave the current room.
 
-*/invite* _<username>_::
-Invite a user into the current room.
+*/invite* _<username>_ _[reason]_::
+Invite a user into the current room. _reason_ is optional.
 
-*/kick* _<username>_::
-Kick a user from the current room.
+*/kick* _<username>_ _[reason]_::
+Kick a user from the current room. _reason_ is optional.
 
-*/ban* _<username>_::
-Ban a user from the current room.
+*/ban* _<username>_ _[reason]_::
+Ban a user from the current room. _reason_ is optional.
 
-*/unban* _<username>_::
-Unban a user.
+*/unban* _<username>_ _[reason]_::
+Unban a user. _reason_ is optional.
 
 */roomnick* _<roomname>_::
 Change your nickname in a single room.
 
 === Emoticons
 
-*/shrug*::
-Inserts `¯\_(ツ)_/¯`
+*/shrug* _[message]_::
+Inserts `¯\_(ツ)_/¯` followed by an optional _message_.
 
 */fliptable*::
 Inserts `(╯°□°)╯︵ ┻━┻`


### PR DESCRIPTION
Fixed some typos and documented the arguments for `invite`, `kick`, `ban`, `unban` and `shrug`.

The first level headings are actually always in upper-case in the man page, regardless of their case in AsciiDoc. The change is just for consistency.