### PR TITLE
Fix roomlist timestamp being off-screen

### DIFF
--- a/resources/qml/RoomList.qml
+++ b/resources/qml/RoomList.qml
@@ -273,7 +273,7 @@ Page {
                     Layout.minimumWidth: 100
                     width: parent.width - avatar.width
                     Layout.preferredWidth: parent.width - avatar.width
-                    spacing: Nheko.paddingSmall
+                    spacing: Nheko.paddingMedium
 
                     RowLayout {
                         Layout.fillWidth: true
@@ -282,12 +282,9 @@ Page {
                         ElidedLabel {
                             Layout.alignment: Qt.AlignBottom
                             color: roomItem.importantText
-                            elideWidth: textContent.width - timestamp.width - Nheko.paddingMedium
+                            elideWidth: width
                             fullText: roomName
                             textFormat: Text.RichText
-                        }
-
-                        Item {
                             Layout.fillWidth: true
                         }
 
@@ -313,12 +310,9 @@ Page {
                         ElidedLabel {
                             color: roomItem.unimportantText
                             font.pixelSize: fontMetrics.font.pixelSize * 0.9
-                            elideWidth: textContent.width - (notificationBubble.visible ? notificationBubble.width : 0) - Nheko.paddingSmall
+                            elideWidth: width
                             fullText: lastMessage
                             textFormat: Text.RichText
-                        }
-
-                        Item {
                             Layout.fillWidth: true
                         }
 

--- a/resources/qml/RoomList.qml
+++ b/resources/qml/RoomList.qml
@@ -38,7 +38,6 @@ Page {
         ScrollHelper {
             flickable: parent
             anchors.fill: parent
-            enabled: !Settings.mobileMode
         }
 
         Connections {


### PR DESCRIPTION
The cause of the problem is that ElidedLabel gets the elideWidth from the text without emojis, but the text with emoji has a different length, depending on the emoji font. This causes the layouts to be pushed over the edge and takes the timestamp with it. I fixed the layouting so this won't happen anymore, but the elideWidth is still wrong. I can't think of a good way to fix this. Still, I consider my changes an improvement both visually and in the code.