### PR TITLE
Show long reaction text in tooltip; Remove extra …

### DIFF
--- a/resources/qml/Reactions.qml
+++ b/resources/qml/Reactions.qml
@@ -33,11 +33,18 @@ Flow {
             implicitWidth: contentItem.childrenRect.width + contentItem.leftPadding * 2
             implicitHeight: contentItem.childrenRect.height
             ToolTip.visible: hovered
-            ToolTip.text: modelData.users
             ToolTip.delay: Nheko.tooltipDelay
             onClicked: {
                 console.debug("Picked " + modelData.key + "in response to " + reactionFlow.eventId + ". selfReactedEvent: " + modelData.selfReactedEvent);
                 room.input.reaction(reactionFlow.eventId, modelData.key);
+            }
+            Component.onCompleted: {
+                ToolTip.text = Qt.binding(function() {
+                    if (textMetrics.elidedText === textMetrics.text) {
+                        return modelData.users;
+                    }
+                    return modelData.displayKey + "\n" + modelData.users;
+                })
             }
 
             contentItem: Row {

--- a/resources/qml/Reactions.qml
+++ b/resources/qml/Reactions.qml
@@ -66,7 +66,15 @@ Flow {
                     id: reactionText
 
                     anchors.baseline: reactionCounter.baseline
-                    text: textMetrics.elidedText + (textMetrics.elidedText == modelData.displayKey ? "" : "…")
+                    text: {
+                        // When an emoji font is selected that doesn't have …, it is dropped from elidedText. So we add it back.
+                        if (textMetrics.elidedText !== modelData.displayKey) {
+                            if (!textMetrics.elidedText.endsWith("…")) {
+                                return textMetrics.elidedText + "…";
+                            }
+                        }
+                        return textMetrics.elidedText;
+                    }
                     font.family: Settings.emojiFont
                     color: reaction.hovered ? Nheko.colors.highlight : Nheko.colors.text
                     maximumLineCount: 1


### PR DESCRIPTION
If the reaction text is elided, it will be shown in the tooltip.

I was thinking of using `elidedText.width() === text.width()`, but what if `elidedText` is “Good morn...” and `text` is “Good morning”? :frowning_face: 

I'm not sure why the extra `…` were added to the text? Looks like nothing broke when I removed it.

![screenshot_2022-03-09T10:45](https://user-images.githubusercontent.com/3681516/157416282-95cda57f-e049-423f-b4f8-6617e992d2df.png)
