### PR TITLE
consider input method keyboard height and attempt to fix some layouti…

### DIFF
--- a/resources/qml/TimelineRow.qml
+++ b/resources/qml/TimelineRow.qml
@@ -105,7 +105,7 @@ Item {
                 Layout.fillWidth: true
                 Layout.maximumWidth: Settings.bubbles? Number.MAX_VALUE : implicitWidth
                 Layout.bottomMargin: visible? 2 : 0
-                Layout.preferredHeight: height
+                Layout.preferredHeight: implicitHeight
                 id: reply
 
                 function fromModel(role) {

--- a/resources/qml/delegates/ImageMessage.qml
+++ b/resources/qml/delegates/ImageMessage.qml
@@ -21,7 +21,7 @@ Item {
 
     property int tempWidth: originalWidth < 1? 400: originalWidth
 
-    implicitWidth: Math.round(tempWidth*Math.min((timelineView.height/divisor)/(tempWidth*proportionalHeight), 1))
+    implicitWidth: Math.round(tempWidth*Math.min(((timelineView.height+Qt.inputMethod.keyboardRectangle.height)/divisor)/(tempWidth*proportionalHeight), 1))
     width: Math.min(parent.width,implicitWidth)
     height: width*proportionalHeight
 

--- a/resources/qml/delegates/PlayableMediaMessage.qml
+++ b/resources/qml/delegates/PlayableMediaMessage.qml
@@ -25,7 +25,7 @@ Item {
     required property string filesize
     property double divisor: isReply ? 4 : 2
     property int tempWidth: originalWidth < 1? 400: originalWidth
-    implicitWidth: type == MtxEvent.VideoMessage ? Math.round(tempWidth*Math.min((timelineView.height/divisor)/(tempWidth*proportionalHeight), 1)) : 500
+    implicitWidth: type == MtxEvent.VideoMessage ? Math.round(tempWidth*Math.min(((timelineView.height+Qt.inputMethod.keyboardRectange.height)/divisor)/(tempWidth*proportionalHeight), 1)) : 500
     width: Math.min(parent.width, implicitWidth)
     height: (type == MtxEvent.VideoMessage ? width*proportionalHeight : 80) + fileInfoLabel.height
     implicitHeight: height

--- a/resources/qml/delegates/Reply.qml
+++ b/resources/qml/delegates/Reply.qml
@@ -39,8 +39,7 @@ Item {
     property int relatedEventCacheBuster
     property int maxWidth
 
-    height: replyContainer.height
-    implicitHeight: replyContainer.height
+    implicitHeight: replyContainer.implicitHeight
     implicitWidth: visible? colorLine.width+Math.max(replyContainer.implicitWidth,userName_.fullTextWidth) : 0 // visible? seems to be causing issues
 
     CursorShape {
@@ -96,10 +95,15 @@ Item {
                 elideWidth: width
             }
             onClicked: room.openUserProfile(userId)
+            CursorShape {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+            }
         }
 
         MessageDelegate {
             Layout.leftMargin: 4
+            Layout.maximumHeight: (timelineView.height+Qt.inputMethod.keyboardRectangle.height) / 8 //this also applies to images etc., but isn't that actually reasonable?
             Layout.preferredHeight: height
             id: reply
             blurhash: r.blurhash
@@ -128,6 +132,12 @@ Item {
             enabled: false
             Layout.fillWidth: true
             isReply: true
+            clip: true
+
+            CursorShape {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+            }
         }
 
     }

--- a/resources/qml/delegates/TextMessage.qml
+++ b/resources/qml/delegates/TextMessage.qml
@@ -36,15 +36,8 @@ MatrixText {
     </style>
     " + formatted.replace(/<pre>/g, "<pre style='white-space: pre-wrap; background-color: " + Nheko.colors.alternateBase + "'>").replace(/<del>/g, "<s>").replace(/<\/del>/g, "</s>").replace(/<strike>/g, "<s>").replace(/<\/strike>/g, "</s>")
     width: parent.width
-    height: isReply ? Math.round(Math.min(timelineView.height / 8, implicitHeight)) : implicitHeight
-    clip: isReply
+    //height: isReply ? Math.round(Math.min(timelineView.height / 8, implicitHeight)) : implicitHeight
     selectByMouse: !Settings.mobileMode && !isReply
     font.pointSize: (Settings.enlargeEmojiOnlyMessages && isOnlyEmoji > 0 && isOnlyEmoji < 4) ? Settings.fontSize * 3 : Settings.fontSize
-
-    CursorShape {
-        enabled: isReply
-        anchors.fill: parent
-        cursorShape: Qt.PointingHandCursor
-    }
 
 }

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -1132,7 +1132,7 @@ UserSettingsModel::data(const QModelIndex &index, int role) const
               "text.");
         case Bubbles:
             return tr(
-              "Messages get a bubble background. This also triggers some layout changes (WIP).");
+              "Messages get a bubble background. This also triggers some layout changes.");
         case SmallAvatars:
             return tr("Avatars are resized to fit above the message.");
         case AnimateImagesOnHover:

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -1131,8 +1131,7 @@ UserSettingsModel::data(const QModelIndex &index, int role) const
               "Allow using markdown in messages.\nWhen disabled, all messages are sent as a plain "
               "text.");
         case Bubbles:
-            return tr(
-              "Messages get a bubble background. This also triggers some layout changes.");
+            return tr("Messages get a bubble background. This also triggers some layout changes.");
         case SmallAvatars:
             return tr("Avatars are resized to fit above the message.");
         case AnimateImagesOnHover:


### PR DESCRIPTION
Initially I just wanted to add the check for the input method height, but I ended up cleaning up the layouting a bit, in the hope of fixing a glitch I'd been experiencing (last row of messages is sometimes outside the bubble on my phone, probably triggered by jerky resizing).

I made replies always 1/8 of the timeline height, no matter the type of the reply. That made layouting simpler and it seems to just make sense that way.