### PR TITLE
use shortcode as a fallback for custom emote title

### DIFF
--- a/src/CombinedImagePackModel.cpp
+++ b/src/CombinedImagePackModel.cpp
@@ -60,7 +60,9 @@ CombinedImagePackModel::data(const QModelIndex &index, int role) const
             return QStringLiteral(
                      "<img data-mx-emoticon height=32 src=\"%1\" alt=\"%2\" title=\"%2\">")
               .arg(QString::fromStdString(images[index.row()].image.url).toHtmlEscaped(),
-                   QString::fromStdString(images[index.row()].image.body));
+                   images[index.row()].image.body.length() > 0
+                     ? QString::fromStdString(images[index.row()].image.body)
+                     : images[index.row()].shortcode);
         case Roles::Url:
             return QString::fromStdString(images[index.row()].image.url);
         case CompletionModel::SearchRole:

--- a/src/CombinedImagePackModel.cpp
+++ b/src/CombinedImagePackModel.cpp
@@ -60,7 +60,7 @@ CombinedImagePackModel::data(const QModelIndex &index, int role) const
             return QStringLiteral(
                      "<img data-mx-emoticon height=32 src=\"%1\" alt=\"%2\" title=\"%2\">")
               .arg(QString::fromStdString(images[index.row()].image.url).toHtmlEscaped(),
-                   images[index.row()].image.body.length() > 0
+                   !images[index.row()].image.body.empty()
                      ? QString::fromStdString(images[index.row()].image.body)
                      : images[index.row()].shortcode);
         case Roles::Url:


### PR DESCRIPTION
Some clients (e.g. FluffyChat) don't have a UI for specifying the emote title, and use the shortcode as the title instead. This sets the title accordingly even if the emote was added through such a client and only has a shortcode.

Personally, it's useful to me as the Discord bridge I use uses the title to bridge custom emotes, and not specifying the title causes it to be bridged as an image link instead.