### PR TITLE
flick left to reply

### DIFF
--- a/resources/qml/TimelineRow.qml
+++ b/resources/qml/TimelineRow.qml
@@ -48,16 +48,10 @@ Flickable {
     property bool hovered: false
 
     flickableDirection: Flickable.HorizontalFlick
-    property bool reachedThreshold
+
     onHorizontalOvershootChanged: {
-        if (horizontalOvershoot > 50) {
-            reachedThreshold = true
-        }
-    }
-    onFlickEnded: {
-        if (reachedThreshold) {
+        if (horizontalOvershoot > 50 && ! draggingHorizontally) { // trigger upon release
             chat.model.reply = eventId
-            reachedThreshold = false
         }
     }
 

--- a/resources/qml/TimelineRow.qml
+++ b/resources/qml/TimelineRow.qml
@@ -11,7 +11,7 @@ import QtQuick.Layouts 1.2
 import QtQuick.Window 2.13
 import im.nheko 1.0
 
-Item {
+Flickable {
     id: r
 
     required property double proportionalHeight
@@ -46,6 +46,20 @@ Item {
     required property int relatedEventCacheBuster
 
     property bool hovered: false
+
+    flickableDirection: Flickable.HorizontalFlick
+    property bool reachedThreshold
+    onHorizontalOvershootChanged: {
+        if (horizontalOvershoot > 50) {
+            reachedThreshold = true
+        }
+    }
+    onFlickEnded: {
+        if (reachedThreshold) {
+            chat.model.reply = eventId
+            reachedThreshold = false
+        }
+    }
 
     width: parent.width
     height: row.height+(reactionRow.height > 0 ? reactionRow.height-2 : 0 )

--- a/resources/qml/components/AdaptiveLayout.qml
+++ b/resources/qml/components/AdaptiveLayout.qml
@@ -131,6 +131,7 @@ Container {
         interactive: singlePageMode
         highlightMoveDuration: container.singlePageMode ? 200 : 0
         currentIndex: container.singlePageMode ? container.pageIndex : 0
+        boundsBehavior: Flickable.StopAtBounds
     }
 
 }


### PR DESCRIPTION
Seems to work just fine.
The reply pops up once the flick has ended. Making it pop up when the threshold is reached awkward
It requires to keep the AdaptiveLayout within its bounds (otherwise the two flicks will overlay in a really non-intuitive way)
flick right to go back to the rooms list still works the same. Right flick of timelinerow is minimal. Any chance of this causing problems?