### PR TITLE
Fix blurriness of svg icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ cscope*
 .clang_complete
 *wintoastlib*
 /.ccls-cache
+/.cache
 /.exrc
 .gdb_history
 .hunter

--- a/resources/qml/ImageButton.qml
+++ b/resources/qml/ImageButton.qml
@@ -6,6 +6,7 @@
 import "./ui"
 import QtQuick 2.3
 import QtQuick.Controls 2.3
+import QtQuick.Window 2.15
 import im.nheko 1.0 // for cursor shape
 
 AbstractButton {
@@ -28,6 +29,8 @@ AbstractButton {
         // Workaround, can't get icon.source working for now...
         anchors.fill: parent
         source: image != "" ? ("image://colorimage/" + image + "?" + ((button.hovered && changeColorOnHover) ? highlightColor : buttonTextColor)) : ""
+        sourceSize.height: button.height * Screen.devicePixelRatio
+        sourceSize.width: button.width * Screen.devicePixelRatio
         fillMode: Image.PreserveAspectFit
     }
 

--- a/src/ColorImageProvider.cpp
+++ b/src/ColorImageProvider.cpp
@@ -6,9 +6,10 @@
 #include "ColorImageProvider.h"
 
 #include <QPainter>
+#include <QIcon> 
 
 QPixmap
-ColorImageProvider::requestPixmap(const QString &id, QSize *size, const QSize &)
+ColorImageProvider::requestPixmap(const QString &id, QSize *size, const QSize &req)
 {
     auto args = id.split('?');
 
@@ -16,7 +17,9 @@ ColorImageProvider::requestPixmap(const QString &id, QSize *size, const QSize &)
 
     if (size)
         *size = QSize(source.width(), source.height());
-
+    
+    if (req.width() > 0 && req.height() > 0)
+        source = QIcon(args[0]).pixmap(req);
     if (args.size() < 2)
         return source;
 


### PR DESCRIPTION
There might be other uses of svgs in the codebase that requires explicitly setting sourceSize, this PR only tries to fix `ImageButton`.