### PR TITLE
Subtle corrections to paste behaviors

### DIFF
--- a/resources/qml/MessageInput.qml
+++ b/resources/qml/MessageInput.qml
@@ -188,8 +188,7 @@ Rectangle {
                 Keys.onShortcutOverride: event.accepted = (popup.opened && (event.key === Qt.Key_Escape || event.key === Qt.Key_Tab || event.key === Qt.Key_Enter || event.key === Qt.Key_Space))
                 Keys.onPressed: {
                     if (event.matches(StandardKey.Paste)) {
-                        room.input.paste(false);
-                        event.accepted = true;
+                        event.accepted = room.input.tryPasteAttachment(false);
                     } else if (event.key == Qt.Key_Space) {
                         // close popup if user enters space after colon
                         if (cursorPosition == completerTriggeredAt + 1)
@@ -361,11 +360,6 @@ Rectangle {
                 }
 
                 Connections {
-                    function onInsertText(text) {
-                        messageInput.remove(messageInput.selectionStart, messageInput.selectionEnd);
-                        messageInput.insert(messageInput.cursorPosition, text);
-                    }
-
                     function onTextChanged(newText) {
                         messageInput.text = newText;
                         messageInput.cursorPosition = newText.length;
@@ -401,7 +395,7 @@ Rectangle {
                     anchors.fill: parent
                     acceptedButtons: Qt.MiddleButton
                     cursorShape: Qt.IBeamCursor
-                    onClicked: room.input.paste(true)
+                    onPressed: (mouse) => mouse.accepted = room.input.tryPasteAttachment(true)
                 }
 
             }

--- a/src/timeline/InputBar.cpp
+++ b/src/timeline/InputBar.cpp
@@ -101,8 +101,8 @@ InputVideoSurface::supportedPixelFormats(QAbstractVideoBuffer::HandleType type) 
     }
 }
 
-void
-InputBar::paste(bool fromMouse)
+bool
+InputBar::tryPasteAttachment(bool fromMouse)
 {
     const QMimeData *md = nullptr;
 
@@ -113,14 +113,16 @@ InputBar::paste(bool fromMouse)
     }
 
     if (md)
-        insertMimeData(md);
+        return insertMimeData(md);
+
+    return false;
 }
 
-void
+bool
 InputBar::insertMimeData(const QMimeData *md)
 {
     if (!md)
-        return;
+        return false;
 
     nhlog::ui()->debug("Got mime formats: {}",
                        md->formats().join(QStringLiteral(", ")).toStdString());
@@ -171,7 +173,7 @@ InputBar::insertMimeData(const QMimeData *md)
         auto data = md->data(QStringLiteral("x-special/gnome-copied-files")).split('\n');
         if (data.size() < 2) {
             nhlog::ui()->warn("MIME format is malformed, cannot perform paste.");
-            return;
+            return false;
         }
 
         for (int i = 1; i < data.size(); ++i) {
@@ -181,10 +183,13 @@ InputBar::insertMimeData(const QMimeData *md)
             }
         }
     } else if (md->hasText()) {
-        emit insertText(md->text());
+        return false;
     } else {
         nhlog::ui()->debug("formats: {}", md->formats().join(QStringLiteral(", ")).toStdString());
+        return false;
     }
+
+    return true;
 }
 
 void

--- a/src/timeline/InputBar.h
+++ b/src/timeline/InputBar.h
@@ -190,8 +190,8 @@ public slots:
     [[nodiscard]] bool containsAtRoom() const { return containsAtRoom_; }
 
     void send();
-    void paste(bool fromMouse);
-    void insertMimeData(const QMimeData *data);
+    bool tryPasteAttachment(bool fromMouse);
+    bool insertMimeData(const QMimeData *data);
     void updateState(int selectionStart, int selectionEnd, int cursorPosition, const QString &text);
     void openFileSelection();
     [[nodiscard]] bool uploading() const { return uploading_; }
@@ -212,7 +212,6 @@ private slots:
     void removeRunUpload(MediaUpload *upload);
 
 signals:
-    void insertText(QString text);
     void textChanged(QString newText);
     void uploadingChanged(bool value);
     void containsAtRoomChanged();


### PR DESCRIPTION
This fixes two issues with pasting text in to the message input field:

1) Pasted text was not considered a separation point for undo
2) Middle-click behavior was functionally equivalent to a regular paste operation

This leaves the nearby "onInsertText" with zero callers, but I left it in anyway.