### PR TITLE
Grammar fix:  Group's sidebar -> Groups sidebar

### DIFF
--- a/resources/langs/nheko_ca.ts
+++ b/resources/langs/nheko_ca.ts
@@ -3589,7 +3589,7 @@ Reason: %4</source>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/resources/langs/nheko_cs.ts
+++ b/resources/langs/nheko_cs.ts
@@ -3599,7 +3599,7 @@ Reason: %4</source>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/resources/langs/nheko_de.ts
+++ b/resources/langs/nheko_de.ts
@@ -3598,7 +3598,7 @@ Grund: %4</translation>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation>Gruppen-Seitenleiste</translation>
     </message>
     <message>

--- a/resources/langs/nheko_el.ts
+++ b/resources/langs/nheko_el.ts
@@ -3589,7 +3589,7 @@ Reason: %4</source>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/resources/langs/nheko_en.ts
+++ b/resources/langs/nheko_en.ts
@@ -3598,8 +3598,8 @@ Reason: %4</translation>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
-        <translation>Group&apos;s sidebar</translation>
+        <source>Groups sidebar</source>
+        <translation>Groups sidebar</translation>
     </message>
     <message>
         <location line="+2"/>

--- a/resources/langs/nheko_eo.ts
+++ b/resources/langs/nheko_eo.ts
@@ -3602,7 +3602,7 @@ Kialo: %4</translation>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation type="unfinished">Flanka breto de grupoj</translation>
     </message>
     <message>

--- a/resources/langs/nheko_es.ts
+++ b/resources/langs/nheko_es.ts
@@ -3599,7 +3599,7 @@ Razón: %4</translation>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation type="unfinished">Barra lateral del grupo</translation>
     </message>
     <message>

--- a/resources/langs/nheko_et.ts
+++ b/resources/langs/nheko_et.ts
@@ -3598,7 +3598,7 @@ Põhjus: %4</translation>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation>Rühmade külgpaan</translation>
     </message>
     <message>

--- a/resources/langs/nheko_fi.ts
+++ b/resources/langs/nheko_fi.ts
@@ -3598,7 +3598,7 @@ Syy: %4</translation>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation>Ryhmäsivupalkki</translation>
     </message>
     <message>

--- a/resources/langs/nheko_fr.ts
+++ b/resources/langs/nheko_fr.ts
@@ -3598,7 +3598,7 @@ Raison : %4</translation>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation>Barre latérale des groupes</translation>
     </message>
     <message>

--- a/resources/langs/nheko_hu.ts
+++ b/resources/langs/nheko_hu.ts
@@ -3583,7 +3583,7 @@ Reason: %4</source>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation type="unfinished">Csoport oldalsávja</translation>
     </message>
     <message>

--- a/resources/langs/nheko_id.ts
+++ b/resources/langs/nheko_id.ts
@@ -3588,7 +3588,7 @@ Alasan: %4</translation>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation>Bilah samping grup</translation>
     </message>
     <message>

--- a/resources/langs/nheko_it.ts
+++ b/resources/langs/nheko_it.ts
@@ -3594,7 +3594,7 @@ Reason: %4</source>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation type="unfinished">Barra laterale dei gruppi</translation>
     </message>
     <message>

--- a/resources/langs/nheko_ja.ts
+++ b/resources/langs/nheko_ja.ts
@@ -3579,7 +3579,7 @@ Reason: %4</source>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation type="unfinished">グループサイドバー</translation>
     </message>
     <message>

--- a/resources/langs/nheko_ml.ts
+++ b/resources/langs/nheko_ml.ts
@@ -3589,7 +3589,7 @@ Reason: %4</source>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/resources/langs/nheko_nl.ts
+++ b/resources/langs/nheko_nl.ts
@@ -3598,7 +3598,7 @@ Reden: %4</translation>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation>Zijbalk met groepen</translation>
     </message>
     <message>

--- a/resources/langs/nheko_pl.ts
+++ b/resources/langs/nheko_pl.ts
@@ -3609,7 +3609,7 @@ Powód: %4</translation>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation>Pasek boczny grupy</translation>
     </message>
     <message>

--- a/resources/langs/nheko_pt_BR.ts
+++ b/resources/langs/nheko_pt_BR.ts
@@ -3589,7 +3589,7 @@ Reason: %4</source>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/resources/langs/nheko_pt_PT.ts
+++ b/resources/langs/nheko_pt_PT.ts
@@ -3595,7 +3595,7 @@ Reason: %4</source>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation type="unfinished">Barra lateral do grupo</translation>
     </message>
     <message>

--- a/resources/langs/nheko_ro.ts
+++ b/resources/langs/nheko_ro.ts
@@ -3603,7 +3603,7 @@ Reason: %4</source>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation type="unfinished">Bara laterală a grupului</translation>
     </message>
     <message>

--- a/resources/langs/nheko_ru.ts
+++ b/resources/langs/nheko_ru.ts
@@ -3603,7 +3603,7 @@ Reason: %4</source>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation type="unfinished">Боковая панель групп</translation>
     </message>
     <message>

--- a/resources/langs/nheko_si.ts
+++ b/resources/langs/nheko_si.ts
@@ -3589,7 +3589,7 @@ Reason: %4</source>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/resources/langs/nheko_sr_Latn.ts
+++ b/resources/langs/nheko_sr_Latn.ts
@@ -3599,7 +3599,7 @@ Reason: %4</source>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/resources/langs/nheko_sv.ts
+++ b/resources/langs/nheko_sv.ts
@@ -3593,7 +3593,7 @@ Reason: %4</source>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation type="unfinished">Gruppens sidofält</translation>
     </message>
     <message>

--- a/resources/langs/nheko_vi.ts
+++ b/resources/langs/nheko_vi.ts
@@ -3579,7 +3579,7 @@ Reason: %4</source>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/resources/langs/nheko_zh_CN.ts
+++ b/resources/langs/nheko_zh_CN.ts
@@ -3588,7 +3588,7 @@ Reason: %4</source>
     </message>
     <message>
         <location line="+2"/>
-        <source>Group&apos;s sidebar</source>
+        <source>Groups sidebar</source>
         <translation>群组侧边栏</translation>
     </message>
     <message>

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -911,7 +911,7 @@ UserSettingsModel::data(const QModelIndex &index, int role) const
         case StartInTray:
             return tr("Start in tray");
         case GroupView:
-            return tr("Group's sidebar");
+            return tr("Groups sidebar");
         case Markdown:
             return tr("Send messages as Markdown");
         case Bubbles:


### PR DESCRIPTION
This is an English grammar fix, removing the incorrect use of an apostrophe.  Since the error is present in a translation key, this fix touches multiple language translation files.