### PR TITLE
Try and port to Apple M1 (Fixing #563)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,8 @@ set(CMAKE_AUTOMOC ON)
 option(HUNTER_ENABLED "Enable Hunter package manager" OFF)
 include("cmake/HunterGate.cmake")
 HunterGate(
-	URL "https://github.com/cpp-pm/hunter/archive/v0.23.305.tar.gz"
-	SHA1 "fc8d7a6dac2fa23681847b3872d88d3839b657b0"
+	URL "https://github.com/cpp-pm/hunter/archive/v0.24.3.tar.gz"
+	SHA1 "10738b59e539818a01090e64c2d09896247530c7"
 	LOCAL
 	)
 

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,7 +1,7 @@
 
 hunter_config(
     spdlog
-    VERSION 1.8.0-p1
+    VERSION 1.9.2-p0
 )
 
 hunter_config(
@@ -9,10 +9,25 @@ hunter_config(
     VERSION 0.9.21-p2
 )
 
-hunter_config(
-    OpenSSL
-    VERSION 1.1.1j
-)
+# TODO: Update to 1.1.1q (latest release of OpenSSL) once hunter supports it
+# Then we can remove hacky version for Apple ARM64
+if (APPLE)
+    set(CMAKE_OSX_ARCHITECTURES arm64)
+    hunter_config(
+        OpenSSL
+        # Modified version to supports apple arm64
+        #
+        # See PR cpp-pm/hunter#248
+        # According to docs "only use this version if you need
+        # ARM64 support before official release"
+        VERSION 1.1.1g-p0
+    )
+else()
+    hunter_config(
+        OpenSSL
+        VERSION 1.1.1j
+    )
+endif()
 
 hunter_config(
     Libevent


### PR DESCRIPTION
I can confirm basic compilation works! See TODO list below.

Requires update for hunter and spdlog,
 using a patched version of openssl (semi-endorsed by hunter since they don't have the full release yet)

I used Homebrew version of Qt5.

TODO:
- [x] Basic compilation
- [ ] Get codesigning working (self-signing)
- [ ] Get one script working on two platforms
  - [ ] Universal binaries
- [ ] CI setup?
  - This costs money as discussed in issue #563

The compilation command that (finally) got it to work:
```bash
cmake -DHUNTER_STATUS_DEBUG=ON  -GNinja -H. -Bbuild -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_SYSTEM_PROCESSOR=arm64 -DCMAKE_BUILD_T
YPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=.deps/usr -DHUNTER_ROOT="../.hunter" -DHUNTER_ENABLED=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DHUN
TER_CONFIGURATION_TYPES=RelWithDebInfo -DUSE_BUNDLED_OPENSSL=ON -DUSE_BUNDLED_BOOST=ON -DUSE_BUNDLED_MTXCLIENT=ON -DUSE_BUNDLED_JSON=ON -DUSE_BUNDLED_CMARK=ON -D
USE_BUNDLED_COEURL=true
```
