### PR TITLE
Make search usable on mobile

### DIFF
--- a/resources/qml/QuickSwitcher.qml
+++ b/resources/qml/QuickSwitcher.qml
@@ -13,7 +13,7 @@ Popup {
     property int textHeight: Math.round(Qt.application.font.pixelSize * 2.4)
 
     background: null
-    width: Math.round(parent.width / 2)
+    width: Math.min(Math.max(Math.round(parent.width / 2),450),parent.width) // limiting width to parent.width/2 can be a bit narrow
     x: Math.round(parent.width / 2 - width / 2)
     y: Math.round(parent.height / 4 - height / 2)
     modal: true

--- a/resources/qml/RoomList.qml
+++ b/resources/qml/RoomList.qml
@@ -680,6 +680,24 @@ Page {
                     ripple: false
                     width: 22
                     height: 22
+                    image: ":/icons/icons/ui/search.svg"
+                    ToolTip.visible: hovered
+                    ToolTip.delay: Nheko.tooltipDelay
+                    ToolTip.text: qsTr("Search rooms (Ctrl+K)")
+                    Layout.margins: Nheko.paddingMedium
+                    onClicked: {
+                        var quickSwitch = quickSwitcherComponent.createObject(timelineRoot);
+                        quickSwitch.open();
+                    }
+                }
+
+                ImageButton {
+                    visible: !collapsed
+                    Layout.fillWidth: true
+                    hoverEnabled: true
+                    ripple: false
+                    width: 22
+                    height: 22
                     image: ":/icons/icons/ui/settings.svg"
                     ToolTip.visible: hovered
                     ToolTip.delay: Nheko.tooltipDelay

--- a/resources/qml/TimelineRow.qml
+++ b/resources/qml/TimelineRow.qml
@@ -48,7 +48,7 @@ Item {
     property bool hovered: false
 
     width: parent.width
-    height: row.height+(reactionRow > 0 ? reactionRow.height-2 : 0 )
+    height: row.height+(reactionRow.height > 0 ? reactionRow.height-2 : 0 )
 
     Rectangle {
         color: (Settings.messageHoverHighlight && hovered) ? Nheko.colors.alternateBase : "transparent"

--- a/resources/qml/TimelineRow.qml
+++ b/resources/qml/TimelineRow.qml
@@ -48,7 +48,7 @@ Item {
     property bool hovered: false
 
     width: parent.width
-    height: childrenRect.height
+    height: row.height+(reactionRow > 0 ? reactionRow.height-2 : 0 )
 
     Rectangle {
         color: (Settings.messageHoverHighlight && hovered) ? Nheko.colors.alternateBase : "transparent"


### PR DESCRIPTION
I added a search button below the rooms list (should this depend on mobileMode? I suppose since Ctrl+K isn't documented anywhere, it's not a bad idea to have a button with a corresponding ToolTip), it's not such a bad idea to have it always visible)
I also added a minimum width to the QuickSwitcher that is either 450 or the available width, depending on which one is narrower. You don't want it to be super narrow.