### PR TITLE
Add GUI to change hidden events per room

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,6 +332,7 @@ set(SRC_FILES
 	src/timeline/RoomlistModel.cpp
 
 	# UI components
+	src/ui/HiddenEvents.cpp
 	src/ui/MxcAnimatedImage.cpp
 	src/ui/MxcMediaProxy.cpp
 	src/ui/NhekoCursorShape.cpp
@@ -403,7 +404,7 @@ if(USE_BUNDLED_MTXCLIENT)
 	FetchContent_Declare(
 		MatrixClient
 		GIT_REPOSITORY https://github.com/Nheko-Reborn/mtxclient.git
-		GIT_TAG        8c03d9ac58274695a71d0eb32519ebce29bc536e
+		GIT_TAG        31a703c9febdfcaaf4e8a74abd424b6fc462e573
 		)
 	set(BUILD_LIB_EXAMPLES OFF CACHE INTERNAL "")
 	set(BUILD_LIB_TESTS OFF CACHE INTERNAL "")
@@ -527,6 +528,7 @@ qt5_wrap_cpp(MOC_HEADERS
 	src/timeline/RoomlistModel.h
 
 	# UI components
+	src/ui/HiddenEvents.h
 	src/ui/MxcAnimatedImage.h
 	src/ui/MxcMediaProxy.h
 	src/ui/NhekoCursorShape.h

--- a/io.github.NhekoReborn.Nheko.yaml
+++ b/io.github.NhekoReborn.Nheko.yaml
@@ -191,7 +191,7 @@ modules:
     buildsystem: cmake-ninja
     name: mtxclient
     sources:
-      - commit: 8c03d9ac58274695a71d0eb32519ebce29bc536e
+      - commit: 31a703c9febdfcaaf4e8a74abd424b6fc462e573
         #tag: v0.6.1
         type: git
         url: https://github.com/Nheko-Reborn/mtxclient.git

--- a/resources/qml/dialogs/HiddenEventsDialog.qml
+++ b/resources/qml/dialogs/HiddenEventsDialog.qml
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2022 Nheko Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import ".."
+import QtQuick 2.12
+import QtQuick.Controls 2.5
+import QtQuick.Layouts 1.3
+import im.nheko 1.0
+
+ApplicationWindow {
+    id: hiddenEventsDialog
+
+    property alias prompt: promptLabel.text
+    property var onAccepted: undefined
+
+    modality: Qt.NonModal
+    flags: Qt.Dialog
+    minimumWidth: 250
+    minimumHeight: 220
+    Component.onCompleted: Nheko.reparent(hiddenEventsDialog)
+    title: qsTr("Hidden events settings for %1").arg(roomSettings.roomName)
+
+    Shortcut {
+        sequence: StandardKey.Cancel
+        onActivated: dbb.rejected()
+    }
+
+    ColumnLayout {
+        spacing: Nheko.paddingMedium
+        anchors.margins: Nheko.paddingMedium
+        anchors.fill: parent
+
+        MatrixText {
+            id: promptLabel
+            font.pixelSize: Math.floor(fontMetrics.font.pixelSize * 1.2)
+            Layout.fillWidth: true
+            Layout.fillHeight: false
+        }
+
+        GridLayout {
+            columns: 2
+            rowSpacing: Nheko.paddingMedium
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            MatrixText {
+                text: qsTr("User events")
+                ToolTip.text: qsTr("Joins, leaves, invites, knocks and bans")
+                ToolTip.visible: hh1.hovered
+                Layout.fillWidth: true
+
+                HoverHandler {
+                    id: hh1
+                }
+            }
+
+            ToggleButton {
+                id: toggleRoomMember
+                checked: roomSettings.eventHidden(0)
+                Layout.alignment: Qt.AlignRight
+            }
+
+            MatrixText {
+                text: qsTr("Power level changes")
+                ToolTip.text: qsTr("Is sent when a moderator is added or removed or the permissions of a room are changed (happens a lot in some IRC rooms)")
+                ToolTip.visible: hh2.hovered
+                Layout.fillWidth: true
+
+                HoverHandler {
+                    id: hh2
+                }
+            }
+
+            ToggleButton {
+                id: toggleRoomPowerLevels
+                checked: roomSettings.eventHidden(1)
+                Layout.alignment: Qt.AlignRight
+            }
+
+            MatrixText {
+                text: qsTr("Stickers")
+                Layout.fillWidth: true
+            }
+
+            ToggleButton {
+                id: toggleSticker
+                Layout.alignment: Qt.AlignRight
+                checked: roomSettings.eventHidden(2)
+            }
+        }
+    }
+
+    footer: DialogButtonBox {
+        id: dbb
+
+        standardButtons: DialogButtonBox.Ok | DialogButtonBox.Cancel
+        onAccepted: {
+            roomSettings.saveHiddenEventsSettings(toggleRoomMember.checked, toggleRoomPowerLevels.checked, toggleSticker.checked);
+
+            hiddenEventsDialog.close();
+        }
+        onRejected: {
+            hiddenEventsDialog.close();
+        }
+    }
+
+}

--- a/resources/qml/dialogs/HiddenEventsDialog.qml
+++ b/resources/qml/dialogs/HiddenEventsDialog.qml
@@ -11,17 +11,24 @@ import im.nheko 1.0
 ApplicationWindow {
     id: hiddenEventsDialog
 
-    property var isRoomSetting: false
+    property string roomid: ""
+    property string roomName: ""
     property var onAccepted: undefined
 
     modality: Qt.NonModal
     flags: Qt.Dialog | Qt.WindowTitleHint
     minimumWidth: 250
     minimumHeight: 220
-    Component.onCompleted: Nheko.reparent(hiddenEventsDialog)
+
+    HiddenEvents {
+        id: hiddenEvents
+
+        roomid: hiddenEventsDialog.roomid
+    }
+
     title: {
-        if (isRoomSetting) {
-            return qsTr("Hidden events for %1").arg(roomSettings.roomName);
+        if (roomid) {
+            return qsTr("Hidden events for %1").arg(roomName);
         }
         else {
             return qsTr("Hidden events");
@@ -41,8 +48,8 @@ ApplicationWindow {
         MatrixText {
             id: promptLabel
             text: {
-                if (isRoomSetting) {
-                    return qsTr("These events will be be <b>shown</b> in %1:").arg(roomSettings.roomName);
+                if (roomid) {
+                    return qsTr("These events will be be <b>shown</b> in %1:").arg(roomName);
                 }
                 else {
                     return qsTr("These events will be be <b>shown</b> in all rooms:");
@@ -71,9 +78,9 @@ ApplicationWindow {
             }
 
             ToggleButton {
-                id: toggleRoomMember
-                checked: !roomSettings.eventHidden("m.room.member")
                 Layout.alignment: Qt.AlignRight
+                checked: !hiddenEvents.hiddenEvents.includes(MtxEvent.Member)
+                onToggled: hiddenEvents.toggle(MtxEvent.Member)
             }
 
             MatrixText {
@@ -88,9 +95,9 @@ ApplicationWindow {
             }
 
             ToggleButton {
-                id: toggleRoomPowerLevels
-                checked: !roomSettings.eventHidden("m.room.power_levels")
                 Layout.alignment: Qt.AlignRight
+                checked: !hiddenEvents.hiddenEvents.includes(MtxEvent.PowerLevels)
+                onToggled: hiddenEvents.toggle(MtxEvent.PowerLevels)
             }
 
             MatrixText {
@@ -99,9 +106,9 @@ ApplicationWindow {
             }
 
             ToggleButton {
-                id: toggleSticker
                 Layout.alignment: Qt.AlignRight
-                checked: !roomSettings.eventHidden("m.sticker")
+                checked: !hiddenEvents.hiddenEvents.includes(MtxEvent.Sticker)
+                onToggled: hiddenEvents.toggle(MtxEvent.Sticker)
             }
         }
     }
@@ -111,23 +118,10 @@ ApplicationWindow {
 
         standardButtons: DialogButtonBox.Ok | DialogButtonBox.Cancel
         onAccepted: {
-            let events = new Array;
-            if (!toggleRoomMember.checked) {
-                events.push("m.room.member");
-            }
-            if (!toggleRoomPowerLevels.checked) {
-                events.push("m.room.power_levels");
-            }
-            if (!toggleSticker.checked) {
-                events.push("m.sticker");
-            }
-            roomSettings.saveHiddenEventsSettings(events, roomSettings.roomId);
-
+            hiddenEvents.save();
             hiddenEventsDialog.close();
         }
-        onRejected: {
-            hiddenEventsDialog.close();
-        }
+        onRejected: hiddenEventsDialog.close();
     }
 
 }

--- a/resources/qml/dialogs/HiddenEventsDialog.qml
+++ b/resources/qml/dialogs/HiddenEventsDialog.qml
@@ -45,7 +45,7 @@ ApplicationWindow {
                     return qsTr("These events will be be <b>shown</b> in %1:").arg(roomSettings.roomName);
                 }
                 else {
-                    return qsTr("These events will be be <b>shown</b>:");
+                    return qsTr("These events will be be <b>shown</b> in all rooms:");
                 }
             }
             font.pixelSize: Math.floor(fontMetrics.font.pixelSize * 1.2)

--- a/resources/qml/dialogs/HiddenEventsDialog.qml
+++ b/resources/qml/dialogs/HiddenEventsDialog.qml
@@ -121,7 +121,7 @@ ApplicationWindow {
             if (!toggleSticker.checked) {
                 events.push("m.sticker");
             }
-            roomSettings.saveHiddenEventsSettings(events);
+            roomSettings.saveHiddenEventsSettings(events, roomSettings.roomId);
 
             hiddenEventsDialog.close();
         }

--- a/resources/qml/dialogs/HiddenEventsDialog.qml
+++ b/resources/qml/dialogs/HiddenEventsDialog.qml
@@ -11,7 +11,7 @@ import im.nheko 1.0
 ApplicationWindow {
     id: hiddenEventsDialog
 
-    property alias prompt: promptLabel.text
+    property var isRoomSetting: false
     property var onAccepted: undefined
 
     modality: Qt.NonModal
@@ -19,7 +19,14 @@ ApplicationWindow {
     minimumWidth: 250
     minimumHeight: 220
     Component.onCompleted: Nheko.reparent(hiddenEventsDialog)
-    title: qsTr("Hidden events settings for %1").arg(roomSettings.roomName)
+    title: {
+        if (isRoomSetting) {
+            return qsTr("Hidden events for %1").arg(roomSettings.roomName);
+        }
+        else {
+            return qsTr("Hidden events");
+        }
+    }
 
     Shortcut {
         sequence: StandardKey.Cancel
@@ -33,6 +40,14 @@ ApplicationWindow {
 
         MatrixText {
             id: promptLabel
+            text: {
+                if (isRoomSetting) {
+                    return qsTr("These events will be be <b>shown</b> in %1:").arg(roomSettings.roomName);
+                }
+                else {
+                    return qsTr("These events will be be <b>shown</b>:");
+                }
+            }
             font.pixelSize: Math.floor(fontMetrics.font.pixelSize * 1.2)
             Layout.fillWidth: true
             Layout.fillHeight: false

--- a/resources/qml/dialogs/HiddenEventsDialog.qml
+++ b/resources/qml/dialogs/HiddenEventsDialog.qml
@@ -46,7 +46,7 @@ ApplicationWindow {
 
             MatrixText {
                 text: qsTr("User events")
-                ToolTip.text: qsTr("Joins, leaves, invites, knocks and bans")
+                ToolTip.text: qsTr("Joins, leaves, avatar and name changes, bans, …")
                 ToolTip.visible: hh1.hovered
                 Layout.fillWidth: true
 
@@ -63,7 +63,7 @@ ApplicationWindow {
 
             MatrixText {
                 text: qsTr("Power level changes")
-                ToolTip.text: qsTr("Is sent when a moderator is added or removed or the permissions of a room are changed (happens a lot in some IRC rooms)")
+                ToolTip.text: qsTr("Sent when a moderator is added/removed or the permissions of a room are changed.")
                 ToolTip.visible: hh2.hovered
                 Layout.fillWidth: true
 

--- a/resources/qml/dialogs/HiddenEventsDialog.qml
+++ b/resources/qml/dialogs/HiddenEventsDialog.qml
@@ -15,7 +15,7 @@ ApplicationWindow {
     property var onAccepted: undefined
 
     modality: Qt.NonModal
-    flags: Qt.Dialog
+    flags: Qt.Dialog | Qt.WindowTitleHint
     minimumWidth: 250
     minimumHeight: 220
     Component.onCompleted: Nheko.reparent(hiddenEventsDialog)
@@ -57,7 +57,7 @@ ApplicationWindow {
 
             ToggleButton {
                 id: toggleRoomMember
-                checked: roomSettings.eventHidden(0)
+                checked: !roomSettings.eventHidden("m.room.member")
                 Layout.alignment: Qt.AlignRight
             }
 
@@ -74,7 +74,7 @@ ApplicationWindow {
 
             ToggleButton {
                 id: toggleRoomPowerLevels
-                checked: roomSettings.eventHidden(1)
+                checked: !roomSettings.eventHidden("m.room.power_levels")
                 Layout.alignment: Qt.AlignRight
             }
 
@@ -86,7 +86,7 @@ ApplicationWindow {
             ToggleButton {
                 id: toggleSticker
                 Layout.alignment: Qt.AlignRight
-                checked: roomSettings.eventHidden(2)
+                checked: !roomSettings.eventHidden("m.sticker")
             }
         }
     }
@@ -96,7 +96,17 @@ ApplicationWindow {
 
         standardButtons: DialogButtonBox.Ok | DialogButtonBox.Cancel
         onAccepted: {
-            roomSettings.saveHiddenEventsSettings(toggleRoomMember.checked, toggleRoomPowerLevels.checked, toggleSticker.checked);
+            let events = new Array;
+            if (!toggleRoomMember.checked) {
+                events.push("m.room.member");
+            }
+            if (!toggleRoomPowerLevels.checked) {
+                events.push("m.room.power_levels");
+            }
+            if (!toggleSticker.checked) {
+                events.push("m.sticker");
+            }
+            roomSettings.saveHiddenEventsSettings(events);
 
             hiddenEventsDialog.close();
         }

--- a/resources/qml/dialogs/RoomSettings.qml
+++ b/resources/qml/dialogs/RoomSettings.qml
@@ -254,6 +254,22 @@ ApplicationWindow {
                 Layout.alignment: Qt.AlignRight
             }
 
+            MatrixText {
+                text: qsTr("Hidden events")
+            }
+
+            HiddenEventsDialog {
+                id: hiddenEventsDialog
+                prompt: qsTr("Select the events you want to hide from %1").arg(roomSettings.roomName)
+            }
+
+            Button {
+                text: qsTr("Configure")
+                ToolTip.text: qsTr("Change which events are hidden in this room")
+                onClicked: hiddenEventsDialog.show()
+                Layout.alignment: Qt.AlignRight
+            }
+
             Item {
                 // for adding extra space between sections
                 Layout.fillWidth: true
@@ -302,5 +318,4 @@ ApplicationWindow {
         }
 
     }
-
 }

--- a/resources/qml/dialogs/RoomSettings.qml
+++ b/resources/qml/dialogs/RoomSettings.qml
@@ -260,7 +260,8 @@ ApplicationWindow {
 
             HiddenEventsDialog {
                 id: hiddenEventsDialog
-                isRoomSetting: true
+                roomid: roomSettings.roomId
+                roomName: roomSettings.roomName
             }
 
             Button {

--- a/resources/qml/dialogs/RoomSettings.qml
+++ b/resources/qml/dialogs/RoomSettings.qml
@@ -260,7 +260,7 @@ ApplicationWindow {
 
             HiddenEventsDialog {
                 id: hiddenEventsDialog
-                prompt: qsTr("These events will be be <b>shown</b> in %1:").arg(roomSettings.roomName)
+                isRoomSetting: true
             }
 
             Button {

--- a/resources/qml/dialogs/RoomSettings.qml
+++ b/resources/qml/dialogs/RoomSettings.qml
@@ -260,12 +260,12 @@ ApplicationWindow {
 
             HiddenEventsDialog {
                 id: hiddenEventsDialog
-                prompt: qsTr("Select the events you want to hide from %1").arg(roomSettings.roomName)
+                prompt: qsTr("These events will be be <b>shown</b> in %1:").arg(roomSettings.roomName)
             }
 
             Button {
                 text: qsTr("Configure")
-                ToolTip.text: qsTr("Change which events are hidden in this room")
+                ToolTip.text: qsTr("Select events to hide in this room")
                 onClicked: hiddenEventsDialog.show()
                 Layout.alignment: Qt.AlignRight
             }

--- a/resources/res.qrc
+++ b/resources/res.qrc
@@ -152,6 +152,7 @@
         <file>qml/dialogs/RoomMembers.qml</file>
         <file>qml/dialogs/RoomSettings.qml</file>
         <file>qml/dialogs/UserProfile.qml</file>
+        <file>qml/dialogs/HiddenEventsDialog.qml</file>
         <file>qml/emoji/EmojiPicker.qml</file>
         <file>qml/emoji/StickerPicker.qml</file>
         <file>qml/ui/NhekoSlider.qml</file>

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -44,6 +44,7 @@
 #include "encryption/SelfVerificationStatus.h"
 #include "timeline/DelegateChooser.h"
 #include "timeline/TimelineViewManager.h"
+#include "ui/HiddenEvents.h"
 #include "ui/MxcAnimatedImage.h"
 #include "ui/MxcMediaProxy.h"
 #include "ui/NhekoCursorShape.h"
@@ -168,6 +169,7 @@ MainWindow::registerQmlTypes()
     qmlRegisterType<RoomDirectoryModel>("im.nheko", 1, 0, "RoomDirectoryModel");
     qmlRegisterType<LoginPage>("im.nheko", 1, 0, "Login");
     qmlRegisterType<RegisterPage>("im.nheko", 1, 0, "Registration");
+    qmlRegisterType<HiddenEvents>("im.nheko", 1, 0, "HiddenEvents");
     qmlRegisterUncreatableType<DeviceVerificationFlow>(
       "im.nheko",
       1,

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -50,59 +50,7 @@ struct RoomEventType
     template<class T>
     qml_mtx_events::EventType operator()(const mtx::events::Event<T> &e)
     {
-        using mtx::events::EventType;
-        switch (e.type) {
-        case EventType::RoomKeyRequest:
-            return qml_mtx_events::EventType::KeyRequest;
-        case EventType::Reaction:
-            return qml_mtx_events::EventType::Reaction;
-        case EventType::RoomAliases:
-            return qml_mtx_events::EventType::Aliases;
-        case EventType::RoomAvatar:
-            return qml_mtx_events::EventType::Avatar;
-        case EventType::RoomCanonicalAlias:
-            return qml_mtx_events::EventType::CanonicalAlias;
-        case EventType::RoomCreate:
-            return qml_mtx_events::EventType::RoomCreate;
-        case EventType::RoomEncrypted:
-            return qml_mtx_events::EventType::Encrypted;
-        case EventType::RoomEncryption:
-            return qml_mtx_events::EventType::Encryption;
-        case EventType::RoomGuestAccess:
-            return qml_mtx_events::EventType::RoomGuestAccess;
-        case EventType::RoomHistoryVisibility:
-            return qml_mtx_events::EventType::RoomHistoryVisibility;
-        case EventType::RoomJoinRules:
-            return qml_mtx_events::EventType::RoomJoinRules;
-        case EventType::RoomMember:
-            return qml_mtx_events::EventType::Member;
-        case EventType::RoomMessage:
-            return qml_mtx_events::EventType::UnknownMessage;
-        case EventType::RoomName:
-            return qml_mtx_events::EventType::Name;
-        case EventType::RoomPowerLevels:
-            return qml_mtx_events::EventType::PowerLevels;
-        case EventType::RoomTopic:
-            return qml_mtx_events::EventType::Topic;
-        case EventType::RoomTombstone:
-            return qml_mtx_events::EventType::Tombstone;
-        case EventType::RoomRedaction:
-            return qml_mtx_events::EventType::Redaction;
-        case EventType::RoomPinnedEvents:
-            return qml_mtx_events::EventType::PinnedEvents;
-        case EventType::Sticker:
-            return qml_mtx_events::EventType::Sticker;
-        case EventType::Tag:
-            return qml_mtx_events::EventType::Tag;
-        case EventType::SpaceParent:
-            return qml_mtx_events::EventType::SpaceParent;
-        case EventType::SpaceChild:
-            return qml_mtx_events::EventType::SpaceChild;
-        case EventType::Unsupported:
-            return qml_mtx_events::EventType::Unsupported;
-        default:
-            return qml_mtx_events::EventType::UnknownMessage;
-        }
+        return qml_mtx_events::toRoomEventType(e.type);
     }
     qml_mtx_events::EventType operator()(const mtx::events::Event<mtx::events::msg::Audio> &)
     {
@@ -196,6 +144,64 @@ struct RoomEventType
     // ::EventType::Type operator()(const Event<mtx::events::msg::Location> &e) { return
     // ::EventType::LocationMessage; }
 };
+}
+
+qml_mtx_events::EventType
+qml_mtx_events::toRoomEventType(mtx::events::EventType e)
+{
+    using mtx::events::EventType;
+    switch (e) {
+    case EventType::RoomKeyRequest:
+        return qml_mtx_events::EventType::KeyRequest;
+    case EventType::Reaction:
+        return qml_mtx_events::EventType::Reaction;
+    case EventType::RoomAliases:
+        return qml_mtx_events::EventType::Aliases;
+    case EventType::RoomAvatar:
+        return qml_mtx_events::EventType::Avatar;
+    case EventType::RoomCanonicalAlias:
+        return qml_mtx_events::EventType::CanonicalAlias;
+    case EventType::RoomCreate:
+        return qml_mtx_events::EventType::RoomCreate;
+    case EventType::RoomEncrypted:
+        return qml_mtx_events::EventType::Encrypted;
+    case EventType::RoomEncryption:
+        return qml_mtx_events::EventType::Encryption;
+    case EventType::RoomGuestAccess:
+        return qml_mtx_events::EventType::RoomGuestAccess;
+    case EventType::RoomHistoryVisibility:
+        return qml_mtx_events::EventType::RoomHistoryVisibility;
+    case EventType::RoomJoinRules:
+        return qml_mtx_events::EventType::RoomJoinRules;
+    case EventType::RoomMember:
+        return qml_mtx_events::EventType::Member;
+    case EventType::RoomMessage:
+        return qml_mtx_events::EventType::UnknownMessage;
+    case EventType::RoomName:
+        return qml_mtx_events::EventType::Name;
+    case EventType::RoomPowerLevels:
+        return qml_mtx_events::EventType::PowerLevels;
+    case EventType::RoomTopic:
+        return qml_mtx_events::EventType::Topic;
+    case EventType::RoomTombstone:
+        return qml_mtx_events::EventType::Tombstone;
+    case EventType::RoomRedaction:
+        return qml_mtx_events::EventType::Redaction;
+    case EventType::RoomPinnedEvents:
+        return qml_mtx_events::EventType::PinnedEvents;
+    case EventType::Sticker:
+        return qml_mtx_events::EventType::Sticker;
+    case EventType::Tag:
+        return qml_mtx_events::EventType::Tag;
+    case EventType::SpaceParent:
+        return qml_mtx_events::EventType::SpaceParent;
+    case EventType::SpaceChild:
+        return qml_mtx_events::EventType::SpaceChild;
+    case EventType::Unsupported:
+        return qml_mtx_events::EventType::Unsupported;
+    default:
+        return qml_mtx_events::EventType::UnknownMessage;
+    }
 }
 
 qml_mtx_events::EventType

--- a/src/timeline/TimelineModel.h
+++ b/src/timeline/TimelineModel.h
@@ -125,6 +125,8 @@ enum EventType
 };
 Q_ENUM_NS(EventType)
 mtx::events::EventType fromRoomEventType(qml_mtx_events::EventType);
+qml_mtx_events::EventType
+toRoomEventType(mtx::events::EventType e);
 
 enum EventState
 {

--- a/src/ui/HiddenEvents.cpp
+++ b/src/ui/HiddenEvents.cpp
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2022 Nheko Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "HiddenEvents.h"
+
+#include "Cache_p.h"
+#include "MainWindow.h"
+#include "MatrixClient.h"
+
+void
+HiddenEvents::load()
+{
+    using namespace mtx::events;
+    mtx::events::account_data::nheko_extensions::HiddenEvents hiddenEvents;
+    hiddenEvents.hidden_event_types = std::vector{
+      EventType::Reaction,
+      EventType::CallCandidates,
+      EventType::Unsupported,
+    };
+
+    if (auto temp =
+          cache::client()->getAccountData(mtx::events::EventType::NhekoHiddenEvents, "")) {
+        auto h = std::get<
+          mtx::events::AccountDataEvent<mtx::events::account_data::nheko_extensions::HiddenEvents>>(
+          *temp);
+        if (h.content.hidden_event_types)
+            hiddenEvents = std::move(h.content);
+    }
+
+    if (!roomid_.isEmpty()) {
+        if (auto temp = cache::client()->getAccountData(mtx::events::EventType::NhekoHiddenEvents,
+                                                        roomid_.toStdString())) {
+            auto h = std::get<mtx::events::AccountDataEvent<
+              mtx::events::account_data::nheko_extensions::HiddenEvents>>(*temp);
+            if (h.content.hidden_event_types)
+                hiddenEvents = std::move(h.content);
+        }
+    }
+
+    hiddenEvents_.clear();
+    hiddenEvents_ = std::move(hiddenEvents.hidden_event_types.value());
+    emit hiddenEventsChanged();
+}
+
+Q_INVOKABLE void
+HiddenEvents::toggle(int type)
+{
+    auto t = qml_mtx_events::fromRoomEventType(static_cast<qml_mtx_events::EventType>(type));
+    if (auto it = std::find(begin(hiddenEvents_), end(hiddenEvents_), t); it != end(hiddenEvents_))
+        hiddenEvents_.erase(it);
+    else
+        hiddenEvents_.push_back(t);
+    emit hiddenEventsChanged();
+}
+
+QVariantList
+HiddenEvents::hiddenEvents() const
+{
+    QVariantList l;
+    for (const auto &e : hiddenEvents_) {
+        l.push_back(qml_mtx_events::toRoomEventType(e));
+    }
+
+    return l;
+}
+
+void
+HiddenEvents::save()
+{
+    mtx::events::account_data::nheko_extensions::HiddenEvents hiddenEvents;
+    hiddenEvents.hidden_event_types = hiddenEvents_;
+
+    if (roomid_.isEmpty())
+        http::client()->put_account_data(hiddenEvents, [](mtx::http::RequestErr e) {
+            if (e) {
+                nhlog::net()->error("Failed to set hidden events: {}", *e);
+                MainWindow::instance()->showNotification(
+                  tr("Failed to set hidden events: %1")
+                    .arg(QString::fromStdString(e->matrix_error.error)));
+            }
+        });
+    else
+        http::client()->put_room_account_data(
+          roomid_.toStdString(), hiddenEvents, [](mtx::http::RequestErr e) {
+              if (e) {
+                  nhlog::net()->error("Failed to set hidden events: {}", *e);
+                  MainWindow::instance()->showNotification(
+                    tr("Failed to set hidden events: %1")
+                      .arg(QString::fromStdString(e->matrix_error.error)));
+              }
+          });
+}

--- a/src/ui/HiddenEvents.h
+++ b/src/ui/HiddenEvents.h
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2022 Nheko Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QVariantList>
+
+#include "timeline/TimelineModel.h"
+
+class HiddenEvents : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString roomid READ roomid WRITE setRoomid NOTIFY roomidChanged REQUIRED)
+    Q_PROPERTY(QVariantList hiddenEvents READ hiddenEvents NOTIFY hiddenEventsChanged)
+public:
+    explicit HiddenEvents(QObject *p = nullptr)
+      : QObject(p)
+    {}
+
+    Q_INVOKABLE void toggle(int type);
+    Q_INVOKABLE void save();
+
+    [[nodiscard]] QString roomid() const { return roomid_; }
+    void setRoomid(const QString &r)
+    {
+        roomid_ = r;
+        emit roomidChanged();
+
+        load();
+    }
+
+    [[nodiscard]] QVariantList hiddenEvents() const;
+
+signals:
+    void roomidChanged();
+    void hiddenEventsChanged();
+
+private:
+    QString roomid_;
+    std::vector<mtx::events::EventType> hiddenEvents_;
+
+    void load();
+};

--- a/src/ui/RoomSettings.cpp
+++ b/src/ui/RoomSettings.cpp
@@ -229,15 +229,7 @@ RoomSettings::RoomSettings(QString roomid, QObject *parent)
     }
     emit accessJoinRulesChanged();
 
-    if (auto hiddenEvents = cache::client()->getAccountData(
-          mtx::events::EventType::NhekoHiddenEvents, roomid_.toStdString())) {
-        if (auto tmp = std::get_if<mtx::events::EphemeralEvent<
-              mtx::events::account_data::nheko_extensions::HiddenEvents>>(&*hiddenEvents)) {
-            for (const auto event : tmp->content.hidden_event_types) {
-                hiddenEvents_.insert(mtx::events::to_string(event).data());
-            }
-        }
-    }
+    readHiddenEventsSettings(roomid_);
 }
 
 QString
@@ -681,4 +673,18 @@ bool
 RoomSettings::eventHidden(const QString event) const
 {
     return hiddenEvents_.contains(event);
+}
+
+void
+RoomSettings::readHiddenEventsSettings(const QString &roomId)
+{
+    if (auto hiddenEvents = cache::client()->getAccountData(
+          mtx::events::EventType::NhekoHiddenEvents, roomId.toStdString())) {
+        if (auto tmp = std::get_if<mtx::events::EphemeralEvent<
+              mtx::events::account_data::nheko_extensions::HiddenEvents>>(&*hiddenEvents)) {
+            for (const auto event : tmp->content.hidden_event_types) {
+                hiddenEvents_.insert(mtx::events::to_string(event).data());
+            }
+        }
+    }
 }

--- a/src/ui/RoomSettings.h
+++ b/src/ui/RoomSettings.h
@@ -134,6 +134,7 @@ private:
     void updateAccessRules(const std::string &room_id,
                            const mtx::events::state::JoinRules &,
                            const mtx::events::state::GuestAccess &);
+    void readHiddenEventsSettings(const QString &roomId = {});
 
 private:
     QString roomid_;

--- a/src/ui/RoomSettings.h
+++ b/src/ui/RoomSettings.h
@@ -111,9 +111,6 @@ public:
     Q_INVOKABLE void openEditModal();
     Q_INVOKABLE void changeAccessRules(int index);
     Q_INVOKABLE void changeNotifications(int currentIndex);
-    Q_INVOKABLE void
-    saveHiddenEventsSettings(const QSet<QString> &events, const QString &roomId = {});
-    Q_INVOKABLE bool eventHidden(QString event) const;
 
 signals:
     void loadingChanged();
@@ -134,7 +131,6 @@ private:
     void updateAccessRules(const std::string &room_id,
                            const mtx::events::state::JoinRules &,
                            const mtx::events::state::GuestAccess &);
-    void readHiddenEventsSettings(const QString &roomId = {});
 
 private:
     QString roomid_;
@@ -143,5 +139,4 @@ private:
     RoomInfo info_;
     int notifications_ = 0;
     int accessRules_   = 0;
-    QSet<QString> hiddenEvents_;
 };

--- a/src/ui/RoomSettings.h
+++ b/src/ui/RoomSettings.h
@@ -11,6 +11,7 @@
 #include <QString>
 
 #include <mtx/events/guest_access.hpp>
+#include <vector>
 
 #include "CacheStructs.h"
 
@@ -107,8 +108,11 @@ public:
     Q_INVOKABLE void enableEncryption();
     Q_INVOKABLE void updateAvatar();
     Q_INVOKABLE void openEditModal();
+    Q_INVOKABLE void
+    saveHiddenEventsSettings(bool toggleRoomMember, bool toggleRoomPowerLevels, bool toggleSticker);
     Q_INVOKABLE void changeAccessRules(int index);
     Q_INVOKABLE void changeNotifications(int currentIndex);
+    Q_INVOKABLE bool eventHidden(int index);
 
 signals:
     void loadingChanged();
@@ -137,4 +141,5 @@ private:
     RoomInfo info_;
     int notifications_ = 0;
     int accessRules_   = 0;
+    std::vector<bool> hiddenEvents_;
 };

--- a/src/ui/RoomSettings.h
+++ b/src/ui/RoomSettings.h
@@ -109,10 +109,10 @@ public:
     Q_INVOKABLE void enableEncryption();
     Q_INVOKABLE void updateAvatar();
     Q_INVOKABLE void openEditModal();
-    Q_INVOKABLE void
-    saveHiddenEventsSettings(const QSet<QString> &events, const QString &roomId = {});
     Q_INVOKABLE void changeAccessRules(int index);
     Q_INVOKABLE void changeNotifications(int currentIndex);
+    Q_INVOKABLE void
+    saveHiddenEventsSettings(const QSet<QString> &events, const QString &roomId = {});
     Q_INVOKABLE bool eventHidden(QString event) const;
 
 signals:

--- a/src/ui/RoomSettings.h
+++ b/src/ui/RoomSettings.h
@@ -8,10 +8,11 @@
 #include <QLabel>
 #include <QObject>
 #include <QPushButton>
+#include <QSet>
 #include <QString>
 
+#include <mtx/events/event_type.hpp>
 #include <mtx/events/guest_access.hpp>
-#include <vector>
 
 #include "CacheStructs.h"
 
@@ -108,11 +109,10 @@ public:
     Q_INVOKABLE void enableEncryption();
     Q_INVOKABLE void updateAvatar();
     Q_INVOKABLE void openEditModal();
-    Q_INVOKABLE void
-    saveHiddenEventsSettings(bool toggleRoomMember, bool toggleRoomPowerLevels, bool toggleSticker);
+    Q_INVOKABLE void saveHiddenEventsSettings(QSet<QString> events);
     Q_INVOKABLE void changeAccessRules(int index);
     Q_INVOKABLE void changeNotifications(int currentIndex);
-    Q_INVOKABLE bool eventHidden(int index);
+    Q_INVOKABLE bool eventHidden(QString event) const;
 
 signals:
     void loadingChanged();
@@ -141,5 +141,5 @@ private:
     RoomInfo info_;
     int notifications_ = 0;
     int accessRules_   = 0;
-    std::vector<bool> hiddenEvents_;
+    QSet<QString> hiddenEvents_;
 };

--- a/src/ui/RoomSettings.h
+++ b/src/ui/RoomSettings.h
@@ -109,7 +109,8 @@ public:
     Q_INVOKABLE void enableEncryption();
     Q_INVOKABLE void updateAvatar();
     Q_INVOKABLE void openEditModal();
-    Q_INVOKABLE void saveHiddenEventsSettings(QSet<QString> events);
+    Q_INVOKABLE void
+    saveHiddenEventsSettings(const QSet<QString> &events, const QString &roomId = {});
     Q_INVOKABLE void changeAccessRules(int index);
     Q_INVOKABLE void changeNotifications(int currentIndex);
     Q_INVOKABLE bool eventHidden(QString event) const;


### PR DESCRIPTION
This adds a dialog to the room settings in which the user can choose
which of these three event types they want to hide (additionally to the
default):

  - m.room.member
  - m.room.power_levels
  - m.sticker

The current state is read when room settings are opened and saved when
new settings are accepted.

----

I plan to add a GUI for global account settings too, but would like some feedback in the meantime. 😊

![screenshot_2022-01-12T09:13:53](https://user-images.githubusercontent.com/3681516/149089122-2811eeba-bee1-4ebc-9457-d18d85354590.png)
