### PR TITLE
Mobile message input

### DIFF
--- a/resources/qml/MessageInput.qml
+++ b/resources/qml/MessageInput.qml
@@ -19,6 +19,22 @@ Rectangle {
     Layout.preferredHeight: row.implicitHeight
     Layout.minimumHeight: 40
     property bool isNarrow: width < 450
+    property bool isExpanded
+
+    Component.onCompleted: {
+        if(!isNarrow) {
+            isExpanded = true
+        } else {
+            isExpanded = false
+        }
+    }
+    onWidthChanged: {
+        if(!isNarrow) {
+            isExpanded = true
+        } else {
+            isExpanded = false
+        }
+    }
 
     Component {
         id: placeCallDialog
@@ -35,9 +51,23 @@ Rectangle {
         visible: room ? room.permissions.canSend(MtxEvent.TextMessage) : false
         anchors.fill: parent
         spacing: 0
+        ImageButton {
+            visible: isNarrow
+            Layout.alignment: Qt.AlignBottom
+            hoverEnabled: true
+            width: 22
+            height: 22
+            image: isExpanded ? ":/icons/icons/ui/angle-arrow-left.svg" : ":/icons/icons/ui/collapsed.svg"
+            ToolTip.visible: hovered
+            ToolTip.text: isExpanded ? qsTr("Collapse") : qsTr("Expand")
+            Layout.margins: 8
+            onClicked: {
+                isExpanded = !isExpanded
+            }
+        }
 
         ImageButton {
-            visible: CallManager.callsSupported
+            visible: CallManager.callsSupported && isExpanded
             opacity: CallManager.haveCallInvite ? 0.3 : 1
             Layout.alignment: Qt.AlignBottom
             hoverEnabled: true
@@ -62,6 +92,7 @@ Rectangle {
         }
 
         ImageButton {
+            visible: isExpanded
             Layout.alignment: Qt.AlignBottom
             hoverEnabled: true
             width: 22
@@ -356,25 +387,8 @@ Rectangle {
         }
 
         ImageButton {
-            id: emojiButton
-
-            Layout.alignment: Qt.AlignRight | Qt.AlignBottom
-            Layout.margins: 8
-            hoverEnabled: true
-            width: 22
-            height: 22
-            image: ":/icons/icons/ui/smile.svg"
-            ToolTip.visible: hovered
-            ToolTip.text: qsTr("Emoji")
-            onClicked: emojiPopup.visible ? emojiPopup.close() : emojiPopup.show(emojiButton, function(emoji) {
-                messageInput.insert(messageInput.cursorPosition, emoji);
-                TimelineManager.focusMessageInput();
-            })
-        }
-
-        ImageButton {
             id: stickerButton
-            visible: !row.hasText || !isNarrow
+            visible: isExpanded
 
             Layout.alignment: Qt.AlignRight | Qt.AlignBottom
             Layout.margins: 8
@@ -398,7 +412,23 @@ Rectangle {
         }
 
         ImageButton {
-            visible: row.hasText || !isNarrow
+            id: emojiButton
+
+            Layout.alignment: Qt.AlignRight | Qt.AlignBottom
+            Layout.margins: 8
+            hoverEnabled: true
+            width: 22
+            height: 22
+            image: ":/icons/icons/ui/smile.svg"
+            ToolTip.visible: hovered
+            ToolTip.text: qsTr("Emoji")
+            onClicked: emojiPopup.visible ? emojiPopup.close() : emojiPopup.show(emojiButton, function(emoji) {
+                messageInput.insert(messageInput.cursorPosition, emoji);
+                TimelineManager.focusMessageInput();
+            })
+        }
+
+        ImageButton {
             Layout.alignment: Qt.AlignRight | Qt.AlignBottom
             Layout.margins: 8
             hoverEnabled: true

--- a/resources/qml/MessageInput.qml
+++ b/resources/qml/MessageInput.qml
@@ -18,6 +18,7 @@ Rectangle {
     Layout.fillWidth: true
     Layout.preferredHeight: row.implicitHeight
     Layout.minimumHeight: 40
+    property bool isNarrow: width < 450
 
     Component {
         id: placeCallDialog
@@ -29,6 +30,7 @@ Rectangle {
 
     RowLayout {
         id: row
+        property bool hasText: messageInput.length > 0
 
         visible: room ? room.permissions.canSend(MtxEvent.TextMessage) : false
         anchors.fill: parent
@@ -354,7 +356,25 @@ Rectangle {
         }
 
         ImageButton {
+            id: emojiButton
+
+            Layout.alignment: Qt.AlignRight | Qt.AlignBottom
+            Layout.margins: 8
+            hoverEnabled: true
+            width: 22
+            height: 22
+            image: ":/icons/icons/ui/smile.svg"
+            ToolTip.visible: hovered
+            ToolTip.text: qsTr("Emoji")
+            onClicked: emojiPopup.visible ? emojiPopup.close() : emojiPopup.show(emojiButton, function(emoji) {
+                messageInput.insert(messageInput.cursorPosition, emoji);
+                TimelineManager.focusMessageInput();
+            })
+        }
+
+        ImageButton {
             id: stickerButton
+            visible: !row.hasText || !isNarrow
 
             Layout.alignment: Qt.AlignRight | Qt.AlignBottom
             Layout.margins: 8
@@ -378,23 +398,7 @@ Rectangle {
         }
 
         ImageButton {
-            id: emojiButton
-
-            Layout.alignment: Qt.AlignRight | Qt.AlignBottom
-            Layout.margins: 8
-            hoverEnabled: true
-            width: 22
-            height: 22
-            image: ":/icons/icons/ui/smile.svg"
-            ToolTip.visible: hovered
-            ToolTip.text: qsTr("Emoji")
-            onClicked: emojiPopup.visible ? emojiPopup.close() : emojiPopup.show(emojiButton, function(emoji) {
-                messageInput.insert(messageInput.cursorPosition, emoji);
-                TimelineManager.focusMessageInput();
-            })
-        }
-
-        ImageButton {
+            visible: row.hasText || !isNarrow
             Layout.alignment: Qt.AlignRight | Qt.AlignBottom
             Layout.margins: 8
             hoverEnabled: true

--- a/resources/qml/MessageInput.qml
+++ b/resources/qml/MessageInput.qml
@@ -18,23 +18,8 @@ Rectangle {
     Layout.fillWidth: true
     Layout.preferredHeight: row.implicitHeight
     Layout.minimumHeight: 40
-    property bool isNarrow: width < 450
-    property bool isExpanded
+    property bool showAllButtons: width > 450 || (messageInput.length == 0 && !messageInput.inputMethodComposing)
 
-    Component.onCompleted: {
-        if(!isNarrow) {
-            isExpanded = true
-        } else {
-            isExpanded = false
-        }
-    }
-    onWidthChanged: {
-        if(!isNarrow) {
-            isExpanded = true
-        } else {
-            isExpanded = false
-        }
-    }
 
     Component {
         id: placeCallDialog
@@ -46,28 +31,13 @@ Rectangle {
 
     RowLayout {
         id: row
-        property bool hasText: messageInput.length > 0
 
         visible: room ? room.permissions.canSend(MtxEvent.TextMessage) : false
         anchors.fill: parent
         spacing: 0
-        ImageButton {
-            visible: isNarrow
-            Layout.alignment: Qt.AlignBottom
-            hoverEnabled: true
-            width: 22
-            height: 22
-            image: isExpanded ? ":/icons/icons/ui/angle-arrow-left.svg" : ":/icons/icons/ui/collapsed.svg"
-            ToolTip.visible: hovered
-            ToolTip.text: isExpanded ? qsTr("Collapse") : qsTr("Expand")
-            Layout.margins: 8
-            onClicked: {
-                isExpanded = !isExpanded
-            }
-        }
 
         ImageButton {
-            visible: CallManager.callsSupported && isExpanded
+            visible: CallManager.callsSupported && showAllButtons
             opacity: CallManager.haveCallInvite ? 0.3 : 1
             Layout.alignment: Qt.AlignBottom
             hoverEnabled: true
@@ -92,7 +62,7 @@ Rectangle {
         }
 
         ImageButton {
-            visible: isExpanded
+            visible: showAllButtons
             Layout.alignment: Qt.AlignBottom
             hoverEnabled: true
             width: 22
@@ -166,6 +136,7 @@ Rectangle {
                 padding: 0
                 topPadding: 8
                 bottomPadding: 8
+                leftPadding: inputBar.showAllButtons? 0 : 8
                 focus: true
                 onTextChanged: {
                     if (room)
@@ -388,7 +359,7 @@ Rectangle {
 
         ImageButton {
             id: stickerButton
-            visible: isExpanded
+            visible: showAllButtons
 
             Layout.alignment: Qt.AlignRight | Qt.AlignBottom
             Layout.margins: 8
@@ -439,6 +410,7 @@ Rectangle {
             ToolTip.visible: hovered
             ToolTip.text: qsTr("Send")
             onClicked: {
+                messageInput.append(messageInput.preeditText)
                 room.input.send();
             }
         }


### PR DESCRIPTION
The message input is way too narrow on my phone. Longer messages become a tall, narrow column with wasted space on the sides. So I decided to make some room. What I wrote works, but I'm not too happy with it.
I added a button that expands or collapses the buttons that you probably don't need while you're typing a message.
I didn't want to change the layout for wide enough windows and I also didn't want to shift things around for narrower layouts. I was thinking it would make sense to replace the send button with one of buttons that would otherwise be hidden. The buttons would swap as soon as there's text. But the buttons this makes sense for are Stickers, Files and calls, all of which are further left. It would be awkward to have them jumping around, so implementing this would probably require a change in button order independent of window width.
I also feel the call button doesn't belong in the message input but on the top right, probably because most popular messengers put it there.
Possibly the input text field should be hidden when the other buttons are expanded, because if it has text in it and changes width, it will also change height, which is a bit awkward.
Any ideas?

edit: the first commit was just a try, it's pretty much undone by the second one.