### PR TITLE
Allow room name in room settings to wrap

### DIFF
--- a/resources/qml/dialogs/RoomSettings.qml
+++ b/resources/qml/dialogs/RoomSettings.qml
@@ -100,7 +100,8 @@ ApplicationWindow {
             MatrixText {
                 text: roomSettings.roomName
                 font.pixelSize: fontMetrics.font.pixelSize * 2
-                Layout.alignment: Qt.AlignHCenter
+                Layout.fillWidth: true
+                horizontalAlignment: TextEdit.AlignHCenter
             }
 
             MatrixText {

--- a/resources/qml/dialogs/UserProfile.qml
+++ b/resources/qml/dialogs/UserProfile.qml
@@ -138,6 +138,9 @@ ApplicationWindow {
                 color: TimelineManager.userColor(profile.userid, Nheko.colors.window)
                 font.bold: true
                 Layout.alignment: Qt.AlignHCenter
+                Layout.maximumWidth: parent.width - (Nheko.paddingSmall * 2) - usernameChangeButton.anchors.leftMargin - (usernameChangeButton.width * 2)
+                horizontalAlignment: TextInput.AlignHCenter
+                wrapMode: TextInput.Wrap
                 selectByMouse: true
                 onAccepted: {
                     profile.changeUsername(displayUsername.text);
@@ -145,6 +148,7 @@ ApplicationWindow {
                 }
 
                 ImageButton {
+                    id: usernameChangeButton
                     visible: profile.isSelf
                     anchors.leftMargin: Nheko.paddingSmall
                     anchors.left: displayUsername.right

--- a/resources/qml/dialogs/UserProfile.qml
+++ b/resources/qml/dialogs/UserProfile.qml
@@ -187,6 +187,8 @@ ApplicationWindow {
                     text: qsTr("Room: %1").arg(profile.room ? profile.room.roomName : "")
                     ToolTip.text: qsTr("This is a room-specific profile. The user's name and avatar may be different from their global versions.")
                     ToolTip.visible: ma.hovered
+                    Layout.maximumWidth: parent.parent.width - (parent.spacing * 3) - 16
+                    horizontalAlignment: TextEdit.AlignHCenter
 
                     HoverHandler {
                         id: ma


### PR DESCRIPTION
Or, to be exact: Prevent it from being wider than the dialog.

Before: ![screenshot_2022-02-04T20:35](https://user-images.githubusercontent.com/3681516/152594571-89d94d81-bf7f-484d-be90-95ad4276984b.png)

After: ![screenshot_2022-02-04T20:50](https://user-images.githubusercontent.com/3681516/152594573-e2eb5a90-9f2b-4c22-a7ce-b3d6339f302c.png)
