### PR TITLE
Update openSUSE install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,20 @@ Make sure you have the testing repositories from `edge` enabled. Note that this 
 sudo apk add nheko
 ```
 
-#### openSUSE (Leap or Tumbleweed)
+#### openSUSE
+
+Note: these instructions have only been tested on Tumbleweed.
+
+First, install nheko:
 ```bash
+sudo zypper addrepo https://download.opensuse.org/repositories/network:messaging:matrix/openSUSE_Tumbleweed/network:messaging:matrix.repo
+sudo zypper ref
 sudo zypper in nheko
-# If you want to add identicon support and are using Tumbleweed, run these as well
+```
+
+If you want to add jdenticon support, run these commands as well:
+
+```bash
 sudo zypper addrepo https://download.opensuse.org/repositories/home:LorenDB/openSUSE_Tumbleweed/home:LorenDB.repo
 sudo zypper refresh
 sudo zypper install qt-jdenticon

--- a/README.md
+++ b/README.md
@@ -108,11 +108,9 @@ sudo zypper ref
 sudo zypper in nheko
 ```
 
-If you want to add jdenticon support, run these commands as well:
+If you want to add jdenticon support:
 
 ```bash
-sudo zypper addrepo https://download.opensuse.org/repositories/home:LorenDB/openSUSE_Tumbleweed/home:LorenDB.repo
-sudo zypper refresh
 sudo zypper install qt-jdenticon
 ```
 


### PR DESCRIPTION
I submitted qt-jdenticon to `network:messaging:matrix` (where nheko lives) and it was accepted, so here's the updated instructions.