### PR TITLE
Use standard buttons where possible

### DIFF
--- a/resources/qml/dialogs/ImagePackEditorDialog.qml
+++ b/resources/qml/dialogs/ImagePackEditorDialog.qml
@@ -329,21 +329,12 @@ ApplicationWindow {
     footer: DialogButtonBox {
         id: buttons
 
-        Button {
-            text: qsTr("Cancel")
-            DialogButtonBox.buttonRole: DialogButtonBox.DestructiveRole
-            onClicked: win.close()
+        standardButtons: DialogButtonBox.Save | DialogButtonBox.Cancel
+        onAccepted: {
+            imagePack.save();
+            win.close();
         }
-
-        Button {
-            text: qsTr("Save")
-            DialogButtonBox.buttonRole: DialogButtonBox.ApplyRole
-            onClicked: {
-                imagePack.save();
-                win.close();
-            }
-        }
-
+        onRejected: win.close()
     }
 
 }

--- a/resources/qml/dialogs/JoinRoomDialog.qml
+++ b/resources/qml/dialogs/JoinRoomDialog.qml
@@ -54,6 +54,7 @@ ApplicationWindow {
     footer: DialogButtonBox {
         id: dbb
 
+        standardButtons: DialogButtonBox.Cancel
         onAccepted: {
             Nheko.joinRoom(input.text);
             joinRoomRoot.close();
@@ -66,11 +67,6 @@ ApplicationWindow {
             text: "Join"
             enabled: input.text.match("#.+?:.{3,}")
             DialogButtonBox.buttonRole: DialogButtonBox.AcceptRole
-        }
-
-        Button {
-            text: "Cancel"
-            DialogButtonBox.buttonRole: DialogButtonBox.RejectRole
         }
 
     }

--- a/src/dialogs/CreateRoom.cpp
+++ b/src/dialogs/CreateRoom.cpp
@@ -38,16 +38,10 @@ CreateRoom::CreateRoom(QWidget *parent)
                                conf::modals::WIDGET_MARGIN,
                                conf::modals::WIDGET_MARGIN);
 
-    auto buttonLayout = new QHBoxLayout();
-    buttonLayout->setSpacing(15);
-
+    buttonBox_  = new QDialogButtonBox(QDialogButtonBox::Cancel);
     confirmBtn_ = new QPushButton(tr("Create room"), this);
     confirmBtn_->setDefault(true);
-    cancelBtn_ = new QPushButton(tr("Cancel"), this);
-
-    buttonLayout->addStretch(1);
-    buttonLayout->addWidget(cancelBtn_);
-    buttonLayout->addWidget(confirmBtn_);
+    buttonBox_->addButton(confirmBtn_, QDialogButtonBox::AcceptRole);
 
     QFont font;
     font.setPointSizeF(font.pointSizeF() * 1.3);
@@ -101,9 +95,9 @@ CreateRoom::CreateRoom(QWidget *parent)
     layout->addLayout(visibilityLayout);
     layout->addLayout(presetLayout);
     layout->addLayout(directLayout);
-    layout->addLayout(buttonLayout);
+    layout->addWidget(buttonBox_);
 
-    connect(confirmBtn_, &QPushButton::clicked, this, [this]() {
+    connect(buttonBox_, &QDialogButtonBox::accepted, this, [this]() {
         request_.name            = nameInput_->text().toStdString();
         request_.topic           = topicInput_->text().toStdString();
         request_.room_alias_name = aliasInput_->text().toStdString();
@@ -114,7 +108,7 @@ CreateRoom::CreateRoom(QWidget *parent)
         emit close();
     });
 
-    connect(cancelBtn_, &QPushButton::clicked, this, [this]() {
+    connect(buttonBox_, &QDialogButtonBox::rejected, this, [this]() {
         clearFields();
         emit close();
     });

--- a/src/dialogs/CreateRoom.h
+++ b/src/dialogs/CreateRoom.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <QDialogButtonBox>
 #include <QFrame>
 
 #include <mtx/requests.hpp>
@@ -37,7 +38,7 @@ private:
     Toggle *directToggle_;
 
     QPushButton *confirmBtn_;
-    QPushButton *cancelBtn_;
+    QDialogButtonBox *buttonBox_;
 
     TextField *nameInput_;
     TextField *topicInput_;


### PR DESCRIPTION
Standard buttons are ordered in the right way and sometimes have an icon (depending on the theme I guess). Some buttons can't be made standard because they require a custom text. In these cases the cancel button might have an icon but the button with the accept role doesn't.

Fixes <https://matrix.to/#/%23nheko%3Anheko.im/%2476PZ2m6YftX8mqGIe9ettKbh_-pEYeVRQSJBfwFzWi0?via=pixie.town&via=matrix.org&via=matrix.flexinos.tech&via=half-shot.uk>.

### Screenshots

<details><summary>Create room</summary>

![1](https://user-images.githubusercontent.com/3681516/157866146-d7761539-ea30-49d9-8dcf-eb2b7a412396.png)
![3](https://user-images.githubusercontent.com/3681516/157866154-234bc827-6b9d-4925-9869-9d5c47789e81.png)

</details>

<details><summary>Join room</summary>

![2](https://user-images.githubusercontent.com/3681516/157866151-274a45d1-b82f-4b89-acd3-51632a6f2cb4.png)
![4](https://user-images.githubusercontent.com/3681516/157866157-d6dce98b-3587-4a56-880d-f705eb8731c4.png)

</details>

<details><summary>Image pack editor</summary>

![6](https://user-images.githubusercontent.com/3681516/157866160-7143a155-849e-474a-b8d1-d2309df42a3f.png)
![5](https://user-images.githubusercontent.com/3681516/157866158-6085dd40-8ee7-46bb-b4e1-9204ba1dae30.png)

</details>