### PR TITLE
Fix "Send by enter" on Windows

### DIFF
--- a/resources/qml/MessageInput.qml
+++ b/resources/qml/MessageInput.qml
@@ -223,7 +223,7 @@ Rectangle {
                                 return;
                             }
                         }
-                        if (!Qt.inputMethod.visible) {
+                        if (!Qt.inputMethod.visible || Qt.platform.os === "windows") {
                             room.input.send();
                             event.accepted = true;
                         }


### PR DESCRIPTION
Apparently on windows `Qt.inputMethod.visible` is always true when an input method is installed. Also on windows even after removing the check enter is still consumed by the input method and not nheko when the input method is active.