### PR TITLE
Control logging via command line or environment variable

### DIFF
--- a/man/nheko.1.adoc
+++ b/man/nheko.1.adoc
@@ -31,7 +31,27 @@ Displays help including Qt specific options.
 Displays version information.
 
 *--debug*::
-Enables debug output.
+Alias for _--log-level trace_.
+
+*-l*, *--log-level* _<level>_::
+Set the global log level, or a comma-separated list of _<component>=<level>_
+pairs, or both. For example, to set the default log level to _warn_ but
+disable logging for the _ui_ component, pass _warn,ui=off_.
++
+levels: _trace_ _debug_ _info_ _warning_ _error_ _critical_ _off_
++
+components: _crypto_ _db_ _mtx_ _net_ _qml_ _ui_
++
+Log levels can also be set in the NHEKO_LOG_LEVEL environment variable, using
+the same syntax. It will be overridden by this command line option.
+
+*-L*, *--log-type* _<type>_::
+Set the log output type. A comma-separated list is allowed. The default is _file,stderr_.
++
+types: _file_ _stderr_ _none_
++
+The log type can also be set in the NHEKO_LOG_TYPE environment variable,
+which will be overridden by this command line option.
 
 *-p* _<profile>_, *--profile* _<profile>_::
 Creates a unique profile, which allows you to log into several accounts at the

--- a/src/Logging.h
+++ b/src/Logging.h
@@ -6,11 +6,15 @@
 #pragma once
 
 #include <memory>
-#include <spdlog/logger.h>
+#include <string>
+
+#include <QString>
+
+#include "spdlog/logger.h"
 
 namespace nhlog {
 void
-init(const std::string &file);
+init(const QString &level, const QString &path, bool to_stderr);
 
 std::shared_ptr<spdlog::logger>
 ui();
@@ -27,5 +31,4 @@ crypto();
 std::shared_ptr<spdlog::logger>
 qml();
 
-extern bool enable_debug_log_from_commandline;
 }


### PR DESCRIPTION
Nheko is very chatty in its log output, generating log noise (which complicates diagnostics) and needless disk writes (which affect power consumption and SSD life).  This patch provides control over it, with command line options for:

- Setting the global log level
- Setting log levels for individual components (loggers)
- Disabling log file writes
- Disabling stderr writes (which are often written to ~/.xsession-errors)

The old --debug command line option still works, at least for now, and is overridden by the new fine-grained option.

Log levels and output type (file/stderr) can also be set by environment variables. (This is especially convenient for flatpak users, who can `flatpak override --env=` instead of having to copy and edit the .desktop file to add command line options.)

Partially addresses #665.