### PR TITLE
Fix missing arguments in logging

### DIFF
--- a/src/timeline/CommunitiesModel.cpp
+++ b/src/timeline/CommunitiesModel.cpp
@@ -852,7 +852,8 @@ CommunitiesModel::updateSpaceStatus(QString space,
                           .arg(QString::fromStdString(err->matrix_error.error)));
                       nhlog::net()->error("Failed to update child {} of {}: {}",
                                           room.toStdString(),
-                                          space.toStdString());
+                                          space.toStdString(),
+                                          err->matrix_error.error);
                   }
               });
         }
@@ -869,7 +870,8 @@ CommunitiesModel::updateSpaceStatus(QString space,
                           .arg(QString::fromStdString(err->matrix_error.error)));
                       nhlog::net()->error("Failed to delete child {} of {}: {}",
                                           room.toStdString(),
-                                          space.toStdString());
+                                          space.toStdString(),
+                                          err->matrix_error.error);
                   }
               });
         }
@@ -891,7 +893,8 @@ CommunitiesModel::updateSpaceStatus(QString space,
                           .arg(QString::fromStdString(err->matrix_error.error)));
                       nhlog::net()->error("Failed to update parent {} of {}: {}",
                                           space.toStdString(),
-                                          room.toStdString());
+                                          room.toStdString(),
+                                          err->matrix_error.error);
                   }
               });
         }
@@ -908,7 +911,8 @@ CommunitiesModel::updateSpaceStatus(QString space,
                           .arg(QString::fromStdString(err->matrix_error.error)));
                       nhlog::net()->error("Failed to delete parent {} of {}: {}",
                                           space.toStdString(),
-                                          room.toStdString());
+                                          room.toStdString(),
+                                          err->matrix_error.error);
                   }
               });
         }


### PR DESCRIPTION
Testing c++20 compilation due to new mtxclient requirement and this causes a compile time error. Given the user facing error messages above, I assume this is the correct error string to use.