### PR TITLE
Clear search text in StickerPicker when the popup closes

### DIFF
--- a/resources/qml/emoji/StickerPicker.qml
+++ b/resources/qml/emoji/StickerPicker.qml
@@ -75,7 +75,8 @@ Menu {
                 onVisibleChanged: {
                     if (visible)
                         forceActiveFocus();
-
+                    else
+                        clear();
                 }
 
                 Timer {


### PR DESCRIPTION
The sticker picker remembers the search results if it is reopened, but only in the same room. After a room change, the search text is remembered but the stickers are not filtered. This patch reapplies the filter if the search text is not empty.

Before: https://user-images.githubusercontent.com/3681516/152196568-c3e2901a-33c2-4d08-a2dd-754858062d90.mp4

After: https://user-images.githubusercontent.com/3681516/152196563-8e1ef372-287f-4e2c-aad2-254b99af3c75.mp4
