### PR TITLE
disable auto-capitalization and auto-completion for MatrixTextField

### DIFF
--- a/resources/qml/MatrixTextField.qml
+++ b/resources/qml/MatrixTextField.qml
@@ -117,6 +117,7 @@ ColumnLayout {
         onTextEdited: c.textEdited()
         onAccepted: c.accepted()
         onEditingFinished: c.editingFinished()
+        inputMethodHints: Qt.ImhNoAutoUppercase | Qt.ImhNoPredictiveText
 
 
         background: Rectangle {


### PR DESCRIPTION
Search-while-you-type doesn't work with auto-completion and it's not necessary with searches and names. Auto-capitalization is probably also not what you want for the uses of MatrixTextField that I've seen.