### PR TITLE
Update namespace for call events

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -580,8 +580,8 @@ if(USE_BUNDLED_MTXCLIENT)
 	include(FetchContent)
 	FetchContent_Declare(
 		MatrixClient
-		GIT_REPOSITORY https://github.com/r0hit05/mtxclient.git
-		GIT_TAG        9743ddde60151c2d0e3fd622d5e3fe469813f5d9
+		GIT_REPOSITORY https://github.com/Nheko-Reborn/mtxclient.git
+		GIT_TAG        c2824dae5050882872a6c3f5677f3309a60511be
 		)
 	set(BUILD_LIB_EXAMPLES OFF CACHE INTERNAL "")
 	set(BUILD_LIB_TESTS OFF CACHE INTERNAL "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -580,8 +580,8 @@ if(USE_BUNDLED_MTXCLIENT)
 	include(FetchContent)
 	FetchContent_Declare(
 		MatrixClient
-		GIT_REPOSITORY https://github.com/Nheko-Reborn/mtxclient.git
-		GIT_TAG        6f908f379c6d7afb6117baee3a59c6f5e3adfdda
+		GIT_REPOSITORY https://github.com/r0hit05/mtxclient.git
+		GIT_TAG        9743ddde60151c2d0e3fd622d5e3fe469813f5d9
 		)
 	set(BUILD_LIB_EXAMPLES OFF CACHE INTERNAL "")
 	set(BUILD_LIB_TESTS OFF CACHE INTERNAL "")

--- a/io.github.NhekoReborn.Nheko.yaml
+++ b/io.github.NhekoReborn.Nheko.yaml
@@ -203,10 +203,10 @@ modules:
     buildsystem: cmake-ninja
     name: mtxclient
     sources:
-      - commit: 9743ddde60151c2d0e3fd622d5e3fe469813f5d9
+      - commit: c2824dae5050882872a6c3f5677f3309a60511be
         #tag: v0.7.0
         type: git
-        url: https://github.com/r0hit05/mtxclient.git
+        url: https://github.com/Nheko-Reborn/mtxclient.git
   - config-opts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DLMDBXX_INCLUDE_DIR=.deps/lmdbxx

--- a/io.github.NhekoReborn.Nheko.yaml
+++ b/io.github.NhekoReborn.Nheko.yaml
@@ -203,10 +203,10 @@ modules:
     buildsystem: cmake-ninja
     name: mtxclient
     sources:
-      - commit: 6f908f379c6d7afb6117baee3a59c6f5e3adfdda
+      - commit: 9743ddde60151c2d0e3fd622d5e3fe469813f5d9
         #tag: v0.7.0
         type: git
-        url: https://github.com/Nheko-Reborn/mtxclient.git
+        url: https://github.com/r0hit05/mtxclient.git
   - config-opts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DLMDBXX_INCLUDE_DIR=.deps/lmdbxx

--- a/src/Cache.cpp
+++ b/src/Cache.cpp
@@ -1639,18 +1639,18 @@ isMessage(const mtx::events::EncryptedEvent<T> &)
 }
 
 auto
-isMessage(const mtx::events::RoomEvent<mtx::events::msg::CallInvite> &)
+isMessage(const mtx::events::RoomEvent<mtx::events::voip::CallInvite> &)
 {
     return true;
 }
 
 auto
-isMessage(const mtx::events::RoomEvent<mtx::events::msg::CallAnswer> &)
+isMessage(const mtx::events::RoomEvent<mtx::events::voip::CallAnswer> &)
 {
     return true;
 }
 auto
-isMessage(const mtx::events::RoomEvent<mtx::events::msg::CallHangUp> &)
+isMessage(const mtx::events::RoomEvent<mtx::events::voip::CallHangUp> &)
 {
     return true;
 }

--- a/src/ChatPage.cpp
+++ b/src/ChatPage.cpp
@@ -247,10 +247,10 @@ ChatPage::ChatPage(QSharedPointer<UserSettings> userSettings, QObject *parent)
       },
       Qt::QueuedConnection);
 
-    connectCallMessage<mtx::events::msg::CallInvite>();
-    connectCallMessage<mtx::events::msg::CallCandidates>();
-    connectCallMessage<mtx::events::msg::CallAnswer>();
-    connectCallMessage<mtx::events::msg::CallHangUp>();
+    connectCallMessage<mtx::events::voip::CallInvite>();
+    connectCallMessage<mtx::events::voip::CallCandidates>();
+    connectCallMessage<mtx::events::voip::CallAnswer>();
+    connectCallMessage<mtx::events::voip::CallHangUp>();
 }
 
 void

--- a/src/EventAccessors.cpp
+++ b/src/EventAccessors.cpp
@@ -77,7 +77,7 @@ struct CallType
     {
         if constexpr (std::is_same_v<mtx::events::RoomEvent<mtx::events::voip::CallInvite>, T>) {
             const char video[]     = "m=video";
-            const std::string &sdp = e.content.sdp;
+            const std::string &sdp = e.content.offer.sdp;
             return std::search(sdp.cbegin(),
                                sdp.cend(),
                                std::cbegin(video),

--- a/src/EventAccessors.cpp
+++ b/src/EventAccessors.cpp
@@ -75,7 +75,7 @@ struct CallType
     template<class T>
     std::string operator()(const T &e)
     {
-        if constexpr (std::is_same_v<mtx::events::RoomEvent<mtx::events::msg::CallInvite>, T>) {
+        if constexpr (std::is_same_v<mtx::events::RoomEvent<mtx::events::voip::CallInvite>, T>) {
             const char video[]     = "m=video";
             const std::string &sdp = e.content.sdp;
             return std::search(sdp.cbegin(),

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -209,9 +209,9 @@ utils::getMessageDescription(const TimelineEvent &event,
     using Notice     = mtx::events::RoomEvent<mtx::events::msg::Notice>;
     using Text       = mtx::events::RoomEvent<mtx::events::msg::Text>;
     using Video      = mtx::events::RoomEvent<mtx::events::msg::Video>;
-    using CallInvite = mtx::events::RoomEvent<mtx::events::msg::CallInvite>;
-    using CallAnswer = mtx::events::RoomEvent<mtx::events::msg::CallAnswer>;
-    using CallHangUp = mtx::events::RoomEvent<mtx::events::msg::CallHangUp>;
+    using CallInvite = mtx::events::RoomEvent<mtx::events::voip::CallInvite>;
+    using CallAnswer = mtx::events::RoomEvent<mtx::events::voip::CallAnswer>;
+    using CallHangUp = mtx::events::RoomEvent<mtx::events::voip::CallHangUp>;
     using Encrypted  = mtx::events::EncryptedEvent<mtx::events::msg::Encrypted>;
 
     if (std::holds_alternative<Audio>(event)) {

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -107,9 +107,9 @@ messageDescription(const QString &username = QString(),
     using Sticker    = mtx::events::Sticker;
     using Text       = mtx::events::RoomEvent<mtx::events::msg::Text>;
     using Video      = mtx::events::RoomEvent<mtx::events::msg::Video>;
-    using CallInvite = mtx::events::RoomEvent<mtx::events::msg::CallInvite>;
-    using CallAnswer = mtx::events::RoomEvent<mtx::events::msg::CallAnswer>;
-    using CallHangUp = mtx::events::RoomEvent<mtx::events::msg::CallHangUp>;
+    using CallInvite = mtx::events::RoomEvent<mtx::events::voip::CallInvite>;
+    using CallAnswer = mtx::events::RoomEvent<mtx::events::voip::CallAnswer>;
+    using CallHangUp = mtx::events::RoomEvent<mtx::events::voip::CallHangUp>;
     using Encrypted  = mtx::events::EncryptedEvent<mtx::events::msg::Encrypted>;
 
     if (std::is_same<T, Audio>::value) {

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -121,20 +121,20 @@ struct RoomEventType
     {
         return qml_mtx_events::EventType::Redacted;
     }
-    qml_mtx_events::EventType operator()(const mtx::events::Event<mtx::events::msg::CallInvite> &)
+    qml_mtx_events::EventType operator()(const mtx::events::Event<mtx::events::voip::CallInvite> &)
     {
         return qml_mtx_events::EventType::CallInvite;
     }
-    qml_mtx_events::EventType operator()(const mtx::events::Event<mtx::events::msg::CallAnswer> &)
+    qml_mtx_events::EventType operator()(const mtx::events::Event<mtx::events::voip::CallAnswer> &)
     {
         return qml_mtx_events::EventType::CallAnswer;
     }
-    qml_mtx_events::EventType operator()(const mtx::events::Event<mtx::events::msg::CallHangUp> &)
+    qml_mtx_events::EventType operator()(const mtx::events::Event<mtx::events::voip::CallHangUp> &)
     {
         return qml_mtx_events::EventType::CallHangUp;
     }
     qml_mtx_events::EventType
-    operator()(const mtx::events::Event<mtx::events::msg::CallCandidates> &)
+    operator()(const mtx::events::Event<mtx::events::voip::CallCandidates> &)
     {
         return qml_mtx_events::EventType::CallCandidates;
     }
@@ -941,17 +941,17 @@ TimelineModel::addEvents(const mtx::responses::Timeline &timeline)
                 e = result.event.value();
         }
 
-        if (std::holds_alternative<RoomEvent<msg::CallCandidates>>(e) ||
-            std::holds_alternative<RoomEvent<msg::CallInvite>>(e) ||
-            std::holds_alternative<RoomEvent<msg::CallAnswer>>(e) ||
-            std::holds_alternative<RoomEvent<msg::CallHangUp>>(e))
+        if (std::holds_alternative<RoomEvent<voip::CallCandidates>>(e) ||
+            std::holds_alternative<RoomEvent<voip::CallInvite>>(e) ||
+            std::holds_alternative<RoomEvent<voip::CallAnswer>>(e) ||
+            std::holds_alternative<RoomEvent<voip::CallHangUp>>(e))
             std::visit(
               [this](auto &event) {
                   event.room_id = room_id_.toStdString();
                   if constexpr (std::is_same_v<std::decay_t<decltype(event)>,
-                                               RoomEvent<msg::CallAnswer>> ||
+                                               RoomEvent<voip::CallAnswer>> ||
                                 std::is_same_v<std::decay_t<decltype(event)>,
-                                               RoomEvent<msg::CallHangUp>>)
+                                               RoomEvent<voip::CallHangUp>>)
                       emit newCallEvent(event);
                   else {
                       if (event.sender != http::client()->user_id().to_string())
@@ -1007,18 +1007,18 @@ isMessage(const mtx::events::EncryptedEvent<T> &)
 }
 
 auto
-isMessage(const mtx::events::RoomEvent<mtx::events::msg::CallInvite> &)
+isMessage(const mtx::events::RoomEvent<mtx::events::voip::CallInvite> &)
 {
     return true;
 }
 
 auto
-isMessage(const mtx::events::RoomEvent<mtx::events::msg::CallAnswer> &)
+isMessage(const mtx::events::RoomEvent<mtx::events::voip::CallAnswer> &)
 {
     return true;
 }
 auto
-isMessage(const mtx::events::RoomEvent<mtx::events::msg::CallHangUp> &)
+isMessage(const mtx::events::RoomEvent<mtx::events::voip::CallHangUp> &)
 {
     return true;
 }
@@ -1460,25 +1460,25 @@ struct SendMessageVisitor
         emit model_->addPendingMessageToStore(msg);
     }
 
-    void operator()(const mtx::events::RoomEvent<mtx::events::msg::CallInvite> &event)
+    void operator()(const mtx::events::RoomEvent<mtx::events::voip::CallInvite> &event)
     {
-        sendRoomEvent<mtx::events::msg::CallInvite, mtx::events::EventType::CallInvite>(event);
+        sendRoomEvent<mtx::events::voip::CallInvite, mtx::events::EventType::CallInvite>(event);
     }
 
-    void operator()(const mtx::events::RoomEvent<mtx::events::msg::CallCandidates> &event)
+    void operator()(const mtx::events::RoomEvent<mtx::events::voip::CallCandidates> &event)
     {
-        sendRoomEvent<mtx::events::msg::CallCandidates, mtx::events::EventType::CallCandidates>(
+        sendRoomEvent<mtx::events::voip::CallCandidates, mtx::events::EventType::CallCandidates>(
           event);
     }
 
-    void operator()(const mtx::events::RoomEvent<mtx::events::msg::CallAnswer> &event)
+    void operator()(const mtx::events::RoomEvent<mtx::events::voip::CallAnswer> &event)
     {
-        sendRoomEvent<mtx::events::msg::CallAnswer, mtx::events::EventType::CallAnswer>(event);
+        sendRoomEvent<mtx::events::voip::CallAnswer, mtx::events::EventType::CallAnswer>(event);
     }
 
-    void operator()(const mtx::events::RoomEvent<mtx::events::msg::CallHangUp> &event)
+    void operator()(const mtx::events::RoomEvent<mtx::events::voip::CallHangUp> &event)
     {
-        sendRoomEvent<mtx::events::msg::CallHangUp, mtx::events::EventType::CallHangUp>(event);
+        sendRoomEvent<mtx::events::voip::CallHangUp, mtx::events::EventType::CallHangUp>(event);
     }
 
     void operator()(const mtx::events::RoomEvent<mtx::events::msg::KeyVerificationRequest> &msg)

--- a/src/timeline/TimelineViewManager.cpp
+++ b/src/timeline/TimelineViewManager.cpp
@@ -347,7 +347,7 @@ TimelineViewManager::queueReply(const QString &roomid,
 
 void
 TimelineViewManager::queueCallMessage(const QString &roomid,
-                                      const mtx::events::msg::CallInvite &callInvite)
+                                      const mtx::events::voip::CallInvite &callInvite)
 {
     if (auto room = rooms_->getRoomById(roomid))
         room->sendMessageEvent(callInvite, mtx::events::EventType::CallInvite);
@@ -355,7 +355,7 @@ TimelineViewManager::queueCallMessage(const QString &roomid,
 
 void
 TimelineViewManager::queueCallMessage(const QString &roomid,
-                                      const mtx::events::msg::CallCandidates &callCandidates)
+                                      const mtx::events::voip::CallCandidates &callCandidates)
 {
     if (auto room = rooms_->getRoomById(roomid))
         room->sendMessageEvent(callCandidates, mtx::events::EventType::CallCandidates);
@@ -363,7 +363,7 @@ TimelineViewManager::queueCallMessage(const QString &roomid,
 
 void
 TimelineViewManager::queueCallMessage(const QString &roomid,
-                                      const mtx::events::msg::CallAnswer &callAnswer)
+                                      const mtx::events::voip::CallAnswer &callAnswer)
 {
     if (auto room = rooms_->getRoomById(roomid))
         room->sendMessageEvent(callAnswer, mtx::events::EventType::CallAnswer);
@@ -371,7 +371,7 @@ TimelineViewManager::queueCallMessage(const QString &roomid,
 
 void
 TimelineViewManager::queueCallMessage(const QString &roomid,
-                                      const mtx::events::msg::CallHangUp &callHangUp)
+                                      const mtx::events::voip::CallHangUp &callHangUp)
 {
     if (auto room = rooms_->getRoomById(roomid))
         room->sendMessageEvent(callHangUp, mtx::events::EventType::CallHangUp);

--- a/src/timeline/TimelineViewManager.h
+++ b/src/timeline/TimelineViewManager.h
@@ -105,10 +105,10 @@ public slots:
 
     void updateColorPalette();
     void queueReply(const QString &roomid, const QString &repliedToEvent, const QString &replyBody);
-    void queueCallMessage(const QString &roomid, const mtx::events::msg::CallInvite &);
-    void queueCallMessage(const QString &roomid, const mtx::events::msg::CallCandidates &);
-    void queueCallMessage(const QString &roomid, const mtx::events::msg::CallAnswer &);
-    void queueCallMessage(const QString &roomid, const mtx::events::msg::CallHangUp &);
+    void queueCallMessage(const QString &roomid, const mtx::events::voip::CallInvite &);
+    void queueCallMessage(const QString &roomid, const mtx::events::voip::CallCandidates &);
+    void queueCallMessage(const QString &roomid, const mtx::events::voip::CallAnswer &);
+    void queueCallMessage(const QString &roomid, const mtx::events::voip::CallHangUp &);
 
     void setVideoCallItem();
 

--- a/src/voip/CallManager.cpp
+++ b/src/voip/CallManager.cpp
@@ -44,6 +44,7 @@ using namespace mtx::events;
 using namespace mtx::events::voip;
 
 using webrtc::CallType;
+//! Session Description Object
 typedef RTCSessionDescriptionInit SDO;
 
 namespace {
@@ -66,7 +67,9 @@ CallManager::CallManager(QObject *parent)
       this,
       [this](const std::string &sdp, const std::vector<CallCandidates::Candidate> &candidates) {
           nhlog::ui()->debug("WebRTC: call id: {} - sending offer", callid_);
-          emit newMessage(roomid_, CallInvite{callid_, partyid_, SDO{sdp, SDO::Type::Offer}, "0", timeoutms_, invitee_});
+          emit newMessage(
+            roomid_,
+            CallInvite{callid_, partyid_, SDO{sdp, SDO::Type::Offer}, "0", timeoutms_, invitee_});
           emit newMessage(roomid_, CallCandidates{callid_, partyid_, candidates, "0"});
           std::string callid(callid_);
           QTimer::singleShot(timeoutms_, this, [this, callid]() {
@@ -299,7 +302,8 @@ CallManager::handleEvent(const RoomEvent<CallInvite> &callInviteEvent)
     if (isOnCall() || roomInfo.member_count != 2) {
         emit newMessage(
           QString::fromStdString(callInviteEvent.room_id),
-          CallHangUp{callInviteEvent.content.call_id, partyid_, "0", CallHangUp::Reason::InviteTimeOut});
+          CallHangUp{
+            callInviteEvent.content.call_id, partyid_, "0", CallHangUp::Reason::InviteTimeOut});
         return;
     }
 

--- a/src/voip/CallManager.cpp
+++ b/src/voip/CallManager.cpp
@@ -36,12 +36,12 @@ extern "C"
 }
 #endif
 
-Q_DECLARE_METATYPE(std::vector<mtx::events::msg::CallCandidates::Candidate>)
-Q_DECLARE_METATYPE(mtx::events::msg::CallCandidates::Candidate)
+Q_DECLARE_METATYPE(std::vector<mtx::events::voip::CallCandidates::Candidate>)
+Q_DECLARE_METATYPE(mtx::events::voip::CallCandidates::Candidate)
 Q_DECLARE_METATYPE(mtx::responses::TurnServer)
 
 using namespace mtx::events;
-using namespace mtx::events::msg;
+using namespace mtx::events::voip;
 
 using webrtc::CallType;
 
@@ -55,8 +55,8 @@ CallManager::CallManager(QObject *parent)
   , session_(WebRTCSession::instance())
   , turnServerTimer_(this)
 {
-    qRegisterMetaType<std::vector<mtx::events::msg::CallCandidates::Candidate>>();
-    qRegisterMetaType<mtx::events::msg::CallCandidates::Candidate>();
+    qRegisterMetaType<std::vector<mtx::events::voip::CallCandidates::Candidate>>();
+    qRegisterMetaType<mtx::events::voip::CallCandidates::Candidate>();
     qRegisterMetaType<mtx::responses::TurnServer>();
 
     connect(

--- a/src/voip/CallManager.h
+++ b/src/voip/CallManager.h
@@ -92,6 +92,8 @@ private:
     QString callPartyDisplayName_;
     QString callPartyAvatarUrl_;
     std::string callid_;
+    std::string partyid_ = "";
+    std::string invitee_ = "";
     const uint32_t timeoutms_  = 120000;
     webrtc::CallType callType_ = webrtc::CallType::VOICE;
     bool haveCallInvite_       = false;

--- a/src/voip/CallManager.h
+++ b/src/voip/CallManager.h
@@ -67,7 +67,8 @@ public slots:
     void toggleMicMute();
     void toggleLocalPiP() { session_.toggleLocalPiP(); }
     void acceptInvite();
-    void hangUp(mtx::events::voip::CallHangUp::Reason = mtx::events::voip::CallHangUp::Reason::User);
+    void
+      hangUp(mtx::events::voip::CallHangUp::Reason = mtx::events::voip::CallHangUp::Reason::User);
     QStringList windowList();
     void previewWindow(unsigned int windowIndex) const;
 
@@ -92,8 +93,8 @@ private:
     QString callPartyDisplayName_;
     QString callPartyAvatarUrl_;
     std::string callid_;
-    std::string partyid_ = "";
-    std::string invitee_ = "";
+    std::string partyid_       = "";
+    std::string invitee_       = "";
     const uint32_t timeoutms_  = 120000;
     webrtc::CallType callType_ = webrtc::CallType::VOICE;
     bool haveCallInvite_       = false;

--- a/src/voip/CallManager.h
+++ b/src/voip/CallManager.h
@@ -67,15 +67,15 @@ public slots:
     void toggleMicMute();
     void toggleLocalPiP() { session_.toggleLocalPiP(); }
     void acceptInvite();
-    void hangUp(mtx::events::msg::CallHangUp::Reason = mtx::events::msg::CallHangUp::Reason::User);
+    void hangUp(mtx::events::voip::CallHangUp::Reason = mtx::events::voip::CallHangUp::Reason::User);
     QStringList windowList();
     void previewWindow(unsigned int windowIndex) const;
 
 signals:
-    void newMessage(const QString &roomid, const mtx::events::msg::CallInvite &);
-    void newMessage(const QString &roomid, const mtx::events::msg::CallCandidates &);
-    void newMessage(const QString &roomid, const mtx::events::msg::CallAnswer &);
-    void newMessage(const QString &roomid, const mtx::events::msg::CallHangUp &);
+    void newMessage(const QString &roomid, const mtx::events::voip::CallInvite &);
+    void newMessage(const QString &roomid, const mtx::events::voip::CallCandidates &);
+    void newMessage(const QString &roomid, const mtx::events::voip::CallAnswer &);
+    void newMessage(const QString &roomid, const mtx::events::voip::CallHangUp &);
     void newInviteState();
     void newCallState();
     void micMuteChanged();
@@ -96,7 +96,7 @@ private:
     webrtc::CallType callType_ = webrtc::CallType::VOICE;
     bool haveCallInvite_       = false;
     std::string inviteSDP_;
-    std::vector<mtx::events::msg::CallCandidates::Candidate> remoteICECandidates_;
+    std::vector<mtx::events::voip::CallCandidates::Candidate> remoteICECandidates_;
     std::vector<std::string> turnURIs_;
     QTimer turnServerTimer_;
     QMediaPlayer player_;
@@ -104,11 +104,11 @@ private:
 
     template<typename T>
     bool handleEvent(const mtx::events::collections::TimelineEvents &event);
-    void handleEvent(const mtx::events::RoomEvent<mtx::events::msg::CallInvite> &);
-    void handleEvent(const mtx::events::RoomEvent<mtx::events::msg::CallCandidates> &);
-    void handleEvent(const mtx::events::RoomEvent<mtx::events::msg::CallAnswer> &);
-    void handleEvent(const mtx::events::RoomEvent<mtx::events::msg::CallHangUp> &);
-    void answerInvite(const mtx::events::msg::CallInvite &, bool isVideo);
+    void handleEvent(const mtx::events::RoomEvent<mtx::events::voip::CallInvite> &);
+    void handleEvent(const mtx::events::RoomEvent<mtx::events::voip::CallCandidates> &);
+    void handleEvent(const mtx::events::RoomEvent<mtx::events::voip::CallAnswer> &);
+    void handleEvent(const mtx::events::RoomEvent<mtx::events::voip::CallHangUp> &);
+    void answerInvite(const mtx::events::voip::CallInvite &, bool isVideo);
     void generateCallID();
     QStringList devices(bool isVideo) const;
     void clear();

--- a/src/voip/WebRTCSession.cpp
+++ b/src/voip/WebRTCSession.cpp
@@ -1151,7 +1151,8 @@ WebRTCSession::acceptAnswer(const std::string &)
 }
 
 void
-WebRTCSession::acceptICECandidates(const std::vector<mtx::events::voip::CallCandidates::Candidate> &)
+WebRTCSession::acceptICECandidates(
+  const std::vector<mtx::events::voip::CallCandidates::Candidate> &)
 {}
 
 bool

--- a/src/voip/WebRTCSession.cpp
+++ b/src/voip/WebRTCSession.cpp
@@ -105,7 +105,7 @@ WebRTCSession::init(std::string *errorMessage)
 namespace {
 
 std::string localsdp_;
-std::vector<mtx::events::msg::CallCandidates::Candidate> localcandidates_;
+std::vector<mtx::events::voip::CallCandidates::Candidate> localcandidates_;
 bool haveAudioStream_     = false;
 bool haveVideoStream_     = false;
 GstPad *localPiPSinkPad_  = nullptr;
@@ -726,7 +726,7 @@ WebRTCSession::acceptAnswer(const std::string &sdp)
 
 void
 WebRTCSession::acceptICECandidates(
-  const std::vector<mtx::events::msg::CallCandidates::Candidate> &candidates)
+  const std::vector<mtx::events::voip::CallCandidates::Candidate> &candidates)
 {
     if (state_ >= State::INITIATED) {
         for (const auto &c : candidates) {
@@ -1151,7 +1151,7 @@ WebRTCSession::acceptAnswer(const std::string &)
 }
 
 void
-WebRTCSession::acceptICECandidates(const std::vector<mtx::events::msg::CallCandidates::Candidate> &)
+WebRTCSession::acceptICECandidates(const std::vector<mtx::events::voip::CallCandidates::Candidate> &)
 {}
 
 bool

--- a/src/voip/WebRTCSession.h
+++ b/src/voip/WebRTCSession.h
@@ -64,7 +64,7 @@ public:
     bool createOffer(webrtc::CallType, uint32_t shareWindowId);
     bool acceptOffer(const std::string &sdp);
     bool acceptAnswer(const std::string &sdp);
-    void acceptICECandidates(const std::vector<mtx::events::msg::CallCandidates::Candidate> &);
+    void acceptICECandidates(const std::vector<mtx::events::voip::CallCandidates::Candidate> &);
 
     bool isMicMuted() const;
     bool toggleMicMute();
@@ -78,10 +78,10 @@ public:
 
 signals:
     void offerCreated(const std::string &sdp,
-                      const std::vector<mtx::events::msg::CallCandidates::Candidate> &);
+                      const std::vector<mtx::events::voip::CallCandidates::Candidate> &);
     void answerCreated(const std::string &sdp,
-                       const std::vector<mtx::events::msg::CallCandidates::Candidate> &);
-    void newICECandidate(const mtx::events::msg::CallCandidates::Candidate &);
+                       const std::vector<mtx::events::voip::CallCandidates::Candidate> &);
+    void newICECandidate(const mtx::events::voip::CallCandidates::Candidate &);
     void stateChanged(webrtc::State);
 
 private slots:


### PR DESCRIPTION
Updates the namespace for call events from `mtx::events::msg` to `mtx::events::voip`. 