### PR TITLE
Line to indicate first unread message

### DIFF
--- a/resources/qml/MessageView.qml
+++ b/resources/qml/MessageView.qml
@@ -399,7 +399,6 @@ Item {
             required property string previousMessageDay
             required property string userName
             property bool scrolledToThis: eventId === chat.model.scrollTarget && (y + height > chat.y + chat.contentY && y < chat.y + chat.height + chat.contentY)
-            property string fullyReadEventId: chat.model.fullyReadEventId
 
             anchors.horizontalCenter: parent ? parent.horizontalCenter : undefined
             width: chat.delegateMaxWidth
@@ -441,7 +440,6 @@ Item {
                 filesize: wrapper.filesize
                 url: wrapper.url
                 thumbnailUrl: wrapper.thumbnailUrl
-                fullyReadEventId: wrapper.fullyReadEventId
                 duration: wrapper.duration
                 isOnlyEmoji: wrapper.isOnlyEmoji
                 isSender: wrapper.isSender

--- a/resources/qml/MessageView.qml
+++ b/resources/qml/MessageView.qml
@@ -399,6 +399,8 @@ Item {
             required property string previousMessageDay
             required property string userName
             property bool scrolledToThis: eventId === chat.model.scrollTarget && (y + height > chat.y + chat.contentY && y < chat.y + chat.height + chat.contentY)
+            property string fullyReadEventId: chat.model.fullyReadEventId
+            property bool roomReadStatus: chat.model.roomReadStatus
 
             anchors.horizontalCenter: parent ? parent.horizontalCenter : undefined
             width: chat.delegateMaxWidth
@@ -440,6 +442,8 @@ Item {
                 filesize: wrapper.filesize
                 url: wrapper.url
                 thumbnailUrl: wrapper.thumbnailUrl
+                fullyReadEventId: wrapper.fullyReadEventId
+                roomReadStatus: wrapper.roomReadStatus
                 duration: wrapper.duration
                 isOnlyEmoji: wrapper.isOnlyEmoji
                 isSender: wrapper.isSender

--- a/resources/qml/MessageView.qml
+++ b/resources/qml/MessageView.qml
@@ -400,7 +400,7 @@ Item {
             required property string userName
             property bool scrolledToThis: eventId === chat.model.scrollTarget && (y + height > chat.y + chat.contentY && y < chat.y + chat.height + chat.contentY)
             property string fullyReadEventId: chat.model.fullyReadEventId
-            property bool roomReadStatus: chat.model.roomReadStatus
+            property bool isRoomUnread: chat.model.isRoomUnread
 
             anchors.horizontalCenter: parent ? parent.horizontalCenter : undefined
             width: chat.delegateMaxWidth
@@ -443,7 +443,7 @@ Item {
                 url: wrapper.url
                 thumbnailUrl: wrapper.thumbnailUrl
                 fullyReadEventId: wrapper.fullyReadEventId
-                roomReadStatus: wrapper.roomReadStatus
+                isRoomUnread: wrapper.isRoomUnread
                 duration: wrapper.duration
                 isOnlyEmoji: wrapper.isOnlyEmoji
                 isSender: wrapper.isSender

--- a/resources/qml/MessageView.qml
+++ b/resources/qml/MessageView.qml
@@ -400,7 +400,6 @@ Item {
             required property string userName
             property bool scrolledToThis: eventId === chat.model.scrollTarget && (y + height > chat.y + chat.contentY && y < chat.y + chat.height + chat.contentY)
             property string fullyReadEventId: chat.model.fullyReadEventId
-            property bool isRoomUnread: chat.model.isRoomUnread
 
             anchors.horizontalCenter: parent ? parent.horizontalCenter : undefined
             width: chat.delegateMaxWidth
@@ -443,7 +442,6 @@ Item {
                 url: wrapper.url
                 thumbnailUrl: wrapper.thumbnailUrl
                 fullyReadEventId: wrapper.fullyReadEventId
-                isRoomUnread: wrapper.isRoomUnread
                 duration: wrapper.duration
                 isOnlyEmoji: wrapper.isOnlyEmoji
                 isSender: wrapper.isSender
@@ -462,6 +460,7 @@ Item {
                 encryptionError: wrapper.encryptionError
                 timestamp: wrapper.timestamp
                 status: wrapper.status
+                index: wrapper.index
                 relatedEventCacheBuster: wrapper.relatedEventCacheBuster
                 y: section.visible && section.active ? section.y + section.height : 0
 

--- a/resources/qml/RoomList.qml
+++ b/resources/qml/RoomList.qml
@@ -106,6 +106,8 @@ Page {
                     timelineRoot: timelineView
                     windowTarget: roomWindowW
                 }
+
+                onActiveChanged: { room.lastReadIdOnWindowFocus(); }
             }
 
         }

--- a/resources/qml/TimelineRow.qml
+++ b/resources/qml/TimelineRow.qml
@@ -26,6 +26,8 @@ AbstractButton {
     required property string filesize
     required property string url
     required property string thumbnailUrl
+    required property string fullyReadEventId
+    required property bool roomReadStatus
     required property bool isOnlyEmoji
     required property bool isSender
     required property bool isEncrypted
@@ -49,7 +51,7 @@ AbstractButton {
     hoverEnabled: true
 
     width: parent.width
-    height: row.height+(reactionRow.height > 0 ? reactionRow.height-2 : 0 )
+    height: row.height+(reactionRow.height > 0 ? reactionRow.height-2 : 0 )+(unreadRow.height > 0 ? unreadRow.height : 0 )
 
     Rectangle {
         color: (Settings.messageHoverHighlight && hovered) ? Nheko.colors.alternateBase : "transparent"
@@ -277,6 +279,7 @@ AbstractButton {
             }
         }
     }
+
     Reactions {
         anchors {
             top: row.bottom
@@ -291,5 +294,18 @@ AbstractButton {
 
         reactions: r.reactions
         eventId: r.eventId
+    }
+
+    Rectangle {
+        id: unreadRow
+        anchors {
+            top: reactionRow.bottom
+            topMargin: 5
+        }
+        color: Nheko.colors.highlight
+        width: row.maxWidth
+        height: 3
+        visible: (r.roomReadStatus && (r.fullyReadEventId == r.eventId)) ? 1 : 0
+
     }
 }

--- a/resources/qml/TimelineRow.qml
+++ b/resources/qml/TimelineRow.qml
@@ -304,8 +304,8 @@ AbstractButton {
         }
         color: Nheko.colors.highlight
         width: row.maxWidth
-        height: 3
         visible: (r.roomReadStatus && (r.fullyReadEventId == r.eventId)) ? 1 : 0
+        height: visible ? 3 : 0
 
     }
 }

--- a/resources/qml/TimelineRow.qml
+++ b/resources/qml/TimelineRow.qml
@@ -26,7 +26,6 @@ AbstractButton {
     required property string filesize
     required property string url
     required property string thumbnailUrl
-    required property string fullyReadEventId
     required property bool isOnlyEmoji
     required property bool isSender
     required property bool isEncrypted
@@ -304,7 +303,7 @@ AbstractButton {
         }
         color: Nheko.colors.highlight
         width: row.maxWidth
-        visible: (r.index && (r.fullyReadEventId == r.eventId))
+        visible: (r.index > 0 && (chat.model.fullyReadEventId == r.eventId))
         height: visible ? 3 : 0
 
     }

--- a/resources/qml/TimelineRow.qml
+++ b/resources/qml/TimelineRow.qml
@@ -27,7 +27,6 @@ AbstractButton {
     required property string url
     required property string thumbnailUrl
     required property string fullyReadEventId
-    required property bool isRoomUnread
     required property bool isOnlyEmoji
     required property bool isSender
     required property bool isEncrypted
@@ -46,6 +45,7 @@ AbstractButton {
     required property int duration
     required property var timestamp
     required property int status
+    required property int index
     required property int relatedEventCacheBuster
 
     hoverEnabled: true
@@ -304,7 +304,7 @@ AbstractButton {
         }
         color: Nheko.colors.highlight
         width: row.maxWidth
-        visible: (r.isRoomUnread && (r.fullyReadEventId == r.eventId))
+        visible: (r.index && (r.fullyReadEventId == r.eventId))
         height: visible ? 3 : 0
 
     }

--- a/resources/qml/TimelineRow.qml
+++ b/resources/qml/TimelineRow.qml
@@ -27,7 +27,7 @@ AbstractButton {
     required property string url
     required property string thumbnailUrl
     required property string fullyReadEventId
-    required property bool roomReadStatus
+    required property bool isRoomUnread
     required property bool isOnlyEmoji
     required property bool isSender
     required property bool isEncrypted
@@ -304,7 +304,7 @@ AbstractButton {
         }
         color: Nheko.colors.highlight
         width: row.maxWidth
-        visible: (r.roomReadStatus && (r.fullyReadEventId == r.eventId)) ? 1 : 0
+        visible: (r.isRoomUnread && (r.fullyReadEventId == r.eventId))
         height: visible ? 3 : 0
 
     }

--- a/resources/qml/TimelineRow.qml
+++ b/resources/qml/TimelineRow.qml
@@ -51,7 +51,7 @@ AbstractButton {
     hoverEnabled: true
 
     width: parent.width
-    height: row.height+(reactionRow.height > 0 ? reactionRow.height-2 : 0 )+(unreadRow.height > 0 ? unreadRow.height : 0 )
+    height: row.height+(reactionRow.height > 0 ? reactionRow.height-2 : 0 )+unreadRow.height
 
     Rectangle {
         color: (Settings.messageHoverHighlight && hovered) ? Nheko.colors.alternateBase : "transparent"

--- a/src/Cache.cpp
+++ b/src/Cache.cpp
@@ -2525,19 +2525,14 @@ Cache::lastVisibleEvent(const std::string &room_id, std::string_view event_id)
         orderDb      = getEventToOrderDb(txn, room_id);
         eventOrderDb = getEventOrderDb(txn, room_id);
         timelineDb   = getMessageToOrderDb(txn, room_id);
-    } catch (lmdb::runtime_error &e) {
-        nhlog::db()->error(
-          "Can't open db for room '{}', probably doesn't exist yet. ({})", room_id, e.what());
-        return {};
-    }
 
-    std::string_view indexVal;
+        std::string_view indexVal;
 
-    bool success = orderDb.get(txn, event_id, indexVal);
-    if (!success) {
-        return {};
-    }
-    try {
+        bool success = orderDb.get(txn, event_id, indexVal);
+        if (!success) {
+            return {};
+        }
+
         uint64_t idx = lmdb::from_sv<uint64_t>(indexVal);
         std::string evId{event_id};
 

--- a/src/Cache.cpp
+++ b/src/Cache.cpp
@@ -1543,7 +1543,7 @@ Cache::getLastFullyReadEventId(const std::string &room_id)
 
     if (auto ev = getAccountData(txn, mtx::events::EventType::FullyRead, room_id)) {
         if (auto fr =
-            std::get_if<mtx::events::AccountDataEvent<mtx::events::account_data::FullyRead>>(
+              std::get_if<mtx::events::AccountDataEvent<mtx::events::account_data::FullyRead>>(
                 &ev.value())) {
             return fr->content.event_id;
         }
@@ -2575,7 +2575,7 @@ Cache::lastVisibleEvent(const std::string &room_id, std::string_view event_id)
                 if (timelineDb.get(txn, evId, temp)) {
                     return std::pair{idx, evId};
                 }
-                } while (cursor.get(indexVal, event_id, MDB_PREV));
+            } while (cursor.get(indexVal, event_id, MDB_PREV));
         }
 
         return std::pair{idx, evId};
@@ -5391,7 +5391,7 @@ getRoomInfo(const std::vector<std::string> &rooms)
 std::string
 getLastFullyReadEventId(const std::string &room_id)
 {
-	return instance_->getLastFullyReadEventId(room_id);
+    return instance_->getLastFullyReadEventId(room_id);
 }
 bool
 calculateRoomReadStatus(const std::string &room_id, const std::string &event_id)

--- a/src/Cache.cpp
+++ b/src/Cache.cpp
@@ -1593,31 +1593,6 @@ Cache::calculateRoomReadStatus(const std::string &room_id)
     return getEventIndex(room_id, last_event_id_) > getEventIndex(room_id, fullyReadEventId_);
 }
 
-bool
-Cache::calculateRoomReadStatus(const std::string &room_id, const std::string &event_id)
-{
-    std::string last_event_id_, fullyReadEventId_;
-    {
-        auto txn = ro_txn(env_);
-
-        // Get last event id on the room.
-        const auto last_event_id = getLastEventId(txn, room_id);
-        const auto localUser     = utils::localUser().toStdString();
-
-        if (last_event_id.empty() || event_id.empty())
-            return true;
-
-        if (last_event_id == event_id)
-            return false;
-
-        last_event_id_    = std::string(last_event_id);
-        fullyReadEventId_ = std::string(event_id);
-    }
-
-    // Retrieve all read receipts for that event.
-    return getEventIndex(room_id, last_event_id_) > getEventIndex(room_id, fullyReadEventId_);
-}
-
 void
 Cache::updateState(const std::string &room, const mtx::responses::StateEvents &state)
 {
@@ -5392,11 +5367,6 @@ std::string
 getLastFullyReadEventId(const std::string &room_id)
 {
     return instance_->getLastFullyReadEventId(room_id);
-}
-bool
-calculateRoomReadStatus(const std::string &room_id, const std::string &event_id)
-{
-    return instance_->calculateRoomReadStatus(room_id, event_id);
 }
 bool
 calculateRoomReadStatus(const std::string &room_id)

--- a/src/Cache.cpp
+++ b/src/Cache.cpp
@@ -2569,7 +2569,7 @@ Cache::lastVisibleEvent(const std::string &room_id, std::string_view event_id)
         auto cursor = lmdb::cursor::open(txn, eventOrderDb);
         if (cursor.get(indexVal, event_id, MDB_SET)) {
             do {
-                std::string evId = nlohmann::json::parse(event_id)["event_id"].get<std::string>();
+                evId = nlohmann::json::parse(event_id)["event_id"].get<std::string>();
                 std::string_view temp;
                 idx = lmdb::from_sv<uint64_t>(indexVal);
                 if (timelineDb.get(txn, evId, temp)) {

--- a/src/Cache.cpp
+++ b/src/Cache.cpp
@@ -1537,7 +1537,7 @@ Cache::updateReadReceipt(lmdb::txn &txn, const std::string &room_id, const Recei
 }
 
 std::string
-Cache::getLastFullyReadEventId(const std::string &room_id)
+Cache::getFullyReadEventId(const std::string &room_id)
 {
     auto txn = ro_txn(env_);
 
@@ -1575,9 +1575,7 @@ Cache::calculateRoomReadStatus(const std::string &room_id)
         const auto last_event_id = getLastEventId(txn, room_id);
         const auto localUser     = utils::localUser().toStdString();
 
-        std::string fullyReadEventId;
-
-        fullyReadEventId = getLastFullyReadEventId(room_id);
+        std::string fullyReadEventId = getFullyReadEventId(room_id);
 
         if (last_event_id.empty() || fullyReadEventId.empty())
             return true;
@@ -5359,9 +5357,9 @@ getRoomInfo(const std::vector<std::string> &rooms)
 //! Calculates which the read status of a room.
 //! Whether all the events in the timeline have been read.
 std::string
-getLastFullyReadEventId(const std::string &room_id)
+getFullyReadEventId(const std::string &room_id)
 {
-    return instance_->getLastFullyReadEventId(room_id);
+    return instance_->getFullyReadEventId(room_id);
 }
 bool
 calculateRoomReadStatus(const std::string &room_id)

--- a/src/Cache.h
+++ b/src/Cache.h
@@ -163,7 +163,7 @@ getRoomInfo(const std::vector<std::string> &rooms);
 //! Calculates which the read status of a room.
 //! Whether all the events in the timeline have been read.
 std::string
-getLastFullyReadEventId(const std::string &room_id);
+getFullyReadEventId(const std::string &room_id);
 bool
 calculateRoomReadStatus(const std::string &room_id);
 void

--- a/src/Cache.h
+++ b/src/Cache.h
@@ -160,6 +160,8 @@ getRoomInfo(const std::vector<std::string> &rooms);
 
 //! Calculates which the read status of a room.
 //! Whether all the events in the timeline have been read.
+std::string
+getLastFullyReadEventId(const std::string &room_id);
 bool
 calculateRoomReadStatus(const std::string &room_id);
 void

--- a/src/Cache.h
+++ b/src/Cache.h
@@ -165,6 +165,8 @@ getRoomInfo(const std::vector<std::string> &rooms);
 std::string
 getLastFullyReadEventId(const std::string &room_id);
 bool
+calculateRoomReadStatus(const std::string &room_id, const std::string &event_id);
+bool
 calculateRoomReadStatus(const std::string &room_id);
 void
 calculateRoomReadStatus();

--- a/src/Cache.h
+++ b/src/Cache.h
@@ -152,6 +152,8 @@ std::optional<uint64_t>
 getEventIndex(const std::string &room_id, std::string_view event_id);
 std::optional<std::pair<uint64_t, std::string>>
 lastInvisibleEventAfter(const std::string &room_id, std::string_view event_id);
+std::optional<std::pair<uint64_t, std::string>>
+lastVisibleEvent(const std::string &room_id, std::string_view event_id);
 
 RoomInfo
 singleRoomInfo(const std::string &room_id);

--- a/src/Cache.h
+++ b/src/Cache.h
@@ -165,8 +165,6 @@ getRoomInfo(const std::vector<std::string> &rooms);
 std::string
 getLastFullyReadEventId(const std::string &room_id);
 bool
-calculateRoomReadStatus(const std::string &room_id, const std::string &event_id);
-bool
 calculateRoomReadStatus(const std::string &room_id);
 void
 calculateRoomReadStatus();

--- a/src/Cache_p.h
+++ b/src/Cache_p.h
@@ -170,6 +170,7 @@ public:
     //! Calculates which the read status of a room.
     //! Whether all the events in the timeline have been read.
     std::string getLastFullyReadEventId(const std::string &room_id);
+    bool calculateRoomReadStatus(const std::string &room_id, const std::string &event_id);
     bool calculateRoomReadStatus(const std::string &room_id);
     void calculateRoomReadStatus();
 

--- a/src/Cache_p.h
+++ b/src/Cache_p.h
@@ -169,6 +169,7 @@ public:
 
     //! Calculates which the read status of a room.
     //! Whether all the events in the timeline have been read.
+    std::string getLastFullyReadEventId(const std::string &room_id);
     bool calculateRoomReadStatus(const std::string &room_id);
     void calculateRoomReadStatus();
 

--- a/src/Cache_p.h
+++ b/src/Cache_p.h
@@ -170,7 +170,6 @@ public:
     //! Calculates which the read status of a room.
     //! Whether all the events in the timeline have been read.
     std::string getLastFullyReadEventId(const std::string &room_id);
-    bool calculateRoomReadStatus(const std::string &room_id, const std::string &event_id);
     bool calculateRoomReadStatus(const std::string &room_id);
     void calculateRoomReadStatus();
 

--- a/src/Cache_p.h
+++ b/src/Cache_p.h
@@ -213,6 +213,8 @@ public:
     std::optional<uint64_t> getEventIndex(const std::string &room_id, std::string_view event_id);
     std::optional<std::pair<uint64_t, std::string>>
     lastInvisibleEventAfter(const std::string &room_id, std::string_view event_id);
+    std::optional<std::pair<uint64_t, std::string>>
+    lastVisibleEvent(const std::string &room_id, std::string_view event_id);
     std::optional<std::string> getTimelineEventId(const std::string &room_id, uint64_t index);
     std::optional<uint64_t> getArrivalIndex(const std::string &room_id, std::string_view event_id);
 

--- a/src/Cache_p.h
+++ b/src/Cache_p.h
@@ -169,7 +169,7 @@ public:
 
     //! Calculates which the read status of a room.
     //! Whether all the events in the timeline have been read.
-    std::string getLastFullyReadEventId(const std::string &room_id);
+    std::string getFullyReadEventId(const std::string &room_id);
     bool calculateRoomReadStatus(const std::string &room_id);
     void calculateRoomReadStatus();
 

--- a/src/ChatPage.h
+++ b/src/ChatPage.h
@@ -74,6 +74,9 @@ public:
 
     void startChat(QString userid, std::optional<bool> encryptionEnabled);
 
+    //! Check if the given room is currently open.
+    bool isRoomActive(const QString &room_id);
+
 public slots:
     bool handleMatrixUri(QString uri);
     bool handleMatrixUri(const QUrl &uri);
@@ -192,9 +195,6 @@ private:
     void removeOldFallbackKey();
     void getProfileInfo();
     void getBackupVersion();
-
-    //! Check if the given room is currently open.
-    bool isRoomActive(const QString &room_id);
 
     using UserID      = QString;
     using Membership  = mtx::events::StateEvent<mtx::events::state::Member>;

--- a/src/timeline/RoomlistModel.cpp
+++ b/src/timeline/RoomlistModel.cpp
@@ -286,11 +286,11 @@ RoomlistModel::addRoom(const QString &room_id, bool suppressInsertNotification)
         connect(this,
                 &RoomlistModel::currentRoomChanged,
                 newRoom.data(),
-                &TimelineModel::updateUnreadLine);
+                &TimelineModel::updateLastReadId);
         connect(MainWindow::instance(),
                 &MainWindow::activeChanged,
                 newRoom.data(),
-                &TimelineModel::unreadLineOnWindowFocus);
+                &TimelineModel::lastReadIdOnWindowFocus);
         connect(newRoom.data(),
                 &TimelineModel::newEncryptedImage,
                 MainWindow::instance()->imageProvider(),
@@ -391,7 +391,7 @@ RoomlistModel::addRoom(const QString &room_id, bool suppressInsertNotification)
             currentRoomPreview_->roomid() == room_id) {
             currentRoom_ = models.value(room_id);
             currentRoomPreview_.reset();
-            emit currentRoomChanged();
+            emit currentRoomChanged(currentRoom_->roomId());
         }
 
         for (auto p : previewsToAdd) {
@@ -652,7 +652,7 @@ RoomlistModel::clear()
     invites.clear();
     roomids.clear();
     currentRoom_ = nullptr;
-    emit currentRoomChanged();
+    emit currentRoomChanged("");
     endResetModel();
 }
 
@@ -751,14 +751,14 @@ RoomlistModel::setCurrentRoom(QString roomid)
     if (roomid.isEmpty()) {
         currentRoom_        = nullptr;
         currentRoomPreview_ = {};
-        emit currentRoomChanged();
+        emit currentRoomChanged("");
     }
 
     nhlog::ui()->debug("Trying to switch to: {}", roomid.toStdString());
     if (models.contains(roomid)) {
         currentRoom_ = models.value(roomid);
         currentRoomPreview_.reset();
-        emit currentRoomChanged();
+        emit currentRoomChanged(currentRoom_->roomId());
         nhlog::ui()->debug("Switched to: {}", roomid.toStdString());
     } else if (invites.contains(roomid) || previewedRooms.contains(roomid)) {
         currentRoom_ = nullptr;
@@ -789,7 +789,7 @@ RoomlistModel::setCurrentRoom(QString roomid)
                                currentRoomPreview_->roomid_.toStdString());
         }
 
-        emit currentRoomChanged();
+        emit currentRoomChanged(currentRoom_->roomId());
     }
 }
 

--- a/src/timeline/RoomlistModel.cpp
+++ b/src/timeline/RoomlistModel.cpp
@@ -287,6 +287,10 @@ RoomlistModel::addRoom(const QString &room_id, bool suppressInsertNotification)
                 &RoomlistModel::currentRoomChanged,
                 newRoom.data(),
                 &TimelineModel::updateUnreadLine);
+        connect(MainWindow::instance(),
+                &MainWindow::activeChanged,
+                newRoom.data(),
+                &TimelineModel::unreadLineOnWindowFocus);
         connect(newRoom.data(),
                 &TimelineModel::newEncryptedImage,
                 MainWindow::instance()->imageProvider(),

--- a/src/timeline/RoomlistModel.cpp
+++ b/src/timeline/RoomlistModel.cpp
@@ -391,7 +391,7 @@ RoomlistModel::addRoom(const QString &room_id, bool suppressInsertNotification)
             currentRoomPreview_->roomid() == room_id) {
             currentRoom_ = models.value(room_id);
             currentRoomPreview_.reset();
-            emit currentRoomChanged(currentRoom_->roomId());
+            emit currentRoomChanged(room_id);
         }
 
         for (auto p : previewsToAdd) {
@@ -789,7 +789,7 @@ RoomlistModel::setCurrentRoom(QString roomid)
                                currentRoomPreview_->roomid_.toStdString());
         }
 
-        emit currentRoomChanged(currentRoom_->roomId());
+        emit currentRoomChanged("");
     }
 }
 

--- a/src/timeline/RoomlistModel.cpp
+++ b/src/timeline/RoomlistModel.cpp
@@ -283,6 +283,10 @@ RoomlistModel::addRoom(const QString &room_id, bool suppressInsertNotification)
         QSharedPointer<TimelineModel> newRoom(new TimelineModel(manager, room_id));
         newRoom->setDecryptDescription(ChatPage::instance()->userSettings()->decryptSidebar());
 
+        connect(this,
+                &RoomlistModel::currentRoomChanged,
+                newRoom.data(),
+                &TimelineModel::updateUnreadLine);
         connect(newRoom.data(),
                 &TimelineModel::newEncryptedImage,
                 MainWindow::instance()->imageProvider(),

--- a/src/timeline/RoomlistModel.h
+++ b/src/timeline/RoomlistModel.h
@@ -116,7 +116,7 @@ public slots:
     {
         currentRoom_ = nullptr;
         currentRoomPreview_.reset();
-        emit currentRoomChanged();
+        emit currentRoomChanged("");
     }
 
 private slots:
@@ -124,7 +124,7 @@ private slots:
 
 signals:
     void totalUnreadMessageCountUpdated(int unreadMessages);
-    void currentRoomChanged();
+    void currentRoomChanged(QString currentRoomId);
     void fetchedPreview(QString roomid, RoomInfo info);
 
 private:
@@ -218,7 +218,7 @@ public slots:
     void updateHiddenTagsAndSpaces();
 
 signals:
-    void currentRoomChanged();
+    void currentRoomChanged(QString currentRoomId);
 
 private:
     short int calculateImportance(const QModelIndex &idx) const;

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -873,7 +873,8 @@ TimelineModel::fetchMore(const QModelIndex &)
      * try again after these new messages were fetched
      */
     if (this->fullyReadEventId_.empty()) {
-        auto lastVisibleEventIndexAndId = cache::lastVisibleEvent(room_id_.toStdString(), last_event_id);
+        auto lastVisibleEventIndexAndId =
+          cache::lastVisibleEvent(room_id_.toStdString(), last_event_id);
         if (lastVisibleEventIndexAndId) {
             this->fullyReadEventId_ = lastVisibleEventIndexAndId->second;
             emit fullyReadEventIdChanged();
@@ -1387,10 +1388,11 @@ void
 TimelineModel::updateLastReadId(QString currentRoomId)
 {
     if (currentRoomId == room_id_) {
-        isActiveRoom = true;
+        isActiveRoom  = true;
         last_event_id = cache::getLastFullyReadEventId(room_id_.toStdString());
         isRoomUnread_ = cache::calculateRoomReadStatus(room_id_.toStdString(), last_event_id);
-        auto lastVisibleEventIndexAndId = cache::lastVisibleEvent(room_id_.toStdString(), last_event_id);
+        auto lastVisibleEventIndexAndId =
+          cache::lastVisibleEvent(room_id_.toStdString(), last_event_id);
         if (lastVisibleEventIndexAndId) {
             fullyReadEventId_ = lastVisibleEventIndexAndId->second;
             emit isRoomUnreadChanged();
@@ -1406,7 +1408,8 @@ TimelineModel::lastReadIdOnWindowFocus()
 {
     /* this stops it from removing the line when focusing another window
      * and from removing the line when refocusing nheko */
-    if (MainWindow::instance()->isActive() && cache::calculateRoomReadStatus(room_id_.toStdString()) && isActiveRoom) {
+    if (MainWindow::instance()->isActive() &&
+        cache::calculateRoomReadStatus(room_id_.toStdString()) && isActiveRoom) {
         updateLastReadId(room_id_);
     }
 }

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -1388,7 +1388,6 @@ void
 TimelineModel::updateLastReadId(QString currentRoomId)
 {
     if (currentRoomId == room_id_) {
-        isActiveRoom  = true;
         last_event_id = cache::getLastFullyReadEventId(room_id_.toStdString());
         isRoomUnread_ = cache::calculateRoomReadStatus(room_id_.toStdString(), last_event_id);
         auto lastVisibleEventIndexAndId =
@@ -1398,8 +1397,6 @@ TimelineModel::updateLastReadId(QString currentRoomId)
             emit isRoomUnreadChanged();
             emit fullyReadEventIdChanged();
         }
-    } else {
-        isActiveRoom = false;
     }
 }
 
@@ -1408,8 +1405,8 @@ TimelineModel::lastReadIdOnWindowFocus()
 {
     /* this stops it from removing the line when focusing another window
      * and from removing the line when refocusing nheko */
-    if (MainWindow::instance()->isActive() &&
-        cache::calculateRoomReadStatus(room_id_.toStdString()) && isActiveRoom) {
+    if (ChatPage::instance()->isRoomActive(room_id_) &&
+        cache::calculateRoomReadStatus(room_id_.toStdString())) {
         updateLastReadId(room_id_);
     }
 }

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -1376,7 +1376,7 @@ void
 TimelineModel::updateLastReadId(QString currentRoomId)
 {
     if (currentRoomId == room_id_) {
-        last_event_id = cache::getLastFullyReadEventId(room_id_.toStdString());
+        last_event_id = cache::getFullyReadEventId(room_id_.toStdString());
         auto lastVisibleEventIndexAndId =
           cache::lastVisibleEvent(room_id_.toStdString(), last_event_id);
         if (lastVisibleEventIndexAndId) {

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -1380,6 +1380,15 @@ TimelineModel::updateUnreadLine()
     emit fullyReadEventIdChanged();
 }
 
+void
+TimelineModel::unreadLineOnWindowFocus()
+{
+    /* this stops it from removing the line when focusing another window
+     * and from removing the line when refocusing nheko */
+    if (MainWindow::instance()->isActive() && !this->roomReadStatus_) {
+        updateUnreadLine();
+    }
+}
 template<typename T>
 void
 TimelineModel::sendEncryptedMessage(mtx::events::RoomEvent<T> msg, mtx::events::EventType eventType)

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -1406,7 +1406,7 @@ TimelineModel::lastReadIdOnWindowFocus()
 {
     /* this stops it from removing the line when focusing another window
      * and from removing the line when refocusing nheko */
-    if (MainWindow::instance()->isActive() && !roomReadStatus_ && isActiveRoom) {
+    if (MainWindow::instance()->isActive() && cache::calculateRoomReadStatus(room_id_.toStdString()) && isActiveRoom) {
         updateLastReadId(room_id_);
     }
 }

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -1373,7 +1373,6 @@ TimelineModel::markEventsAsRead(const std::vector<QString> &event_ids)
     }
 }
 
-
 void
 TimelineModel::updateLastReadId(QString currentRoomId)
 {
@@ -1404,7 +1403,8 @@ TimelineModel::lastReadIdOnWindowFocus()
  * try again after these new messages were fetched
  */
 void
-TimelineModel::checkAfterFetch(){
+TimelineModel::checkAfterFetch()
+{
     if (fullyReadEventId_.empty()) {
         auto lastVisibleEventIndexAndId =
           cache::lastVisibleEvent(room_id_.toStdString(), last_event_id);

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -1374,10 +1374,15 @@ TimelineModel::markEventsAsRead(const std::vector<QString> &event_ids)
 void
 TimelineModel::updateUnreadLine()
 {
+
     this->roomReadStatus_ = cache::calculateRoomReadStatus(room_id_.toStdString());
-    this->fullyReadEventId_ = cache::getLastFullyReadEventId(room_id_.toStdString());
-    emit roomReadStatusChanged();
-    emit fullyReadEventIdChanged();
+    std::string last_event_id = cache::getLastFullyReadEventId(room_id_.toStdString());
+    auto lastVisibleEventIndexAndId = cache::lastVisibleEvent(room_id_.toStdString(), last_event_id);
+    if (lastVisibleEventIndexAndId) {
+        this->fullyReadEventId_ = lastVisibleEventIndexAndId->second;
+        emit roomReadStatusChanged();
+        emit fullyReadEventIdChanged();
+    }
 }
 
 void

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -1389,11 +1389,11 @@ TimelineModel::updateLastReadId(QString currentRoomId)
     if (currentRoomId == room_id_) {
         isActiveRoom = true;
         last_event_id = cache::getLastFullyReadEventId(room_id_.toStdString());
-        roomReadStatus_ = cache::calculateRoomReadStatus(room_id_.toStdString(), last_event_id);
+        isRoomUnread_ = cache::calculateRoomReadStatus(room_id_.toStdString(), last_event_id);
         auto lastVisibleEventIndexAndId = cache::lastVisibleEvent(room_id_.toStdString(), last_event_id);
         if (lastVisibleEventIndexAndId) {
             fullyReadEventId_ = lastVisibleEventIndexAndId->second;
-            emit roomReadStatusChanged();
+            emit isRoomUnreadChanged();
             emit fullyReadEventIdChanged();
         }
     } else {

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -868,7 +868,6 @@ TimelineModel::fetchMore(const QModelIndex &)
     setPaginationInProgress(true);
 
     events.fetchMore();
-
 }
 
 void

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -1389,12 +1389,10 @@ TimelineModel::updateLastReadId(QString currentRoomId)
 {
     if (currentRoomId == room_id_) {
         last_event_id = cache::getLastFullyReadEventId(room_id_.toStdString());
-        isRoomUnread_ = cache::calculateRoomReadStatus(room_id_.toStdString(), last_event_id);
         auto lastVisibleEventIndexAndId =
           cache::lastVisibleEvent(room_id_.toStdString(), last_event_id);
         if (lastVisibleEventIndexAndId) {
             fullyReadEventId_ = lastVisibleEventIndexAndId->second;
-            emit isRoomUnreadChanged();
             emit fullyReadEventIdChanged();
         }
     }
@@ -1590,6 +1588,9 @@ TimelineModel::addPendingMessage(mtx::events::collections::TimelineEvents event)
       event);
 
     std::visit(SendMessageVisitor{this}, event);
+
+    fullyReadEventId_ = this->EventId;
+    emit fullyReadEventIdChanged();
 }
 
 void

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -977,6 +977,7 @@ TimelineModel::addEvents(const mtx::responses::Timeline &timeline)
             emit encryptionChanged();
         }
     }
+
     updateLastMessage();
 }
 
@@ -1368,6 +1369,15 @@ TimelineModel::markEventsAsRead(const std::vector<QString> &event_ids)
         }
         emit dataChanged(index(idx, 0), index(idx, 0));
     }
+}
+
+void
+TimelineModel::updateUnreadLine()
+{
+    this->roomReadStatus_ = cache::calculateRoomReadStatus(room_id_.toStdString());
+    this->fullyReadEventId_ = cache::getLastFullyReadEventId(room_id_.toStdString());
+    emit roomReadStatusChanged();
+    emit fullyReadEventIdChanged();
 }
 
 template<typename T>

--- a/src/timeline/TimelineModel.h
+++ b/src/timeline/TimelineModel.h
@@ -180,6 +180,7 @@ class TimelineModel : public QAbstractListModel
     Q_PROPERTY(QString edit READ edit WRITE setEdit NOTIFY editChanged RESET resetEdit)
     Q_PROPERTY(
       bool paginationInProgress READ paginationInProgress NOTIFY paginationInProgressChanged)
+    Q_PROPERTY(bool roomReadStatus READ roomReadStatus NOTIFY roomReadStatusChanged)
     Q_PROPERTY(QString roomId READ roomId CONSTANT)
     Q_PROPERTY(QString roomName READ roomName NOTIFY roomNameChanged)
     Q_PROPERTY(QString plainRoomName READ plainRoomName NOTIFY roomNameChanged)
@@ -189,6 +190,7 @@ class TimelineModel : public QAbstractListModel
     Q_PROPERTY(QStringList widgetLinks READ widgetLinks NOTIFY widgetLinksChanged)
     Q_PROPERTY(int roomMemberCount READ roomMemberCount NOTIFY roomMemberCountChanged)
     Q_PROPERTY(bool isEncrypted READ isEncrypted NOTIFY encryptionChanged)
+    Q_PROPERTY(QString fullyReadEventId READ fullyReadEventId NOTIFY fullyReadEventIdChanged)
     Q_PROPERTY(bool isSpace READ isSpace CONSTANT)
     Q_PROPERTY(int trustlevel READ trustlevel NOTIFY trustlevelChanged)
     Q_PROPERTY(bool isDirect READ isDirect NOTIFY isDirectChanged)
@@ -320,11 +322,13 @@ public:
     void sendMessageEvent(const T &content, mtx::events::EventType eventType);
     RelatedInfo relatedInfo(const QString &id);
 
+    bool roomReadStatus() const { return roomReadStatus_; }
     DescInfo lastMessage() const;
     uint64_t lastMessageTimestamp() const { return lastMessage_.timestamp; }
 
     bool isSpace() const { return isSpace_; }
     bool isEncrypted() const { return isEncrypted_; }
+    QString fullyReadEventId() const { return QString::fromStdString(fullyReadEventId_); }
     crypto::Trust trustlevel() const;
     int roomMemberCount() const;
     bool isDirect() const { return roomMemberCount() <= 2; }
@@ -344,6 +348,7 @@ public slots:
     int currentIndex() const { return idToIndex(currentId); }
     void eventShown();
     void markEventsAsRead(const std::vector<QString> &event_ids);
+    void updateUnreadLine();
     QVariantMap getDump(const QString &eventId, const QString &relatedTo) const;
     void updateTypingUsers(const std::vector<QString> &users)
     {
@@ -417,6 +422,7 @@ signals:
     void newCallEvent(const mtx::events::collections::TimelineEvents &event);
     void scrollToIndex(int index);
 
+    void roomReadStatusChanged();
     void lastMessageChanged();
     void notificationsChanged();
 
@@ -427,6 +433,7 @@ signals:
     void updateFlowEventId(std::string event_id);
 
     void encryptionChanged();
+    void fullyReadEventIdChanged();
     void trustlevelChanged();
     void roomNameChanged();
     void roomTopicChanged();
@@ -468,6 +475,8 @@ private:
     QString eventIdToShow;
     int showEventTimerCounter = 0;
 
+    bool roomReadStatus_;
+
     DescInfo lastMessage_{};
 
     friend struct SendMessageVisitor;
@@ -480,6 +489,7 @@ private:
     bool m_paginationInProgress = false;
     bool isSpace_               = false;
     bool isEncrypted_           = false;
+    std::string fullyReadEventId_;
 };
 
 template<class T>

--- a/src/timeline/TimelineModel.h
+++ b/src/timeline/TimelineModel.h
@@ -348,6 +348,7 @@ public slots:
     void markEventsAsRead(const std::vector<QString> &event_ids);
     void updateLastReadId(QString currentRoomId);
     void lastReadIdOnWindowFocus();
+    void checkAfterFetch();
     QVariantMap getDump(const QString &eventId, const QString &relatedTo) const;
     void updateTypingUsers(const std::vector<QString> &users)
     {

--- a/src/timeline/TimelineModel.h
+++ b/src/timeline/TimelineModel.h
@@ -348,8 +348,8 @@ public slots:
     int currentIndex() const { return idToIndex(currentId); }
     void eventShown();
     void markEventsAsRead(const std::vector<QString> &event_ids);
-    void updateUnreadLine();
-    void unreadLineOnWindowFocus();
+    void updateLastReadId(QString currentRoomId);
+    void lastReadIdOnWindowFocus();
     QVariantMap getDump(const QString &eventId, const QString &relatedTo) const;
     void updateTypingUsers(const std::vector<QString> &users)
     {
@@ -457,6 +457,7 @@ private:
     void setPaginationInProgress(const bool paginationInProgress);
 
     QString room_id_;
+    bool isActiveRoom;
 
     QSet<QString> read;
 

--- a/src/timeline/TimelineModel.h
+++ b/src/timeline/TimelineModel.h
@@ -490,6 +490,7 @@ private:
     bool m_paginationInProgress = false;
     bool isSpace_               = false;
     bool isEncrypted_           = false;
+    std::string last_event_id;
     std::string fullyReadEventId_;
 };
 

--- a/src/timeline/TimelineModel.h
+++ b/src/timeline/TimelineModel.h
@@ -180,7 +180,6 @@ class TimelineModel : public QAbstractListModel
     Q_PROPERTY(QString edit READ edit WRITE setEdit NOTIFY editChanged RESET resetEdit)
     Q_PROPERTY(
       bool paginationInProgress READ paginationInProgress NOTIFY paginationInProgressChanged)
-    Q_PROPERTY(bool isRoomUnread READ isRoomUnread NOTIFY isRoomUnreadChanged)
     Q_PROPERTY(QString roomId READ roomId CONSTANT)
     Q_PROPERTY(QString roomName READ roomName NOTIFY roomNameChanged)
     Q_PROPERTY(QString plainRoomName READ plainRoomName NOTIFY roomNameChanged)
@@ -322,7 +321,6 @@ public:
     void sendMessageEvent(const T &content, mtx::events::EventType eventType);
     RelatedInfo relatedInfo(const QString &id);
 
-    bool isRoomUnread() const { return isRoomUnread_; }
     DescInfo lastMessage() const;
     uint64_t lastMessageTimestamp() const { return lastMessage_.timestamp; }
 
@@ -423,7 +421,6 @@ signals:
     void newCallEvent(const mtx::events::collections::TimelineEvents &event);
     void scrollToIndex(int index);
 
-    void isRoomUnreadChanged();
     void lastMessageChanged();
     void notificationsChanged();
 
@@ -476,8 +473,6 @@ private:
     QString eventIdToShow;
     int showEventTimerCounter = 0;
 
-    bool isRoomUnread_;
-
     DescInfo lastMessage_{};
 
     friend struct SendMessageVisitor;
@@ -509,8 +504,6 @@ TimelineModel::sendMessageEvent(const T &content, mtx::events::EventType eventTy
         msgCopy.type                      = eventType;
         emit newMessageToSend(msgCopy);
     }
-    isRoomUnread_ = false;
-    emit isRoomUnreadChanged();
 
     resetReply();
     resetEdit();

--- a/src/timeline/TimelineModel.h
+++ b/src/timeline/TimelineModel.h
@@ -349,6 +349,7 @@ public slots:
     void eventShown();
     void markEventsAsRead(const std::vector<QString> &event_ids);
     void updateUnreadLine();
+    void unreadLineOnWindowFocus();
     QVariantMap getDump(const QString &eventId, const QString &relatedTo) const;
     void updateTypingUsers(const std::vector<QString> &users)
     {

--- a/src/timeline/TimelineModel.h
+++ b/src/timeline/TimelineModel.h
@@ -457,7 +457,6 @@ private:
     void setPaginationInProgress(const bool paginationInProgress);
 
     QString room_id_;
-    bool isActiveRoom;
 
     QSet<QString> read;
 
@@ -512,6 +511,7 @@ TimelineModel::sendMessageEvent(const T &content, mtx::events::EventType eventTy
     }
     isRoomUnread_ = false;
     emit isRoomUnreadChanged();
+
     resetReply();
     resetEdit();
 }

--- a/src/timeline/TimelineModel.h
+++ b/src/timeline/TimelineModel.h
@@ -180,7 +180,7 @@ class TimelineModel : public QAbstractListModel
     Q_PROPERTY(QString edit READ edit WRITE setEdit NOTIFY editChanged RESET resetEdit)
     Q_PROPERTY(
       bool paginationInProgress READ paginationInProgress NOTIFY paginationInProgressChanged)
-    Q_PROPERTY(bool roomReadStatus READ roomReadStatus NOTIFY roomReadStatusChanged)
+    Q_PROPERTY(bool isRoomUnread READ isRoomUnread NOTIFY isRoomUnreadChanged)
     Q_PROPERTY(QString roomId READ roomId CONSTANT)
     Q_PROPERTY(QString roomName READ roomName NOTIFY roomNameChanged)
     Q_PROPERTY(QString plainRoomName READ plainRoomName NOTIFY roomNameChanged)
@@ -322,7 +322,7 @@ public:
     void sendMessageEvent(const T &content, mtx::events::EventType eventType);
     RelatedInfo relatedInfo(const QString &id);
 
-    bool roomReadStatus() const { return roomReadStatus_; }
+    bool isRoomUnread() const { return isRoomUnread_; }
     DescInfo lastMessage() const;
     uint64_t lastMessageTimestamp() const { return lastMessage_.timestamp; }
 
@@ -423,7 +423,7 @@ signals:
     void newCallEvent(const mtx::events::collections::TimelineEvents &event);
     void scrollToIndex(int index);
 
-    void roomReadStatusChanged();
+    void isRoomUnreadChanged();
     void lastMessageChanged();
     void notificationsChanged();
 
@@ -477,7 +477,7 @@ private:
     QString eventIdToShow;
     int showEventTimerCounter = 0;
 
-    bool roomReadStatus_;
+    bool isRoomUnread_;
 
     DescInfo lastMessage_{};
 
@@ -510,6 +510,8 @@ TimelineModel::sendMessageEvent(const T &content, mtx::events::EventType eventTy
         msgCopy.type                      = eventType;
         emit newMessageToSend(msgCopy);
     }
+    isRoomUnread_ = false;
+    emit isRoomUnreadChanged();
     resetReply();
     resetEdit();
 }


### PR DESCRIPTION
Closes #560.

This PR makes it so that if a room has unread messages, a line will appear to show the user the last read message/first unread message since the room was last opened. A feature that I felt was so sorely needed that I had to de-rust my Qt knowledge to implement it.

As it stands in its current state, this PR has a few problems. In no particular order:

<s>

- If the last read event was one of a handful, the line will not show up. These events are any that aren't conventionally showed as a message (most notably redactions and reactions)</s> done

<s>

-  If the last read event was hidden through nheko's "Hidden events" room option, the line will also be hidden</s> done

<s>

- To get the ID of the last read message, it currently runs getLastFullyReadEventId twice, once directly and once indirectly</s> done

<s>

- If the line is being shown and the user sends a message, the line doesn't disappear</s> done

Handling the line disappearing on some events has been the one that's been nagging me the most so far, I still haven't found a good way of solving it.