### PR TITLE
Get large avatar images as scale and crop locally

### DIFF
--- a/src/MxcImageProvider.cpp
+++ b/src/MxcImageProvider.cpp
@@ -97,14 +97,6 @@ clipRadius(QImage img, double radius)
     return out;
 }
 
-QImage
-MxcImageProvider::cropImage(const QImage &image)
-{
-    int delta  = image.width() - image.height();
-    int length = delta >= 0 ? image.height() : image.width();
-    return image.copy(delta >= 0 ? delta / 2 : 0, delta >= 0 ? 0 : -delta / 2, length, length);
-}
-
 void
 MxcImageProvider::download(const QString &id,
                            const QSize &requestedSize,
@@ -152,11 +144,16 @@ MxcImageProvider::download(const QString &id,
                 if (requestedSize.width() <= 0) {
                     image = image.scaledToHeight(requestedSize.height(), Qt::SmoothTransformation);
                 } else {
+                    image = image.scaled(requestedSize,
+                                         cropLocally ? Qt::KeepAspectRatioByExpanding
+                                                     : Qt::KeepAspectRatio,
+                                         Qt::SmoothTransformation);
                     if (cropLocally) {
-                        image = cropImage(image);
+                        image = image.copy((image.width() - requestedSize.width()) / 2,
+                                           (image.height() - requestedSize.height()) / 2,
+                                           requestedSize.width(),
+                                           requestedSize.height());
                     }
-                    image =
-                      image.scaled(requestedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
                 }
 
                 if (radius != 0) {
@@ -191,11 +188,16 @@ MxcImageProvider::download(const QString &id,
                       image =
                         image.scaledToHeight(requestedSize.height(), Qt::SmoothTransformation);
                   } else {
+                      image = image.scaled(requestedSize,
+                                           cropLocally ? Qt::KeepAspectRatioByExpanding
+                                                       : Qt::KeepAspectRatio,
+                                           Qt::SmoothTransformation);
                       if (cropLocally) {
-                          image = cropImage(image);
+                          image = image.copy((image.width() - requestedSize.width()) / 2,
+                                             (image.height() - requestedSize.height()) / 2,
+                                             requestedSize.width(),
+                                             requestedSize.height());
                       }
-                      image =
-                        image.scaled(requestedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
                   }
 
                   if (radius != 0) {

--- a/src/MxcImageProvider.h
+++ b/src/MxcImageProvider.h
@@ -90,7 +90,4 @@ public slots:
                          std::function<void(QString, QSize, QImage, QString)> then,
                          bool crop     = true,
                          double radius = 0);
-
-private:
-    static QImage cropImage(const QImage &image);
 };

--- a/src/MxcImageProvider.h
+++ b/src/MxcImageProvider.h
@@ -90,4 +90,7 @@ public slots:
                          std::function<void(QString, QSize, QImage, QString)> then,
                          bool crop     = true,
                          double radius = 0);
+
+private:
+    static QImage cropImage(const QImage &image);
 };


### PR DESCRIPTION
Resolves #1069

The Matrix spec requires servers to provide thumbnails at (96x96, crop) and (320x240, scale) among others. [1] The avatars in Nheko's global/room profile and room settings are sized 130x130 on normal scaling and 260x260 on 2x scaling like on a HiDPI device. In both cases the avatar is requested as cropped and that way displayed at 96x96, making it look blurry.

This can be solved by requesting scaled avatars rather than cropped where appropriate, and cropping to the requested size afterwards.

HiDPI can be simulated in Qt by setting QT_SCALE_FACTOR=2.

[1] https://spec.matrix.org/v1.3/client-server-api/#thumbnails
