### PR TITLE
Mobile room settings

### DIFF
--- a/resources/qml/dialogs/RoomSettings.qml
+++ b/resources/qml/dialogs/RoomSettings.qml
@@ -41,105 +41,105 @@ ApplicationWindow {
         flickableDirection: Flickable.VerticalFlick
         contentWidth: contentLayout1.width
         contentHeight: contentLayout1.height
-    ColumnLayout {
-        id: contentLayout1
-        width: flickable.width
-        spacing: Nheko.paddingMedium
+        ColumnLayout {
+            id: contentLayout1
+            width: flickable.width
+            spacing: Nheko.paddingMedium
 
-        Avatar {
-            Layout.topMargin: Nheko.paddingMedium
-            url: roomSettings.roomAvatarUrl.replace("mxc://", "image://MxcImage/")
-            roomid: roomSettings.roomId
-            displayName: roomSettings.roomName
-            height: 130
-            width: 130
-            Layout.alignment: Qt.AlignHCenter
-            onClicked: {
-                if (roomSettings.canChangeAvatar)
-                    roomSettings.updateAvatar();
-
-            }
-        }
-
-        Spinner {
-            Layout.alignment: Qt.AlignHCenter
-            visible: roomSettings.isLoading
-            foreground: Nheko.colors.mid
-            running: roomSettings.isLoading
-        }
-
-        Text {
-            id: errorText
-
-            color: "red"
-            visible: opacity > 0
-            opacity: 0
-            Layout.alignment: Qt.AlignHCenter
-            wrapMode: Text.Wrap // somehow still doesn't wrap
-        }
-
-        SequentialAnimation {
-            id: hideErrorAnimation
-
-            running: false
-
-            PauseAnimation {
-                duration: 4000
-            }
-
-            NumberAnimation {
-                target: errorText
-                property: 'opacity'
-                to: 0
-                duration: 1000
-            }
-
-        }
-
-        Connections {
-            target: roomSettings
-            function onDisplayError(errorMessage) {
-                errorText.text = errorMessage;
-                errorText.opacity = 1;
-                hideErrorAnimation.restart();
-            }
-        }
-            Label {
-                text: roomSettings.roomName
+            Avatar {
+                Layout.topMargin: Nheko.paddingMedium
+                url: roomSettings.roomAvatarUrl.replace("mxc://", "image://MxcImage/")
+                roomid: roomSettings.roomId
+                displayName: roomSettings.roomName
+                height: 130
+                width: 130
                 Layout.alignment: Qt.AlignHCenter
-                font.pixelSize: fontMetrics.font.pixelSize * 2
+                onClicked: {
+                    if (roomSettings.canChangeAvatar)
+                        roomSettings.updateAvatar();
+
+                }
+            }
+
+            Spinner {
+                Layout.alignment: Qt.AlignHCenter
+                visible: roomSettings.isLoading
+                foreground: Nheko.colors.mid
+                running: roomSettings.isLoading
+            }
+
+            Text {
+                id: errorText
+
+                color: "red"
+                visible: opacity > 0
+                opacity: 0
+                Layout.alignment: Qt.AlignHCenter
+                wrapMode: Text.Wrap // somehow still doesn't wrap
+            }
+
+            SequentialAnimation {
+                id: hideErrorAnimation
+
+                running: false
+
+                PauseAnimation {
+                    duration: 4000
+                }
+
+                NumberAnimation {
+                    target: errorText
+                    property: 'opacity'
+                    to: 0
+                    duration: 1000
+                }
+
+            }
+
+            Connections {
+                target: roomSettings
+                function onDisplayError(errorMessage) {
+                    errorText.text = errorMessage;
+                    errorText.opacity = 1;
+                    hideErrorAnimation.restart();
+                }
+            }
+                Label {
+                    text: roomSettings.roomName
+                    Layout.alignment: Qt.AlignHCenter
+                    font.pixelSize: fontMetrics.font.pixelSize * 2
+                    Layout.fillWidth: true
+                    horizontalAlignment: TextEdit.AlignHCenter
+                }
+
+                Label {
+                    text: qsTr("%n member(s)", "", roomSettings.memberCount)
+                    Layout.alignment: Qt.AlignHCenter
+
+                    TapHandler {
+                        onSingleTapped: TimelineManager.openRoomMembers(Rooms.getRoomById(roomSettings.roomId))
+                    }
+
+                    CursorShape {
+                        cursorShape: Qt.PointingHandCursor
+                        anchors.fill: parent
+                    }
+
+                }
+
+            ImageButton {
+                Layout.alignment: Qt.AlignHCenter
+                image: ":/icons/icons/ui/edit.svg"
+                visible: roomSettings.canChangeNameAndTopic
+                onClicked: roomSettings.openEditModal()
+            }
+
+            TextArea {
+                Layout.fillHeight: true
+                Layout.alignment: Qt.AlignHCenter
                 Layout.fillWidth: true
-                horizontalAlignment: TextEdit.AlignHCenter
-            }
-
-            Label {
-                text: qsTr("%n member(s)", "", roomSettings.memberCount)
-                Layout.alignment: Qt.AlignHCenter
-
-                TapHandler {
-                    onSingleTapped: TimelineManager.openRoomMembers(Rooms.getRoomById(roomSettings.roomId))
-                }
-
-                CursorShape {
-                    cursorShape: Qt.PointingHandCursor
-                    anchors.fill: parent
-                }
-
-            }
-
-        ImageButton {
-            Layout.alignment: Qt.AlignHCenter
-            image: ":/icons/icons/ui/edit.svg"
-            visible: roomSettings.canChangeNameAndTopic
-            onClicked: roomSettings.openEditModal()
-        }
-
-        TextArea {
-            Layout.fillHeight: true
-            Layout.alignment: Qt.AlignHCenter
-            Layout.fillWidth: true
-            Layout.leftMargin: Nheko.paddingLarge
-            Layout.rightMargin: Nheko.paddingLarge
+                Layout.leftMargin: Nheko.paddingLarge
+                Layout.rightMargin: Nheko.paddingLarge
 
                 text: TimelineManager.escapeEmoji(roomSettings.roomTopic)
                 wrapMode: TextEdit.WordWrap
@@ -156,166 +156,166 @@ ApplicationWindow {
                     cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
                 }
 
-        }
-
-        GridLayout {
-            columns: 2
-            rowSpacing: Nheko.paddingMedium
-            Layout.margins: Nheko.paddingMedium
-
-            Label {
-                text: qsTr("SETTINGS")
-                font.bold: true
             }
 
-            Item {
-                Layout.fillWidth: true
-            }
+            GridLayout {
+                columns: 2
+                rowSpacing: Nheko.paddingMedium
+                Layout.margins: Nheko.paddingMedium
 
-            Label {
-                text: qsTr("Notifications")
-                Layout.fillWidth: true
-            }
-
-            ComboBox {
-                model: [qsTr("Muted"), qsTr("Mentions only"), qsTr("All messages")]
-                currentIndex: roomSettings.notifications
-                onActivated: {
-                    roomSettings.changeNotifications(index);
+                Label {
+                    text: qsTr("SETTINGS")
+                    font.bold: true
                 }
-                Layout.fillWidth: true
-            }
 
-            Label {
-                text: qsTr("Room access")
-                Layout.fillWidth: true
-            }
-
-            ComboBox {
-                enabled: roomSettings.canChangeJoinRules
-                model: {
-                    let opts = [qsTr("Anyone and guests"), qsTr("Anyone"), qsTr("Invited users")];
-                    if (roomSettings.supportsKnocking)
-                        opts.push(qsTr("By knocking"));
-
-                    if (roomSettings.supportsRestricted)
-                        opts.push(qsTr("Restricted by membership in other rooms"));
-
-                    return opts;
+                Item {
+                    Layout.fillWidth: true
                 }
-                currentIndex: roomSettings.accessJoinRules
-                onActivated: {
-                    roomSettings.changeAccessRules(index);
+
+                Label {
+                    text: qsTr("Notifications")
+                    Layout.fillWidth: true
                 }
-                Layout.fillWidth: true
-            }
 
-            Label {
-                text: qsTr("Encryption")
-            }
-
-            ToggleButton {
-                id: encryptionToggle
-
-                checked: roomSettings.isEncryptionEnabled
-                onCheckedChanged: {
-                    if (roomSettings.isEncryptionEnabled) {
-                        checked = true;
-                        return ;
+                ComboBox {
+                    model: [qsTr("Muted"), qsTr("Mentions only"), qsTr("All messages")]
+                    currentIndex: roomSettings.notifications
+                    onActivated: {
+                        roomSettings.changeNotifications(index);
                     }
-                    confirmEncryptionDialog.open();
+                    Layout.fillWidth: true
                 }
-                Layout.alignment: Qt.AlignRight
-            }
 
-            Platform.MessageDialog {
-                id: confirmEncryptionDialog
-
-                title: qsTr("End-to-End Encryption")
-                text: qsTr("Encryption is currently experimental and things might break unexpectedly. <br>
-                            Please take note that it can't be disabled afterwards.")
-                modality: Qt.NonModal
-                onAccepted: {
-                    if (roomSettings.isEncryptionEnabled)
-                        return ;
-
-                    roomSettings.enableEncryption();
+                Label {
+                    text: qsTr("Room access")
+                    Layout.fillWidth: true
                 }
-                onRejected: {
-                    encryptionToggle.checked = false;
+
+                ComboBox {
+                    enabled: roomSettings.canChangeJoinRules
+                    model: {
+                        let opts = [qsTr("Anyone and guests"), qsTr("Anyone"), qsTr("Invited users")];
+                        if (roomSettings.supportsKnocking)
+                            opts.push(qsTr("By knocking"));
+
+                        if (roomSettings.supportsRestricted)
+                            opts.push(qsTr("Restricted by membership in other rooms"));
+
+                        return opts;
+                    }
+                    currentIndex: roomSettings.accessJoinRules
+                    onActivated: {
+                        roomSettings.changeAccessRules(index);
+                    }
+                    Layout.fillWidth: true
                 }
-                buttons: Platform.MessageDialog.Ok | Platform.MessageDialog.Cancel
-            }
 
-            Label {
-                text: qsTr("Sticker & Emote Settings")
-            }
+                Label {
+                    text: qsTr("Encryption")
+                }
 
-            Button {
-                text: qsTr("Change")
-                ToolTip.text: qsTr("Change what packs are enabled, remove packs or create new ones")
-                onClicked: TimelineManager.openImagePackSettings(roomSettings.roomId)
-                Layout.alignment: Qt.AlignRight
-            }
+                ToggleButton {
+                    id: encryptionToggle
 
-            Label {
-                text: qsTr("Hidden events")
-            }
+                    checked: roomSettings.isEncryptionEnabled
+                    onCheckedChanged: {
+                        if (roomSettings.isEncryptionEnabled) {
+                            checked = true;
+                            return ;
+                        }
+                        confirmEncryptionDialog.open();
+                    }
+                    Layout.alignment: Qt.AlignRight
+                }
 
-            HiddenEventsDialog {
-                id: hiddenEventsDialog
-                roomid: roomSettings.roomId
-                roomName: roomSettings.roomName
-            }
+                Platform.MessageDialog {
+                    id: confirmEncryptionDialog
 
-            Button {
-                text: qsTr("Configure")
-                ToolTip.text: qsTr("Select events to hide in this room")
-                onClicked: hiddenEventsDialog.show()
-                Layout.alignment: Qt.AlignRight
-            }
+                    title: qsTr("End-to-End Encryption")
+                    text: qsTr("Encryption is currently experimental and things might break unexpectedly. <br>
+                                Please take note that it can't be disabled afterwards.")
+                    modality: Qt.NonModal
+                    onAccepted: {
+                        if (roomSettings.isEncryptionEnabled)
+                            return ;
 
-            Item {
-                // for adding extra space between sections
-                Layout.fillWidth: true
-            }
+                        roomSettings.enableEncryption();
+                    }
+                    onRejected: {
+                        encryptionToggle.checked = false;
+                    }
+                    buttons: Platform.MessageDialog.Ok | Platform.MessageDialog.Cancel
+                }
 
-            Item {
-                // for adding extra space between sections
-                Layout.fillWidth: true
-            }
+                Label {
+                    text: qsTr("Sticker & Emote Settings")
+                }
 
-            Label {
-                text: qsTr("INFO")
-                font.bold: true
-            }
+                Button {
+                    text: qsTr("Change")
+                    ToolTip.text: qsTr("Change what packs are enabled, remove packs or create new ones")
+                    onClicked: TimelineManager.openImagePackSettings(roomSettings.roomId)
+                    Layout.alignment: Qt.AlignRight
+                }
 
-            Item {
-                Layout.fillWidth: true
-            }
+                Label {
+                    text: qsTr("Hidden events")
+                }
 
-            Label {
-                text: qsTr("Internal ID")
-            }
+                HiddenEventsDialog {
+                    id: hiddenEventsDialog
+                    roomid: roomSettings.roomId
+                    roomName: roomSettings.roomName
+                }
 
-            Label {
-                text: roomSettings.roomId
-                font.pixelSize: Math.floor(fontMetrics.font.pixelSize * 0.8)
-                Layout.alignment: Qt.AlignRight
-            }
+                Button {
+                    text: qsTr("Configure")
+                    ToolTip.text: qsTr("Select events to hide in this room")
+                    onClicked: hiddenEventsDialog.show()
+                    Layout.alignment: Qt.AlignRight
+                }
 
-            Label {
-                text: qsTr("Room Version")
-            }
+                Item {
+                    // for adding extra space between sections
+                    Layout.fillWidth: true
+                }
 
-            Label {
-                text: roomSettings.roomVersion
-                font.pixelSize: fontMetrics.font.pixelSize
-                Layout.alignment: Qt.AlignRight
-            }
+                Item {
+                    // for adding extra space between sections
+                    Layout.fillWidth: true
+                }
 
+                Label {
+                    text: qsTr("INFO")
+                    font.bold: true
+                }
+
+                Item {
+                    Layout.fillWidth: true
+                }
+
+                Label {
+                    text: qsTr("Internal ID")
+                }
+
+                Label {
+                    text: roomSettings.roomId
+                    font.pixelSize: Math.floor(fontMetrics.font.pixelSize * 0.8)
+                    Layout.alignment: Qt.AlignRight
+                }
+
+                Label {
+                    text: qsTr("Room Version")
+                }
+
+                Label {
+                    text: roomSettings.roomVersion
+                    font.pixelSize: fontMetrics.font.pixelSize
+                    Layout.alignment: Qt.AlignRight
+                }
+
+            }
         }
-    }
     }
     footer: DialogButtonBox {
         standardButtons: DialogButtonBox.Ok

--- a/resources/qml/dialogs/RoomSettings.qml
+++ b/resources/qml/dialogs/RoomSettings.qml
@@ -17,8 +17,8 @@ ApplicationWindow {
 
     property var roomSettings
 
-    minimumWidth: 450
-    minimumHeight: 680
+    minimumWidth: 340
+    minimumHeight: 340
     palette: Nheko.colors
     color: Nheko.colors.window
     modality: Qt.NonModal
@@ -29,15 +29,25 @@ ApplicationWindow {
         sequence: StandardKey.Cancel
         onActivated: roomSettingsDialog.close()
     }
-
+    ScrollHelper {
+        flickable: flickable
+        anchors.fill: flickable
+    }
+    Flickable {
+        id: flickable
+        boundsBehavior: Flickable.StopAtBounds
+        anchors.fill: parent
+        clip: true
+        flickableDirection: Flickable.VerticalFlick
+        contentWidth: contentLayout1.width
+        contentHeight: contentLayout1.height
     ColumnLayout {
         id: contentLayout1
-
-        anchors.fill: parent
-        anchors.margins: Nheko.paddingMedium
+        width: flickable.width
         spacing: Nheko.paddingMedium
 
         Avatar {
+            Layout.topMargin: Nheko.paddingMedium
             url: roomSettings.roomAvatarUrl.replace("mxc://", "image://MxcImage/")
             roomid: roomSettings.roomId
             displayName: roomSettings.roomName
@@ -65,6 +75,7 @@ ApplicationWindow {
             visible: opacity > 0
             opacity: 0
             Layout.alignment: Qt.AlignHCenter
+            wrapMode: Text.Wrap // somehow still doesn't wrap
         }
 
         SequentialAnimation {
@@ -93,18 +104,15 @@ ApplicationWindow {
                 hideErrorAnimation.restart();
             }
         }
-
-        ColumnLayout {
-            Layout.alignment: Qt.AlignHCenter
-
-            MatrixText {
+            Label {
                 text: roomSettings.roomName
+                Layout.alignment: Qt.AlignHCenter
                 font.pixelSize: fontMetrics.font.pixelSize * 2
                 Layout.fillWidth: true
                 horizontalAlignment: TextEdit.AlignHCenter
             }
 
-            MatrixText {
+            Label {
                 text: qsTr("%n member(s)", "", roomSettings.memberCount)
                 Layout.alignment: Qt.AlignHCenter
 
@@ -119,8 +127,6 @@ ApplicationWindow {
 
             }
 
-        }
-
         ImageButton {
             Layout.alignment: Qt.AlignHCenter
             image: ":/icons/icons/ui/edit.svg"
@@ -128,14 +134,13 @@ ApplicationWindow {
             onClicked: roomSettings.openEditModal()
         }
 
-        ScrollView {
+        TextArea {
             Layout.fillHeight: true
             Layout.alignment: Qt.AlignHCenter
             Layout.fillWidth: true
             Layout.leftMargin: Nheko.paddingLarge
             Layout.rightMargin: Nheko.paddingLarge
 
-            TextArea {
                 text: TimelineManager.escapeEmoji(roomSettings.roomTopic)
                 wrapMode: TextEdit.WordWrap
                 textFormat: TextEdit.RichText
@@ -151,15 +156,14 @@ ApplicationWindow {
                     cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
                 }
 
-            }
-
         }
 
         GridLayout {
             columns: 2
             rowSpacing: Nheko.paddingMedium
+            Layout.margins: Nheko.paddingMedium
 
-            MatrixText {
+            Label {
                 text: qsTr("SETTINGS")
                 font.bold: true
             }
@@ -168,7 +172,7 @@ ApplicationWindow {
                 Layout.fillWidth: true
             }
 
-            MatrixText {
+            Label {
                 text: qsTr("Notifications")
                 Layout.fillWidth: true
             }
@@ -182,7 +186,7 @@ ApplicationWindow {
                 Layout.fillWidth: true
             }
 
-            MatrixText {
+            Label {
                 text: qsTr("Room access")
                 Layout.fillWidth: true
             }
@@ -206,7 +210,7 @@ ApplicationWindow {
                 Layout.fillWidth: true
             }
 
-            MatrixText {
+            Label {
                 text: qsTr("Encryption")
             }
 
@@ -243,7 +247,7 @@ ApplicationWindow {
                 buttons: Platform.MessageDialog.Ok | Platform.MessageDialog.Cancel
             }
 
-            MatrixText {
+            Label {
                 text: qsTr("Sticker & Emote Settings")
             }
 
@@ -254,7 +258,7 @@ ApplicationWindow {
                 Layout.alignment: Qt.AlignRight
             }
 
-            MatrixText {
+            Label {
                 text: qsTr("Hidden events")
             }
 
@@ -281,7 +285,7 @@ ApplicationWindow {
                 Layout.fillWidth: true
             }
 
-            MatrixText {
+            Label {
                 text: qsTr("INFO")
                 font.bold: true
             }
@@ -290,33 +294,31 @@ ApplicationWindow {
                 Layout.fillWidth: true
             }
 
-            MatrixText {
+            Label {
                 text: qsTr("Internal ID")
             }
 
-            MatrixText {
+            Label {
                 text: roomSettings.roomId
                 font.pixelSize: Math.floor(fontMetrics.font.pixelSize * 0.8)
                 Layout.alignment: Qt.AlignRight
             }
 
-            MatrixText {
+            Label {
                 text: qsTr("Room Version")
             }
 
-            MatrixText {
+            Label {
                 text: roomSettings.roomVersion
                 font.pixelSize: fontMetrics.font.pixelSize
                 Layout.alignment: Qt.AlignRight
             }
 
         }
-
-        DialogButtonBox {
-            Layout.fillWidth: true
-            standardButtons: DialogButtonBox.Ok
-            onAccepted: close()
-        }
-
+    }
+    }
+    footer: DialogButtonBox {
+        standardButtons: DialogButtonBox.Ok
+        onAccepted: close()
     }
 }

--- a/resources/qml/dialogs/RoomSettings.qml
+++ b/resources/qml/dialogs/RoomSettings.qml
@@ -115,6 +115,7 @@ ApplicationWindow {
                     horizontalAlignment: TextEdit.AlignHCenter
                     color: Nheko.colors.text
                     wrapMode: Text.Wrap
+                    textFormat: Text.RichText
                 }
 
                 Label {

--- a/resources/qml/dialogs/RoomSettings.qml
+++ b/resources/qml/dialogs/RoomSettings.qml
@@ -144,8 +144,8 @@ ApplicationWindow {
                 property bool cut: implicitHeight > 100
                 property bool showMore
                 clip: true
-                height: cut && !showMore? 100 : undefined
-                Layout.preferredHeight: height
+                Layout.maximumHeight: showMore? Number.POSITIVE_INFINITY : 100
+                Layout.preferredHeight: implicitHeight
                 Layout.alignment: Qt.AlignHCenter
                 Layout.fillWidth: true
                 Layout.leftMargin: Nheko.paddingLarge
@@ -373,8 +373,8 @@ ApplicationWindow {
     }
     Button {
         id: showMoreButton
-        x: contentLayout1.showMorePos.x
-        y: Math.min(contentLayout1.showMorePos.y-flickable.contentY,flickable.height-height)
+        anchors.horizontalCenter: flickable.horizontalCenter
+        y: Math.min(showMorePlaceholder.y+contentLayout1.y-flickable.contentY,flickable.height-height)
         visible: roomTopic.cut
         text: roomTopic.showMore? "show less" : "show more"
         onClicked: {roomTopic.showMore = !roomTopic.showMore

--- a/resources/qml/dialogs/RoomSettings.qml
+++ b/resources/qml/dialogs/RoomSettings.qml
@@ -18,7 +18,7 @@ ApplicationWindow {
     property var roomSettings
 
     minimumWidth: 340
-    minimumHeight: 340
+    minimumHeight: 450
     width: 450
     height: 680
     palette: Nheko.colors
@@ -41,11 +41,11 @@ ApplicationWindow {
         anchors.fill: parent
         clip: true
         flickableDirection: Flickable.VerticalFlick
-        contentWidth: contentLayout1.width
+        contentWidth: roomSettingsDialog.width
         contentHeight: contentLayout1.height
         ColumnLayout {
             id: contentLayout1
-            width: flickable.width
+            width: parent.width
             spacing: Nheko.paddingMedium
 
             Avatar {
@@ -78,6 +78,7 @@ ApplicationWindow {
                 opacity: 0
                 Layout.alignment: Qt.AlignHCenter
                 wrapMode: Text.Wrap // somehow still doesn't wrap
+                Layout.fillWidth: true
             }
 
             SequentialAnimation {
@@ -137,7 +138,12 @@ ApplicationWindow {
             }
 
             TextArea {
-                Layout.fillHeight: true
+                id: roomTopic
+                property bool cut: implicitHeight > 100
+                property bool showMore
+                clip: true
+                height: cut && !showMore? 100 : implicitHeight
+                Layout.preferredHeight: height
                 Layout.alignment: Qt.AlignHCenter
                 Layout.fillWidth: true
                 Layout.leftMargin: Nheko.paddingLarge
@@ -148,7 +154,7 @@ ApplicationWindow {
                 textFormat: TextEdit.RichText
                 readOnly: true
                 background: null
-                selectByMouse: true
+                selectByMouse: !Settings.mobileMode
                 color: Nheko.colors.text
                 horizontalAlignment: TextEdit.AlignHCenter
                 onLinkActivated: Nheko.openLink(link)
@@ -159,11 +165,20 @@ ApplicationWindow {
                 }
 
             }
+            Item {
+                Layout.alignment: Qt.AlignHCenter
+                id: showMorePlaceholder
+                Layout.preferredHeight: showMoreButton.height
+                Layout.preferredWidth: showMoreButton.width
+                visible: roomTopic.cut
+            }
+            property point showMorePos: mapToGlobal(showMorePlaceholder.x,showMorePlaceholder.y)
 
             GridLayout {
                 columns: 2
                 rowSpacing: Nheko.paddingMedium
                 Layout.margins: Nheko.paddingMedium
+                Layout.fillWidth: true
 
                 Label {
                     text: qsTr("SETTINGS")
@@ -186,6 +201,7 @@ ApplicationWindow {
                         roomSettings.changeNotifications(index);
                     }
                     Layout.fillWidth: true
+                    WheelHandler{} // suppress scrolling changing values
                 }
 
                 Label {
@@ -210,6 +226,7 @@ ApplicationWindow {
                         roomSettings.changeAccessRules(index);
                     }
                     Layout.fillWidth: true
+                    WheelHandler{} // suppress scrolling changing values
                 }
 
                 Label {
@@ -303,7 +320,9 @@ ApplicationWindow {
                 Label {
                     text: roomSettings.roomId
                     font.pixelSize: Math.floor(fontMetrics.font.pixelSize * 0.8)
+                    wrapMode: Text.WrapAnywhere
                     Layout.alignment: Qt.AlignRight
+                    Layout.fillWidth: true
                 }
 
                 Label {
@@ -317,6 +336,16 @@ ApplicationWindow {
                 }
 
             }
+        }
+    }
+    Button {
+        id: showMoreButton
+        x: contentLayout1.showMorePos.x
+        y: Math.min(contentLayout1.showMorePos.y-flickable.contentY,parent.height-height)
+        visible: roomTopic.cut
+        text: roomTopic.showMore? "show less" : "show more"
+        onClicked: {roomTopic.showMore = !roomTopic.showMore
+            console.log(flickable.visibleArea)
         }
     }
     footer: DialogButtonBox {

--- a/resources/qml/dialogs/RoomSettings.qml
+++ b/resources/qml/dialogs/RoomSettings.qml
@@ -114,6 +114,7 @@ ApplicationWindow {
                     Layout.fillWidth: true
                     horizontalAlignment: TextEdit.AlignHCenter
                     color: Nheko.colors.text
+                    wrapMode: Text.Wrap
                 }
 
                 Label {

--- a/resources/qml/dialogs/RoomSettings.qml
+++ b/resources/qml/dialogs/RoomSettings.qml
@@ -174,7 +174,6 @@ ApplicationWindow {
                 Layout.preferredWidth: showMoreButton.width
                 visible: roomTopic.cut
             }
-            property point showMorePos: mapToGlobal(showMorePlaceholder.x,showMorePlaceholder.y)
 
             GridLayout {
                 columns: 2
@@ -337,6 +336,7 @@ ApplicationWindow {
                         font.pixelSize: Math.floor(fontMetrics.font.pixelSize * 0.8)
                         color: Nheko.colors.text
                         width: parent.width
+                        horizontalAlignment: Text.AlignRight
                         wrapMode: Text.WrapAnywhere
                         ToolTip.text: qsTr("Copied to clipboard")
                         ToolTip.visible: toolTipTimer.running

--- a/resources/qml/dialogs/RoomSettings.qml
+++ b/resources/qml/dialogs/RoomSettings.qml
@@ -113,11 +113,13 @@ ApplicationWindow {
                     font.pixelSize: fontMetrics.font.pixelSize * 2
                     Layout.fillWidth: true
                     horizontalAlignment: TextEdit.AlignHCenter
+                    color: Nheko.colors.text
                 }
 
                 Label {
                     text: qsTr("%n member(s)", "", roomSettings.memberCount)
                     Layout.alignment: Qt.AlignHCenter
+                    color: Nheko.colors.text
 
                     TapHandler {
                         onSingleTapped: TimelineManager.openRoomMembers(Rooms.getRoomById(roomSettings.roomId))
@@ -142,7 +144,7 @@ ApplicationWindow {
                 property bool cut: implicitHeight > 100
                 property bool showMore
                 clip: true
-                height: cut && !showMore? 100 : implicitHeight
+                height: cut && !showMore? 100 : undefined
                 Layout.preferredHeight: height
                 Layout.alignment: Qt.AlignHCenter
                 Layout.fillWidth: true
@@ -183,6 +185,7 @@ ApplicationWindow {
                 Label {
                     text: qsTr("SETTINGS")
                     font.bold: true
+                    color: Nheko.colors.text
                 }
 
                 Item {
@@ -192,6 +195,7 @@ ApplicationWindow {
                 Label {
                     text: qsTr("Notifications")
                     Layout.fillWidth: true
+                    color: Nheko.colors.text
                 }
 
                 ComboBox {
@@ -207,6 +211,7 @@ ApplicationWindow {
                 Label {
                     text: qsTr("Room access")
                     Layout.fillWidth: true
+                    color: Nheko.colors.text
                 }
 
                 ComboBox {
@@ -231,6 +236,7 @@ ApplicationWindow {
 
                 Label {
                     text: qsTr("Encryption")
+                    color: Nheko.colors.text
                 }
 
                 ToggleButton {
@@ -268,6 +274,7 @@ ApplicationWindow {
 
                 Label {
                     text: qsTr("Sticker & Emote Settings")
+                    color: Nheko.colors.text
                 }
 
                 Button {
@@ -279,6 +286,7 @@ ApplicationWindow {
 
                 Label {
                     text: qsTr("Hidden events")
+                    color: Nheko.colors.text
                 }
 
                 HiddenEventsDialog {
@@ -307,6 +315,7 @@ ApplicationWindow {
                 Label {
                     text: qsTr("INFO")
                     font.bold: true
+                    color: Nheko.colors.text
                 }
 
                 Item {
@@ -315,24 +324,48 @@ ApplicationWindow {
 
                 Label {
                     text: qsTr("Internal ID")
+                    color: Nheko.colors.text
                 }
 
-                Label {
-                    text: roomSettings.roomId
-                    font.pixelSize: Math.floor(fontMetrics.font.pixelSize * 0.8)
-                    wrapMode: Text.WrapAnywhere
+                AbstractButton { // AbstractButton does not allow setting text color
                     Layout.alignment: Qt.AlignRight
                     Layout.fillWidth: true
+                    Layout.preferredHeight: idLabel.height
+                    Label { // TextEdit does not trigger onClicked
+                        id: idLabel
+                        text: roomSettings.roomId
+                        font.pixelSize: Math.floor(fontMetrics.font.pixelSize * 0.8)
+                        color: Nheko.colors.text
+                        width: parent.width
+                        wrapMode: Text.WrapAnywhere
+                        ToolTip.text: qsTr("Copied to clipboard")
+                        ToolTip.visible: toolTipTimer.running
+                    }
+                    TextEdit{ // label does not allow selection
+                        id: textEdit
+                        visible: false
+                        text: roomSettings.roomId
+                    }
+                    onClicked: {
+                        textEdit.selectAll()
+                        textEdit.copy()
+                        toolTipTimer.start()
+                    }
+                    Timer {
+                        id: toolTipTimer
+                    }
                 }
 
                 Label {
                     text: qsTr("Room Version")
+                    color: Nheko.colors.text
                 }
 
                 Label {
                     text: roomSettings.roomVersion
                     font.pixelSize: fontMetrics.font.pixelSize
                     Layout.alignment: Qt.AlignRight
+                    color: Nheko.colors.text
                 }
 
             }
@@ -341,7 +374,7 @@ ApplicationWindow {
     Button {
         id: showMoreButton
         x: contentLayout1.showMorePos.x
-        y: Math.min(contentLayout1.showMorePos.y-flickable.contentY,parent.height-height)
+        y: Math.min(contentLayout1.showMorePos.y-flickable.contentY,flickable.height-height)
         visible: roomTopic.cut
         text: roomTopic.showMore? "show less" : "show more"
         onClicked: {roomTopic.showMore = !roomTopic.showMore

--- a/resources/qml/dialogs/RoomSettings.qml
+++ b/resources/qml/dialogs/RoomSettings.qml
@@ -19,6 +19,8 @@ ApplicationWindow {
 
     minimumWidth: 340
     minimumHeight: 340
+    width: 450
+    height: 680
     palette: Nheko.colors
     color: Nheko.colors.window
     modality: Qt.NonModal


### PR DESCRIPTION
- RoomSettings now fits a mobile screen
- ScrollView in the middle was kind of awkward, it's now a Flickable for the whole thing (we don't need scrollbars). It is now a lot more similar to UserProfile, which imho is good for consistency.
- MatrixText seemed to serve no purpose, replaced by Label

There's still an issue with the error text not wrapping when it actually should. I haven't figured out how to make it behave.