### PR TITLE
Add sender names to state events

### DIFF
--- a/resources/qml/TimelineRow.qml
+++ b/resources/qml/TimelineRow.qml
@@ -53,7 +53,7 @@ Item {
     Rectangle {
         color: (Settings.messageHoverHighlight && hovered) ? Nheko.colors.alternateBase : "transparent"
         anchors.fill: parent
-        anchors.leftMargin: Settings.smallAvatars? 0 : Nheko.avatarSize+8
+        // this looks better without margins
     }
 
     TapHandler {
@@ -72,10 +72,11 @@ Item {
         id: row
         property bool bubbleOnRight : isSender && Settings.bubbles
         property int bubblePadding: (parent.width-(Settings.smallAvatars? 0 : Nheko.avatarSize+8))/10
-        anchors.rightMargin: isSender || !Settings.bubbles? 0 : bubblePadding
-        anchors.leftMargin: (Settings.smallAvatars? 0 : Nheko.avatarSize+8) + (bubbleOnRight? bubblePadding : 0) // align bubble with section header
-        anchors.left: bubbleOnRight? undefined : parent.left
-        anchors.right: bubbleOnRight? parent.right : undefined
+        anchors.rightMargin: isStateEvent? 0 : (isSender || !Settings.bubbles? 0 : bubblePadding)
+        anchors.leftMargin: isStateEvent? 0 :((Settings.smallAvatars? 0 : Nheko.avatarSize+8) + (bubbleOnRight? bubblePadding : 0)) // align bubble with section header
+        anchors.left: isStateEvent? undefined : (bubbleOnRight? undefined : parent.left)
+        anchors.right: isStateEvent? undefined: (bubbleOnRight? parent.right : undefined)
+        anchors.horizontalCenter: isStateEvent? parent.horizontalCenter : undefined
         property int maxWidth: parent.width-anchors.leftMargin-anchors.rightMargin
         width: Settings.bubbles? Math.min(maxWidth,implicitWidth+metadata.width+12) : maxWidth
         leftPadding: 4

--- a/resources/qml/delegates/NoticeMessage.qml
+++ b/resources/qml/delegates/NoticeMessage.qml
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import QtQuick 2.5
 import im.nheko 1.0
 
 
@@ -10,5 +11,6 @@ TextMessage {
     property bool isStateEvent
     font.italic: true
     color: Nheko.colors.buttonText
-    font.pointSize: isStateEvent? 0.75*fontMetrics.font.pointSize : 1*fontMetrics.font.pointSize
+    font.pointSize: isStateEvent? 0.8*Settings.fontSize : Settings.fontSize
+    horizontalAlignment: isStateEvent? Text.AlignHCenter : undefined
 }

--- a/resources/qml/delegates/Pill.qml
+++ b/resources/qml/delegates/Pill.qml
@@ -11,9 +11,8 @@ Label {
     property bool isStateEvent
     color: Nheko.colors.text
     horizontalAlignment: Text.AlignHCenter
-    //height: contentHeight * 1.2
-    //width: contentWidth * 1.2
-    font.pointSize: isStateEvent? 0.75*fontMetrics.font.pointSize : 1*fontMetrics.font.pointSize
+    height: Math.round(fontMetrics.height * 1.4)
+    width: contentWidth * 1.2
 
     background: Rectangle {
         radius: parent.height / 2

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -2031,12 +2031,14 @@ TimelineModel::formatMemberEvent(const QString &id)
     QString user = QString::fromStdString(event->state_key);
     QString name = utils::replaceEmoji(displayName(user));
     QString rendered;
+    QString sender = QString::fromStdString(event->sender);
+    QString senderName = utils::replaceEmoji(displayName(sender));
 
     // see table https://matrix.org/docs/spec/client_server/latest#m-room-member
     using namespace mtx::events::state;
     switch (event->content.membership) {
     case Membership::Invite:
-        rendered = tr("%1 was invited.").arg(name);
+        rendered = tr("%1 invited %2.").arg(senderName).arg(name);
         break;
     case Membership::Join:
         if (prevEvent && prevEvent->content.membership == Membership::Join) {
@@ -2077,19 +2079,19 @@ TimelineModel::formatMemberEvent(const QString &id)
             if (event->state_key == event->sender)
                 rendered = tr("%1 rejected their invite.").arg(name);
             else
-                rendered = tr("Revoked the invite to %1.").arg(name);
+                rendered = tr("%2 revoked the invite to %1.").arg(name,senderName);
         } else if (prevEvent->content.membership == Membership::Join) {
             if (event->state_key == event->sender)
                 rendered = tr("%1 left the room.").arg(name);
             else
-                rendered = tr("Kicked %1.").arg(name);
+                rendered = tr("%2 kicked %1.").arg(name,senderName);
         } else if (prevEvent->content.membership == Membership::Ban) {
-            rendered = tr("Unbanned %1.").arg(name);
+            rendered = tr("%2 unbanned %1.").arg(name,senderName);
         } else if (prevEvent->content.membership == Membership::Knock) {
             if (event->state_key == event->sender)
                 rendered = tr("%1 redacted their knock.").arg(name);
             else
-                rendered = tr("Rejected the knock from %1.").arg(name);
+                rendered = tr("%2 rejected the knock from %1.").arg(name,senderName);
         } else
             return tr("%1 left after having already left!",
                       "This is a leave event after the user already left and shouldn't "
@@ -2098,7 +2100,7 @@ TimelineModel::formatMemberEvent(const QString &id)
         break;
 
     case Membership::Ban:
-        rendered = tr("%1 was banned.").arg(name);
+        rendered = tr("%1 banned %2").arg(senderName,name);
         break;
     case Membership::Knock:
         rendered = tr("%1 knocked.").arg(name);
@@ -2197,7 +2199,7 @@ TimelineModel::resetState()
       room_id_.toStdString(),
       [this](const mtx::responses::StateEvents &events_, mtx::http::RequestErr e) {
           if (e) {
-              nhlog::net()->error("Failed to retrive current room state: {}", *e);
+              nhlog::net()->error("Failed to retrieve current room state: {}", *e);
               return;
           }
 

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -2031,7 +2031,7 @@ TimelineModel::formatMemberEvent(const QString &id)
     QString user = QString::fromStdString(event->state_key);
     QString name = utils::replaceEmoji(displayName(user));
     QString rendered;
-    QString sender = QString::fromStdString(event->sender);
+    QString sender     = QString::fromStdString(event->sender);
     QString senderName = utils::replaceEmoji(displayName(sender));
 
     // see table https://matrix.org/docs/spec/client_server/latest#m-room-member
@@ -2079,19 +2079,19 @@ TimelineModel::formatMemberEvent(const QString &id)
             if (event->state_key == event->sender)
                 rendered = tr("%1 rejected their invite.").arg(name);
             else
-                rendered = tr("%2 revoked the invite to %1.").arg(name,senderName);
+                rendered = tr("%2 revoked the invite to %1.").arg(name, senderName);
         } else if (prevEvent->content.membership == Membership::Join) {
             if (event->state_key == event->sender)
                 rendered = tr("%1 left the room.").arg(name);
             else
-                rendered = tr("%2 kicked %1.").arg(name,senderName);
+                rendered = tr("%2 kicked %1.").arg(name, senderName);
         } else if (prevEvent->content.membership == Membership::Ban) {
-            rendered = tr("%2 unbanned %1.").arg(name,senderName);
+            rendered = tr("%2 unbanned %1.").arg(name, senderName);
         } else if (prevEvent->content.membership == Membership::Knock) {
             if (event->state_key == event->sender)
                 rendered = tr("%1 redacted their knock.").arg(name);
             else
-                rendered = tr("%2 rejected the knock from %1.").arg(name,senderName);
+                rendered = tr("%2 rejected the knock from %1.").arg(name, senderName);
         } else
             return tr("%1 left after having already left!",
                       "This is a leave event after the user already left and shouldn't "
@@ -2100,7 +2100,7 @@ TimelineModel::formatMemberEvent(const QString &id)
         break;
 
     case Membership::Ban:
-        rendered = tr("%1 banned %2").arg(senderName,name);
+        rendered = tr("%1 banned %2").arg(senderName, name);
         break;
     case Membership::Knock:
         rendered = tr("%1 knocked.").arg(name);

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -2038,7 +2038,7 @@ TimelineModel::formatMemberEvent(const QString &id)
     using namespace mtx::events::state;
     switch (event->content.membership) {
     case Membership::Invite:
-        rendered = tr("%1 invited %2.").arg(senderName).arg(name);
+        rendered = tr("%1 invited %2.").arg(senderName, name);
         break;
     case Membership::Join:
         if (prevEvent && prevEvent->content.membership == Membership::Join) {


### PR DESCRIPTION
- add sender names to state events
- center state events (I'm not too sure if this is the most attractive option. It makes sense for message bubbles (because the neutral between left and right is center, also aligns well with date bubbles), but left-align might be the better option without bubbles. Let's see what the senate thinks.
- text of state events is now slightly larger
- Pill doesn't get reduced in size anymore (that made it almost indistinguishable from other state events)
- fixed the padding of the Pill bubble.