### PR TITLE
D-Bus fixes

### DIFF
--- a/src/dbus/NhekoDBusApi.cpp
+++ b/src/dbus/NhekoDBusApi.cpp
@@ -114,8 +114,7 @@ getRooms()
 {
     if (QDBusInterface interface{QStringLiteral(NHEKO_DBUS_SERVICE_NAME), QStringLiteral("/")};
         interface.isValid())
-        return QDBusReply<QVector<nheko::dbus::RoomInfoItem>>{
-          interface.call(QStringLiteral("getRooms"))}
+        return QDBusReply<QVector<RoomInfoItem>>{interface.call(QStringLiteral("getRooms"))}
           .value();
     else
         return {};

--- a/src/dbus/NhekoDBusApi.cpp
+++ b/src/dbus/NhekoDBusApi.cpp
@@ -14,18 +14,17 @@ init()
     qDBusRegisterMetaType<RoomInfoItem>();
     qDBusRegisterMetaType<QVector<RoomInfoItem>>();
     qDBusRegisterMetaType<QImage>();
-    qDBusRegisterMetaType<QVersionNumber>();
 }
 
 bool
 apiVersionIsCompatible(const QVersionNumber &clientAppVersion)
 {
-    if (clientAppVersion.majorVersion() != nheko::dbus::apiVersion.majorVersion())
+    if (clientAppVersion.majorVersion() != nheko::dbus::dbusApiVersion.majorVersion())
         return false;
-    if (clientAppVersion.minorVersion() > nheko::dbus::apiVersion.minorVersion())
+    if (clientAppVersion.minorVersion() > nheko::dbus::dbusApiVersion.minorVersion())
         return false;
-    if (clientAppVersion.minorVersion() == nheko::dbus::apiVersion.minorVersion() &&
-        clientAppVersion.microVersion() < nheko::dbus::apiVersion.microVersion())
+    if (clientAppVersion.minorVersion() == nheko::dbus::dbusApiVersion.minorVersion() &&
+        clientAppVersion.microVersion() < nheko::dbus::dbusApiVersion.microVersion())
         return false;
 
     return true;
@@ -142,25 +141,5 @@ operator>>(const QDBusArgument &arg, QImage &image)
 
     image = QImage(reinterpret_cast<uchar *>(bits.data()), width, height, QImage::Format_RGBA8888);
 
-    return arg;
-}
-
-QDBusArgument &
-operator<<(QDBusArgument &arg, const QVersionNumber &v)
-{
-    arg.beginStructure();
-    arg << v.toString();
-    arg.endStructure();
-    return arg;
-}
-
-const QDBusArgument &
-operator>>(const QDBusArgument &arg, QVersionNumber &v)
-{
-    arg.beginStructure();
-    QString temp;
-    arg >> temp;
-    v = QVersionNumber::fromString(temp);
-    arg.endStructure();
     return arg;
 }

--- a/src/dbus/NhekoDBusApi.cpp
+++ b/src/dbus/NhekoDBusApi.cpp
@@ -100,21 +100,21 @@ apiVersion()
 }
 
 QString
-nhekoVersionString()
+nhekoVersion()
 {
     if (QDBusInterface interface{QStringLiteral(NHEKO_DBUS_SERVICE_NAME), QStringLiteral("/")};
         interface.isValid())
-        return QDBusReply<QString>{interface.call(QStringLiteral("nhekoVersionString"))}.value();
+        return QDBusReply<QString>{interface.call(QStringLiteral("nhekoVersion"))}.value();
     else
         return {};
 }
 
 QVector<RoomInfoItem>
-getRooms()
+rooms()
 {
     if (QDBusInterface interface{QStringLiteral(NHEKO_DBUS_SERVICE_NAME), QStringLiteral("/")};
         interface.isValid())
-        return QDBusReply<QVector<RoomInfoItem>>{interface.call(QStringLiteral("getRooms"))}
+        return QDBusReply<QVector<RoomInfoItem>>{interface.call(QStringLiteral("rooms"))}
           .value();
     else
         return {};
@@ -137,11 +137,11 @@ joinRoom(const QString &alias)
 }
 
 void
-startDirectChat(const QString &userId)
+directChat(const QString &userId)
 {
     if (QDBusInterface interface{QStringLiteral(NHEKO_DBUS_SERVICE_NAME), QStringLiteral("/")};
         interface.isValid())
-        interface.call(QDBus::NoBlock, QStringLiteral("startDirectChat"), userId);
+        interface.call(QDBus::NoBlock, QStringLiteral("directChat"), userId);
 }
 } // nheko::dbus
 

--- a/src/dbus/NhekoDBusApi.cpp
+++ b/src/dbus/NhekoDBusApi.cpp
@@ -109,7 +109,7 @@ nhekoVersionString()
         return {};
 }
 
-QVector<nheko::dbus::RoomInfoItem>
+QVector<RoomInfoItem>
 getRooms()
 {
     if (QDBusInterface interface{QStringLiteral(NHEKO_DBUS_SERVICE_NAME), QStringLiteral("/")};

--- a/src/dbus/NhekoDBusApi.cpp
+++ b/src/dbus/NhekoDBusApi.cpp
@@ -196,7 +196,12 @@ operator>>(const QDBusArgument &arg, QImage &image)
     arg >> width >> height >> garbage >> garbage >> garbage >> garbage >> bits;
     arg.endStructure();
 
-    image = QImage(reinterpret_cast<uchar *>(bits.data()), width, height, QImage::Format_RGBA8888);
+    // Unfortunately, this copy-and-detach is necessary to make sure that the image will always
+    // decode properly. If anybody finds a better solution, please implement it.
+    auto temp =
+      QImage(reinterpret_cast<uchar *>(bits.data()), width, height, QImage::Format_RGBA8888);
+    image = temp;
+    image.detach();
 
     return arg;
 }

--- a/src/dbus/NhekoDBusApi.cpp
+++ b/src/dbus/NhekoDBusApi.cpp
@@ -196,8 +196,8 @@ operator>>(const QDBusArgument &arg, QImage &image)
     arg >> width >> height >> garbage >> garbage >> garbage >> garbage >> bits;
     arg.endStructure();
 
-    // Unfortunately, this copy-and-detach is necessary to make sure that the image will always
-    // decode properly. If anybody finds a better solution, please implement it.
+    // Unfortunately, this copy-and-detach is necessary to ensure that the source buffer
+    // is copied properly. If anybody finds a better solution, please implement it.
     auto temp =
       QImage(reinterpret_cast<uchar *>(bits.data()), width, height, QImage::Format_RGBA8888);
     image = temp;

--- a/src/dbus/NhekoDBusApi.cpp
+++ b/src/dbus/NhekoDBusApi.cpp
@@ -5,7 +5,9 @@
 
 #include "NhekoDBusApi.h"
 
+#include <QDBusInterface>
 #include <QDBusMetaType>
+#include <QDBusReply>
 
 namespace nheko::dbus {
 void
@@ -85,6 +87,62 @@ operator>>(const QDBusArgument &arg, RoomInfoItem &item)
 
     arg.endStructure();
     return arg;
+}
+
+QString
+apiVersion()
+{
+    if (QDBusInterface interface{QStringLiteral(NHEKO_DBUS_SERVICE_NAME), QStringLiteral("/")};
+        interface.isValid())
+        return QDBusReply<QString>{interface.call(QStringLiteral("apiVersion"))}.value();
+    else
+        return {};
+}
+
+QString
+nhekoVersionString()
+{
+    if (QDBusInterface interface{QStringLiteral(NHEKO_DBUS_SERVICE_NAME), QStringLiteral("/")};
+        interface.isValid())
+        return QDBusReply<QString>{interface.call(QStringLiteral("nhekoVersionString"))}.value();
+    else
+        return {};
+}
+
+QVector<nheko::dbus::RoomInfoItem>
+getRooms()
+{
+    if (QDBusInterface interface{QStringLiteral(NHEKO_DBUS_SERVICE_NAME), QStringLiteral("/")};
+        interface.isValid())
+        return QDBusReply<QVector<nheko::dbus::RoomInfoItem>>{
+          interface.call(QStringLiteral("getRooms"))}
+          .value();
+    else
+        return {};
+}
+
+void
+activateRoom(const QString &alias)
+{
+    if (QDBusInterface interface{QStringLiteral(NHEKO_DBUS_SERVICE_NAME), QStringLiteral("/")};
+        interface.isValid())
+        interface.call(QDBus::NoBlock, QStringLiteral("activateRoom"), alias);
+}
+
+void
+joinRoom(const QString &alias)
+{
+    if (QDBusInterface interface{QStringLiteral(NHEKO_DBUS_SERVICE_NAME), QStringLiteral("/")};
+        interface.isValid())
+        interface.call(QDBus::NoBlock, QStringLiteral("joinRoom"), alias);
+}
+
+void
+startDirectChat(const QString &userId)
+{
+    if (QDBusInterface interface{QStringLiteral(NHEKO_DBUS_SERVICE_NAME), QStringLiteral("/")};
+        interface.isValid())
+        interface.call(QDBus::NoBlock, QStringLiteral("startDirectChat"), userId);
 }
 } // nheko::dbus
 

--- a/src/dbus/NhekoDBusApi.h
+++ b/src/dbus/NhekoDBusApi.h
@@ -63,10 +63,10 @@ QString
 apiVersion();
 //! Get the nheko version.
 QString
-nhekoVersionString();
+nhekoVersion();
 //! Call this function to get a list of all joined rooms.
 QVector<RoomInfoItem>
-getRooms();
+rooms();
 //! Activates a currently joined room.
 void
 activateRoom(const QString &alias);
@@ -76,7 +76,7 @@ joinRoom(const QString &alias);
 //! Starts or activates a direct chat. It is your responsibility to ask for confirmation (if
 //! desired).
 void
-startDirectChat(const QString &userId);
+directChat(const QString &userId);
 
 QDBusArgument &
 operator<<(QDBusArgument &arg, const RoomInfoItem &item);

--- a/src/dbus/NhekoDBusApi.h
+++ b/src/dbus/NhekoDBusApi.h
@@ -58,13 +58,6 @@ private:
     int unreadNotifications_;
 };
 
-QDBusArgument &
-operator<<(QDBusArgument &arg, const RoomInfoItem &item);
-const QDBusArgument &
-operator>>(const QDBusArgument &arg, RoomInfoItem &item);
-} // nheko::dbus
-Q_DECLARE_METATYPE(nheko::dbus::RoomInfoItem)
-
 //! Get the nheko D-Bus API version.
 QString
 apiVersion();
@@ -72,7 +65,7 @@ apiVersion();
 QString
 nhekoVersionString();
 //! Call this function to get a list of all joined rooms.
-QVector<nheko::dbus::RoomInfoItem>
+QVector<RoomInfoItem>
 getRooms();
 //! Activates a currently joined room.
 void
@@ -84,6 +77,13 @@ joinRoom(const QString &alias);
 //! desired).
 void
 startDirectChat(const QString &userId);
+
+QDBusArgument &
+operator<<(QDBusArgument &arg, const RoomInfoItem &item);
+const QDBusArgument &
+operator>>(const QDBusArgument &arg, RoomInfoItem &item);
+} // nheko::dbus
+Q_DECLARE_METATYPE(nheko::dbus::RoomInfoItem)
 
 QDBusArgument &
 operator<<(QDBusArgument &arg, const QImage &image);

--- a/src/dbus/NhekoDBusApi.h
+++ b/src/dbus/NhekoDBusApi.h
@@ -18,7 +18,7 @@ init();
 
 //! The nheko D-Bus API version provided by this file. The API version number follows semantic
 //! versioning as defined by https://semver.org.
-const QVersionNumber apiVersion{0, 0, 1};
+const QVersionNumber dbusApiVersion{0, 0, 1};
 
 //! Compare the installed Nheko API to the version that your client app targets to see if they
 //! are compatible.
@@ -69,11 +69,6 @@ QDBusArgument &
 operator<<(QDBusArgument &arg, const QImage &image);
 const QDBusArgument &
 operator>>(const QDBusArgument &arg, QImage &);
-
-QDBusArgument &
-operator<<(QDBusArgument &arg, const QVersionNumber &v);
-const QDBusArgument &
-operator>>(const QDBusArgument &arg, QVersionNumber &v);
 
 #define NHEKO_DBUS_SERVICE_NAME "im.nheko.Nheko"
 

--- a/src/dbus/NhekoDBusApi.h
+++ b/src/dbus/NhekoDBusApi.h
@@ -65,6 +65,26 @@ operator>>(const QDBusArgument &arg, RoomInfoItem &item);
 } // nheko::dbus
 Q_DECLARE_METATYPE(nheko::dbus::RoomInfoItem)
 
+//! Get the nheko D-Bus API version.
+QString
+apiVersion();
+//! Get the nheko version.
+QString
+nhekoVersionString();
+//! Call this function to get a list of all joined rooms.
+QVector<nheko::dbus::RoomInfoItem>
+getRooms();
+//! Activates a currently joined room.
+void
+activateRoom(const QString &alias);
+//! Joins a room. It is your responsibility to ask for confirmation (if desired).
+void
+joinRoom(const QString &alias);
+//! Starts or activates a direct chat. It is your responsibility to ask for confirmation (if
+//! desired).
+void
+startDirectChat(const QString &userId);
+
 QDBusArgument &
 operator<<(QDBusArgument &arg, const QImage &image);
 const QDBusArgument &

--- a/src/dbus/NhekoDBusBackend.cpp
+++ b/src/dbus/NhekoDBusBackend.cpp
@@ -19,7 +19,7 @@ NhekoDBusBackend::NhekoDBusBackend(RoomlistModel *parent)
 {}
 
 QVector<nheko::dbus::RoomInfoItem>
-NhekoDBusBackend::getRooms(const QDBusMessage &message)
+NhekoDBusBackend::rooms(const QDBusMessage &message)
 {
     const auto roomListModel = m_parent->models;
     QSharedPointer<QVector<nheko::dbus::RoomInfoItem>> model{
@@ -81,7 +81,7 @@ NhekoDBusBackend::joinRoom(const QString &alias) const
 }
 
 void
-NhekoDBusBackend::startDirectChat(const QString &userId) const
+NhekoDBusBackend::directChat(const QString &userId) const
 {
     bringWindowToTop();
     ChatPage::instance()->startChat(userId);

--- a/src/dbus/NhekoDBusBackend.cpp
+++ b/src/dbus/NhekoDBusBackend.cpp
@@ -39,7 +39,7 @@ NhekoDBusBackend::getRooms(const QDBusMessage &message)
               }
 
               model->push_back(nheko::dbus::RoomInfoItem{
-                room->roomId(), room->roomName(), alias, image, room->notificationCount()});
+                room->roomId(), alias, room->roomName(), image, room->notificationCount()});
 
               if (model->length() == roomListModelSize) {
                   auto reply = message.createReply();

--- a/src/dbus/NhekoDBusBackend.h
+++ b/src/dbus/NhekoDBusBackend.h
@@ -25,16 +25,16 @@ public slots:
     //! Get the nheko D-Bus API version.
     Q_SCRIPTABLE QString apiVersion() const { return nheko::dbus::dbusApiVersion.toString(); }
     //! Get the nheko version.
-    Q_SCRIPTABLE QString nhekoVersionString() const { return nheko::version; }
+    Q_SCRIPTABLE QString nhekoVersion() const { return nheko::version; }
     //! Call this function to get a list of all joined rooms.
-    Q_SCRIPTABLE QVector<nheko::dbus::RoomInfoItem> getRooms(const QDBusMessage &message);
+    Q_SCRIPTABLE QVector<nheko::dbus::RoomInfoItem> rooms(const QDBusMessage &message);
     //! Activates a currently joined room.
     Q_SCRIPTABLE void activateRoom(const QString &alias) const;
     //! Joins a room. It is your responsibility to ask for confirmation (if desired).
     Q_SCRIPTABLE void joinRoom(const QString &alias) const;
     //! Starts or activates a direct chat. It is your responsibility to ask for confirmation (if
     //! desired).
-    Q_SCRIPTABLE void startDirectChat(const QString &userId) const;
+    Q_SCRIPTABLE void directChat(const QString &userId) const;
 
 private:
     void bringWindowToTop() const;

--- a/src/dbus/NhekoDBusBackend.h
+++ b/src/dbus/NhekoDBusBackend.h
@@ -23,7 +23,7 @@ public:
 
 public slots:
     //! Get the nheko D-Bus API version.
-    Q_SCRIPTABLE QVersionNumber apiVersion() const { return nheko::dbus::apiVersion; }
+    Q_SCRIPTABLE QString apiVersion() const { return nheko::dbus::dbusApiVersion.toString(); }
     //! Get the nheko version.
     Q_SCRIPTABLE QString nhekoVersionString() const { return nheko::version; }
     //! Call this function to get a list of all joined rooms.


### PR DESCRIPTION
According to LorenDB's First Law of Software Development, once a developer has committed or merged a new feature, he will find at least one problem with the implementation.

I realized that I was constructing the room info items with some parameters out of order, which required a rather urgent fix. Furthermore, I fixed the image decoding algorithms in the QDBusArgument operator. Finally, I switched the API version parameter back to QString, since passing it as a QVersionNumber would create a problem for non-Qt API users.

On the general improvements side of things, I added some handy wrappers for D-Bus calls so that other devs that copy the NhekoDBusApi files to use for their own applications won't have to go to the effort of making the D-Bus calls themselves.
