### PR TITLE
properly commit preedit text

### DIFF
--- a/resources/qml/MessageInput.qml
+++ b/resources/qml/MessageInput.qml
@@ -446,10 +446,10 @@ Rectangle {
             width: 22
             height: 22
             image: ":/icons/icons/ui/send.svg"
+            Layout.rightMargin: 8
             ToolTip.visible: hovered
             ToolTip.text: qsTr("Send")
             onClicked: {
-                messageInput.append(messageInput.preeditText)
                 room.input.send();
             }
         }

--- a/src/timeline/InputBar.cpp
+++ b/src/timeline/InputBar.cpp
@@ -9,6 +9,7 @@
 #include <QDropEvent>
 #include <QFileDialog>
 #include <QGuiApplication>
+#include <QInputMethod>
 #include <QMimeData>
 #include <QMimeDatabase>
 #include <QStandardPaths>
@@ -234,6 +235,8 @@ InputBar::nextText()
 void
 InputBar::send()
 {
+    QInputMethod *im = QGuiApplication::inputMethod();
+    im->commit();
     if (text().trimmed().isEmpty())
         return;
 


### PR DESCRIPTION
Preedit text is now committed using the commit() function of the input method. This does away with undesired line breaks between the previously committed text and the current preedit text.