### PR TITLE
options to open images/videos with external program by default

### DIFF
--- a/resources/langs/nheko_en.ts
+++ b/resources/langs/nheko_en.ts
@@ -2910,6 +2910,11 @@ Reason: %4</translation>
     </message>
     <message>
         <location line="+2"/>
+        <source>Open images with external program</source>
+        <translation>Open images with external program</translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Decrypt messages in sidebar</source>
         <translation>Decrypt messages in sidebar</translation>
     </message>

--- a/resources/langs/nheko_en.ts
+++ b/resources/langs/nheko_en.ts
@@ -2915,6 +2915,11 @@ Reason: %4</translation>
     </message>
     <message>
         <location line="+2"/>
+        <source>Open videos with external program</source>
+        <translation>Open videos with external program</translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Decrypt messages in sidebar</source>
         <translation>Decrypt messages in sidebar</translation>
     </message>

--- a/resources/qml/delegates/ImageMessage.qml
+++ b/resources/qml/delegates/ImageMessage.qml
@@ -68,7 +68,7 @@ Item {
     TapHandler {
         //enabled: type == MtxEvent.ImageMessage && (img.status == Image.Ready || mxcimage.loaded)
         onSingleTapped: {
-            TimelineManager.openImageOverlay(room, url, eventId);
+            Settings.openImageExternal ? room.openMedia(eventId) : TimelineManager.openImageOverlay(room, url, eventId);
             eventPoint.accepted = true;
         }
         gesturePolicy: TapHandler.ReleaseWithinBounds

--- a/resources/qml/delegates/PlayableMediaMessage.qml
+++ b/resources/qml/delegates/PlayableMediaMessage.qml
@@ -52,7 +52,7 @@ Item {
         height: parent.height - fileInfoLabel.height
 
         TapHandler {
-            onTapped: mediaControls.showControls()
+            onTapped: Settings.openVideoExternal ? room.openMedia(eventId) : mediaControls.showControls()
         }
 
         Image {

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -82,11 +82,12 @@ UserSettings::load(std::optional<QString> profile)
 
     font_ = settings.value(QStringLiteral("user/font_family"), "").toString();
 
-    avatarCircles_  = settings.value(QStringLiteral("user/avatar_circles"), true).toBool();
-    useIdenticon_   = settings.value(QStringLiteral("user/use_identicon"), true).toBool();
-    openImageExternal_   = settings.value(QStringLiteral("user/open_image_external"), false).toBool();
-    decryptSidebar_ = settings.value(QStringLiteral("user/decrypt_sidebar"), true).toBool();
-    privacyScreen_  = settings.value(QStringLiteral("user/privacy_screen"), false).toBool();
+    avatarCircles_     = settings.value(QStringLiteral("user/avatar_circles"), true).toBool();
+    useIdenticon_      = settings.value(QStringLiteral("user/use_identicon"), true).toBool();
+    openImageExternal_ = settings.value(QStringLiteral("user/open_image_external"), false).toBool();
+    openVideoExternal_ = settings.value(QStringLiteral("user/open_video_external"), false).toBool();
+    decryptSidebar_    = settings.value(QStringLiteral("user/decrypt_sidebar"), true).toBool();
+    privacyScreen_     = settings.value(QStringLiteral("user/privacy_screen"), false).toBool();
     privacyScreenTimeout_ =
       settings.value(QStringLiteral("user/privacy_screen_timeout"), 0).toInt();
     mobileMode_ = settings.value(QStringLiteral("user/mobile_mode"), false).toBool();
@@ -699,6 +700,16 @@ UserSettings::setOpenImageExternal(bool state)
 }
 
 void
+UserSettings::setOpenVideoExternal(bool state)
+{
+    if (state == openVideoExternal_)
+        return;
+    openVideoExternal_ = state;
+    emit openVideoExternalChanged(openVideoExternal_);
+    save();
+}
+
+void
 UserSettings::applyTheme()
 {
     QFile stylefile;
@@ -776,6 +787,7 @@ UserSettings::save()
     settings.setValue(QStringLiteral("currentProfile"), profile_);
     settings.setValue(QStringLiteral("use_identicon"), useIdenticon_);
     settings.setValue(QStringLiteral("open_image_external"), openImageExternal_);
+    settings.setValue(QStringLiteral("open_video_external"), openVideoExternal_);
 
     settings.endGroup(); // user
 
@@ -880,8 +892,10 @@ UserSettingsModel::data(const QModelIndex &index, int role) const
             return tr("Circular Avatars");
         case UseIdenticon:
             return tr("Use identicons");
-	case OpenImageExternal:
+        case OpenImageExternal:
             return tr("Open images with external program");
+        case OpenVideoExternal:
+            return tr("Open videos with external program");
         case DecryptSidebar:
             return tr("Decrypt messages in sidebar");
         case PrivacyScreen:
@@ -1006,8 +1020,10 @@ UserSettingsModel::data(const QModelIndex &index, int role) const
             return i->avatarCircles();
         case UseIdenticon:
             return i->useIdenticon();
-	case OpenImageExternal:
+        case OpenImageExternal:
             return i->openImageExternal();
+        case OpenVideoExternal:
+            return i->openVideoExternal();
         case DecryptSidebar:
             return i->decryptSidebar();
         case PrivacyScreen:
@@ -1150,9 +1166,12 @@ UserSettingsModel::data(const QModelIndex &index, int role) const
               "Change the appearance of user avatars in chats.\nOFF - square, ON - circle.");
         case UseIdenticon:
             return tr("Display an identicon instead of a letter when no avatar is set.");
-	case OpenImageExternal:
+        case OpenImageExternal:
             return tr("Click to open image with external program. \nSame as Right-Click>Open "
-		      "in External Program");
+                      "in external program");
+        case OpenVideoExternal:
+            return tr("Click to open video with external program. \nSame as Right-Click>Open "
+                      "in external program");
         case DecryptSidebar:
             return tr("Decrypt the messages shown in the sidebar.\nOnly affects messages in "
                       "encrypted chats.");
@@ -1249,7 +1268,8 @@ UserSettingsModel::data(const QModelIndex &index, int role) const
         case AlertOnNotification:
         case AvatarCircles:
         case UseIdenticon:
-	case OpenImageExternal:
+        case OpenImageExternal:
+        case OpenVideoExternal:
         case DecryptSidebar:
         case PrivacyScreen:
         case MobileMode:
@@ -1542,9 +1562,16 @@ UserSettingsModel::setData(const QModelIndex &index, const QVariant &value, int 
             } else
                 return false;
         }
-	case OpenImageExternal: {
+        case OpenImageExternal: {
             if (value.userType() == QMetaType::Bool) {
                 i->setOpenImageExternal(value.toBool());
+                return true;
+            } else
+                return false;
+        }
+        case OpenVideoExternal: {
+            if (value.userType() == QMetaType::Bool) {
+                i->setOpenVideoExternal(value.toBool());
                 return true;
             } else
                 return false;
@@ -1811,6 +1838,9 @@ UserSettingsModel::UserSettingsModel(QObject *p)
     });
     connect(s.get(), &UserSettings::openImageExternalChanged, this, [this]() {
         emit dataChanged(index(OpenImageExternal), index(OpenImageExternal), {Value});
+    });
+    connect(s.get(), &UserSettings::openVideoExternalChanged, this, [this]() {
+        emit dataChanged(index(OpenVideoExternal), index(OpenVideoExternal), {Value});
     });
     connect(s.get(), &UserSettings::privacyScreenChanged, this, [this]() {
         emit dataChanged(index(PrivacyScreen), index(PrivacyScreen), {Value});

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -1167,11 +1167,13 @@ UserSettingsModel::data(const QModelIndex &index, int role) const
         case UseIdenticon:
             return tr("Display an identicon instead of a letter when no avatar is set.");
         case OpenImageExternal:
-            return tr("Click to open image with external program. \nSame as Right-Click>Open "
-                      "in external program");
+            return tr("Toggles the behavior of \"Right-Click>Open with external program\" "
+                      "when tapping the image.\nNote that when this option is ON, opened "
+                      "files are left unencrypted on disk and must be manually deleted.");
         case OpenVideoExternal:
-            return tr("Click to open video with external program. \nSame as Right-Click>Open "
-                      "in external program");
+            return tr("Toggles the behavior of \"Right-Click>Open with external program\" "
+                      "when tapping the video.\nNote that when this option is ON, opened "
+                      "files are left unencrypted on disk and must be manually deleted.");
         case DecryptSidebar:
             return tr("Decrypt the messages shown in the sidebar.\nOnly affects messages in "
                       "encrypted chats.");

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -84,6 +84,7 @@ UserSettings::load(std::optional<QString> profile)
 
     avatarCircles_  = settings.value(QStringLiteral("user/avatar_circles"), true).toBool();
     useIdenticon_   = settings.value(QStringLiteral("user/use_identicon"), true).toBool();
+    openImageExternal_   = settings.value(QStringLiteral("user/open_image_external"), false).toBool();
     decryptSidebar_ = settings.value(QStringLiteral("user/decrypt_sidebar"), true).toBool();
     privacyScreen_  = settings.value(QStringLiteral("user/privacy_screen"), false).toBool();
     privacyScreenTimeout_ =
@@ -688,6 +689,16 @@ UserSettings::setUseIdenticon(bool state)
 }
 
 void
+UserSettings::setOpenImageExternal(bool state)
+{
+    if (state == openImageExternal_)
+        return;
+    openImageExternal_ = state;
+    emit openImageExternalChanged(openImageExternal_);
+    save();
+}
+
+void
 UserSettings::applyTheme()
 {
     QFile stylefile;
@@ -764,6 +775,7 @@ UserSettings::save()
     settings.setValue(QStringLiteral("use_stun_server"), useStunServer_);
     settings.setValue(QStringLiteral("currentProfile"), profile_);
     settings.setValue(QStringLiteral("use_identicon"), useIdenticon_);
+    settings.setValue(QStringLiteral("open_image_external"), openImageExternal_);
 
     settings.endGroup(); // user
 
@@ -868,6 +880,8 @@ UserSettingsModel::data(const QModelIndex &index, int role) const
             return tr("Circular Avatars");
         case UseIdenticon:
             return tr("Use identicons");
+	case OpenImageExternal:
+            return tr("Open images with external program");
         case DecryptSidebar:
             return tr("Decrypt messages in sidebar");
         case PrivacyScreen:
@@ -992,6 +1006,8 @@ UserSettingsModel::data(const QModelIndex &index, int role) const
             return i->avatarCircles();
         case UseIdenticon:
             return i->useIdenticon();
+	case OpenImageExternal:
+            return i->openImageExternal();
         case DecryptSidebar:
             return i->decryptSidebar();
         case PrivacyScreen:
@@ -1134,6 +1150,9 @@ UserSettingsModel::data(const QModelIndex &index, int role) const
               "Change the appearance of user avatars in chats.\nOFF - square, ON - circle.");
         case UseIdenticon:
             return tr("Display an identicon instead of a letter when no avatar is set.");
+	case OpenImageExternal:
+            return tr("Click to open image with external program. \nSame as Right-Click>Open "
+		      "in External Program");
         case DecryptSidebar:
             return tr("Decrypt the messages shown in the sidebar.\nOnly affects messages in "
                       "encrypted chats.");
@@ -1230,6 +1249,7 @@ UserSettingsModel::data(const QModelIndex &index, int role) const
         case AlertOnNotification:
         case AvatarCircles:
         case UseIdenticon:
+	case OpenImageExternal:
         case DecryptSidebar:
         case PrivacyScreen:
         case MobileMode:
@@ -1522,6 +1542,13 @@ UserSettingsModel::setData(const QModelIndex &index, const QVariant &value, int 
             } else
                 return false;
         }
+	case OpenImageExternal: {
+            if (value.userType() == QMetaType::Bool) {
+                i->setOpenImageExternal(value.toBool());
+                return true;
+            } else
+                return false;
+        }
         case DecryptSidebar: {
             if (value.userType() == QMetaType::Bool) {
                 i->setDecryptSidebar(value.toBool());
@@ -1781,6 +1808,9 @@ UserSettingsModel::UserSettingsModel(QObject *p)
     });
     connect(s.get(), &UserSettings::useIdenticonChanged, this, [this]() {
         emit dataChanged(index(UseIdenticon), index(UseIdenticon), {Value});
+    });
+    connect(s.get(), &UserSettings::openImageExternalChanged, this, [this]() {
+        emit dataChanged(index(OpenImageExternal), index(OpenImageExternal), {Value});
     });
     connect(s.get(), &UserSettings::privacyScreenChanged, this, [this]() {
         emit dataChanged(index(PrivacyScreen), index(PrivacyScreen), {Value});

--- a/src/UserSettingsPage.h
+++ b/src/UserSettingsPage.h
@@ -105,6 +105,7 @@ class UserSettings : public QObject
     Q_PROPERTY(bool disableCertificateValidation READ disableCertificateValidation WRITE
                  setDisableCertificateValidation NOTIFY disableCertificateValidationChanged)
     Q_PROPERTY(bool useIdenticon READ useIdenticon WRITE setUseIdenticon NOTIFY useIdenticonChanged)
+    Q_PROPERTY(bool openImageExternal READ openImageExternal WRITE setOpenImageExternal NOTIFY openImageExternalChanged)
 
     Q_PROPERTY(QStringList hiddenPins READ hiddenPins WRITE setHiddenPins NOTIFY hiddenPinsChanged)
     Q_PROPERTY(QStringList recentReactions READ recentReactions WRITE setRecentReactions NOTIFY
@@ -184,6 +185,7 @@ public:
     void setHiddenWidgets(QStringList hiddenTags);
     void setRecentReactions(QStringList recent);
     void setUseIdenticon(bool state);
+    void setOpenImageExternal(bool state);
     void setCollapsedSpaces(QList<QStringList> spaces);
 
     QString theme() const { return !theme_.isEmpty() ? theme_ : defaultTheme_; }
@@ -246,6 +248,7 @@ public:
     QStringList hiddenWidgets() const { return hiddenWidgets_; }
     QStringList recentReactions() const { return recentReactions_; }
     bool useIdenticon() const { return useIdenticon_ && JdenticonProvider::isAvailable(); }
+    bool openImageExternal() const { return openImageExternal_; }
     QList<QStringList> collapsedSpaces() const { return collapsedSpaces_; }
 
 signals:
@@ -297,6 +300,7 @@ signals:
     void homeserverChanged(QString homeserver);
     void disableCertificateValidationChanged(bool disabled);
     void useIdenticonChanged(bool state);
+    void openImageExternalChanged(bool state);
     void hiddenPinsChanged();
     void hiddenWidgetsChanged();
     void recentReactionsChanged();
@@ -361,6 +365,7 @@ private:
     QStringList recentReactions_;
     QList<QStringList> collapsedSpaces_;
     bool useIdenticon_;
+    bool openImageExternal_;
 
     QSettings settings;
 
@@ -384,6 +389,7 @@ class UserSettingsModel : public QAbstractListModel
         EmojiFont,
         AvatarCircles,
         UseIdenticon,
+	OpenImageExternal,
         PrivacyScreen,
         PrivacyScreenTimeout,
 
@@ -491,3 +497,4 @@ public:
     Q_INVOKABLE void requestCrossSigningSecrets();
     Q_INVOKABLE void downloadCrossSigningSecrets();
 };
+

--- a/src/UserSettingsPage.h
+++ b/src/UserSettingsPage.h
@@ -105,7 +105,10 @@ class UserSettings : public QObject
     Q_PROPERTY(bool disableCertificateValidation READ disableCertificateValidation WRITE
                  setDisableCertificateValidation NOTIFY disableCertificateValidationChanged)
     Q_PROPERTY(bool useIdenticon READ useIdenticon WRITE setUseIdenticon NOTIFY useIdenticonChanged)
-    Q_PROPERTY(bool openImageExternal READ openImageExternal WRITE setOpenImageExternal NOTIFY openImageExternalChanged)
+    Q_PROPERTY(bool openImageExternal READ openImageExternal WRITE setOpenImageExternal NOTIFY
+                 openImageExternalChanged)
+    Q_PROPERTY(bool openVideoExternal READ openVideoExternal WRITE setOpenVideoExternal NOTIFY
+                 openVideoExternalChanged)
 
     Q_PROPERTY(QStringList hiddenPins READ hiddenPins WRITE setHiddenPins NOTIFY hiddenPinsChanged)
     Q_PROPERTY(QStringList recentReactions READ recentReactions WRITE setRecentReactions NOTIFY
@@ -186,6 +189,7 @@ public:
     void setRecentReactions(QStringList recent);
     void setUseIdenticon(bool state);
     void setOpenImageExternal(bool state);
+    void setOpenVideoExternal(bool state);
     void setCollapsedSpaces(QList<QStringList> spaces);
 
     QString theme() const { return !theme_.isEmpty() ? theme_ : defaultTheme_; }
@@ -249,6 +253,7 @@ public:
     QStringList recentReactions() const { return recentReactions_; }
     bool useIdenticon() const { return useIdenticon_ && JdenticonProvider::isAvailable(); }
     bool openImageExternal() const { return openImageExternal_; }
+    bool openVideoExternal() const { return openVideoExternal_; }
     QList<QStringList> collapsedSpaces() const { return collapsedSpaces_; }
 
 signals:
@@ -301,6 +306,7 @@ signals:
     void disableCertificateValidationChanged(bool disabled);
     void useIdenticonChanged(bool state);
     void openImageExternalChanged(bool state);
+    void openVideoExternalChanged(bool state);
     void hiddenPinsChanged();
     void hiddenWidgetsChanged();
     void recentReactionsChanged();
@@ -366,6 +372,7 @@ private:
     QList<QStringList> collapsedSpaces_;
     bool useIdenticon_;
     bool openImageExternal_;
+    bool openVideoExternal_;
 
     QSettings settings;
 
@@ -389,7 +396,8 @@ class UserSettingsModel : public QAbstractListModel
         EmojiFont,
         AvatarCircles,
         UseIdenticon,
-	OpenImageExternal,
+        OpenImageExternal,
+        OpenVideoExternal,
         PrivacyScreen,
         PrivacyScreenTimeout,
 
@@ -497,4 +505,3 @@ public:
     Q_INVOKABLE void requestCrossSigningSecrets();
     Q_INVOKABLE void downloadCrossSigningSecrets();
 };
-

--- a/src/timeline/TimelineViewManager.h
+++ b/src/timeline/TimelineViewManager.h
@@ -133,3 +133,4 @@ Q_DECLARE_METATYPE(mtx::events::msg::KeyVerificationMac)
 Q_DECLARE_METATYPE(mtx::events::msg::KeyVerificationReady)
 Q_DECLARE_METATYPE(mtx::events::msg::KeyVerificationRequest)
 Q_DECLARE_METATYPE(mtx::events::msg::KeyVerificationStart)
+

--- a/src/timeline/TimelineViewManager.h
+++ b/src/timeline/TimelineViewManager.h
@@ -133,4 +133,3 @@ Q_DECLARE_METATYPE(mtx::events::msg::KeyVerificationMac)
 Q_DECLARE_METATYPE(mtx::events::msg::KeyVerificationReady)
 Q_DECLARE_METATYPE(mtx::events::msg::KeyVerificationRequest)
 Q_DECLARE_METATYPE(mtx::events::msg::KeyVerificationStart)
-


### PR DESCRIPTION
toggles the behaviour of "Right Click > Open with external program", but when tapping the image/video

this option only affects chat images/videos, avatar images for example are still open with the overlay previewer, closes #725 