### PR TITLE
Make hover highlight fill the full width of the timeline

### DIFF
--- a/resources/qml/TimelineRow.qml
+++ b/resources/qml/TimelineRow.qml
@@ -52,7 +52,8 @@ Item {
 
     Rectangle {
         color: (Settings.messageHoverHighlight && hovered) ? Nheko.colors.alternateBase : "transparent"
-        anchors.fill: row
+        anchors.fill: parent
+        anchors.leftMargin: Settings.smallAvatars? 0 : Nheko.avatarSize+8
     }
 
     TapHandler {


### PR DESCRIPTION
Rows in the message bubble design are only as wide as the bubbles. This
lead to invisible hover highlight. Now it's consistent.

![hover_highlight](https://user-images.githubusercontent.com/3681516/154599414-4fb43173-6b36-407e-99ba-b2c8ee60e7ca.png)

