### PR TITLE
Focus message input box when pressing Esc

### DIFF
--- a/resources/qml/MessageView.qml
+++ b/resources/qml/MessageView.qml
@@ -198,6 +198,7 @@ Item {
                     chat.model.reply = undefined;
                 else
                     chat.model.edit = undefined;
+                TimelineManager.focusMessageInput();
             }
         }
 


### PR DESCRIPTION
This helps with #1065, although I think making the message input box get focus by default would still be worthwhile.