### PR TITLE
Fix input method

### DIFF
--- a/resources/qml/MessageInput.qml
+++ b/resources/qml/MessageInput.qml
@@ -224,8 +224,10 @@ Rectangle {
                                 return;
                             }
                         }
-                        room.input.send();
-                        event.accepted = true;
+                        if (!Qt.inputMethod.visible) {
+                            room.input.send();
+                            event.accepted = true;
+                        }
                     } else if (event.key == Qt.Key_Tab && (event.modifiers == Qt.NoModifier || event.modifiers == Qt.ShiftModifier)) {
                         event.accepted = true;
                         if (popup.opened) {

--- a/resources/qml/MessageInput.qml
+++ b/resources/qml/MessageInput.qml
@@ -175,8 +175,12 @@ Rectangle {
                         popup.close();
 
                     if (popup.opened)
-                        completer.completer.setSearchString(messageInput.getText(completerTriggeredAt, cursorPosition));
+                        completer.completer.setSearchString(messageInput.getText(completerTriggeredAt, cursorPosition)+messageInput.preeditText);
 
+                }
+                onPreeditTextChanged: {
+                    if (popup.opened)
+                        completer.completer.setSearchString(messageInput.getText(completerTriggeredAt, cursorPosition)+messageInput.preeditText);
                 }
                 onSelectionStartChanged: room.input.updateState(selectionStart, selectionEnd, cursorPosition, text)
                 onSelectionEndChanged: room.input.updateState(selectionStart, selectionEnd, cursorPosition, text)

--- a/resources/qml/MessageInput.qml
+++ b/resources/qml/MessageInput.qml
@@ -124,7 +124,7 @@ Rectangle {
                     completerTriggeredAt = pos;
                     completer.completerName = type;
                     popup.open();
-                    completer.completer.setSearchString(messageInput.getText(completerTriggeredAt, cursorPosition));
+                    completer.completer.setSearchString(messageInput.getText(completerTriggeredAt, cursorPosition)+messageInput.preeditText);
                 }
 
                 function positionCursorAtEnd() {

--- a/resources/qml/MessageInput.qml
+++ b/resources/qml/MessageInput.qml
@@ -147,11 +147,24 @@ Rectangle {
                 bottomPadding: 8
                 leftPadding: inputBar.showAllButtons? 0 : 8
                 focus: true
+                property string lastChar
                 onTextChanged: {
                     if (room)
                         room.input.updateState(selectionStart, selectionEnd, cursorPosition, text);
-
                     forceActiveFocus();
+                    if (cursorPosition > 0)
+                        lastChar = text.charAt(cursorPosition-1)
+                    else
+                        lastChar = ''
+                    if (lastChar == '@') {
+                        messageInput.openCompleter(selectionStart, "user");
+                    } else if (lastChar == ':') {
+                        messageInput.openCompleter(selectionStart, "emoji");
+                    } else if (lastChar == '#') {
+                        messageInput.openCompleter(selectionStart, "roomAliases");
+                    } else if (lastChar == "~") {
+                        messageInput.openCompleter(selectionStart, "customEmoji");
+                    }
                 }
                 onCursorPositionChanged: {
                     if (!room)
@@ -187,14 +200,6 @@ Rectangle {
                         messageInput.text = room.input.previousText();
                     } else if (event.modifiers == Qt.ControlModifier && event.key == Qt.Key_N) {
                         messageInput.text = room.input.nextText();
-                    } else if (event.key == Qt.Key_At) {
-                        messageInput.openCompleter(selectionStart, "user");
-                    } else if (event.key == Qt.Key_Colon) {
-                        messageInput.openCompleter(selectionStart, "emoji");
-                    } else if (event.key == Qt.Key_NumberSign) {
-                        messageInput.openCompleter(selectionStart, "roomAliases");
-                    } else if (event.text == "~") {
-                        messageInput.openCompleter(selectionStart, "customEmoji");
                     } else if (event.key == Qt.Key_Escape && popup.opened) {
                         completer.completerName = "";
                         popup.close();

--- a/resources/qml/MessageInput.qml
+++ b/resources/qml/MessageInput.qml
@@ -157,13 +157,13 @@ Rectangle {
                     else
                         lastChar = ''
                     if (lastChar == '@') {
-                        messageInput.openCompleter(selectionStart, "user");
+                        messageInput.openCompleter(selectionStart-1, "user");
                     } else if (lastChar == ':') {
-                        messageInput.openCompleter(selectionStart, "emoji");
+                        messageInput.openCompleter(selectionStart-1, "emoji");
                     } else if (lastChar == '#') {
-                        messageInput.openCompleter(selectionStart, "roomAliases");
+                        messageInput.openCompleter(selectionStart-1, "roomAliases");
                     } else if (lastChar == "~") {
-                        messageInput.openCompleter(selectionStart, "customEmoji");
+                        messageInput.openCompleter(selectionStart-1, "customEmoji");
                     }
                 }
                 onCursorPositionChanged: {


### PR DESCRIPTION
The completer pops up just fine and there don't seem to be new problems, although I don't understand the details of the text processing so I don't know what to test for.

Since my desktop input method seems to behave differently from the maliit, I don't know if the inclusion of the preedit text in the search string actually works. I'll give it a whirl once the gitlab runner is done.

As for not sending using Enter when it's coming from an On-Screen keyboard, that's a bit more difficult because QInputMethod has no QML equivalent (InputMethod is different), so we need to pull that information from C++. Another option would be to just disable send on enter when mobileMode is on, but that will probably upset a few people.