### PR TITLE
Fixed a crash in member list loading

### DIFF
--- a/src/MemberList.cpp
+++ b/src/MemberList.cpp
@@ -46,7 +46,7 @@ MemberListBackend::addUsers(const std::vector<RoomMember> &members)
     for (const auto &member : members)
         m_memberList.push_back(
           {member,
-           ChatPage::instance()->timelineManager()->rooms()->currentRoom()->avatarUrl(
+           ChatPage::instance()->timelineManager()->rooms()->getRoomById(room_id_)->avatarUrl(
              member.user_id)});
 
     endInsertRows();

--- a/src/MemberList.cpp
+++ b/src/MemberList.cpp
@@ -44,8 +44,11 @@ MemberListBackend::addUsers(const std::vector<RoomMember> &members)
       QModelIndex{}, m_memberList.count(), m_memberList.count() + (int)members.size() - 1);
 
     auto thisRoom = ChatPage::instance()->timelineManager()->rooms()->getRoomById(room_id_);
-    for (const auto &member : members)
-        m_memberList.push_back({member, thisRoom->avatarUrl(member.user_id)});
+    if (thisRoom.isNull())
+        nhlog::ui()->error("Could not load the current room");
+    else
+        for (const auto &member : members)
+            m_memberList.push_back({member, thisRoom->avatarUrl(member.user_id)});
 
     endInsertRows();
 }

--- a/src/MemberList.cpp
+++ b/src/MemberList.cpp
@@ -43,11 +43,9 @@ MemberListBackend::addUsers(const std::vector<RoomMember> &members)
     beginInsertRows(
       QModelIndex{}, m_memberList.count(), m_memberList.count() + (int)members.size() - 1);
 
+    auto thisRoom = ChatPage::instance()->timelineManager()->rooms()->getRoomById(room_id_);
     for (const auto &member : members)
-        m_memberList.push_back(
-          {member,
-           ChatPage::instance()->timelineManager()->rooms()->getRoomById(room_id_)->avatarUrl(
-             member.user_id)});
+        m_memberList.push_back({member, thisRoom->avatarUrl(member.user_id)});
 
     endInsertRows();
 }

--- a/src/MemberList.cpp
+++ b/src/MemberList.cpp
@@ -40,15 +40,17 @@ MemberListBackend::MemberListBackend(const QString &room_id, QObject *parent)
 void
 MemberListBackend::addUsers(const std::vector<RoomMember> &members)
 {
+    auto thisRoom = ChatPage::instance()->timelineManager()->rooms()->getRoomById(room_id_);
+    if (thisRoom.isNull()) {
+        nhlog::ui()->error("Could not load the current room");
+        return;
+    }
+
     beginInsertRows(
       QModelIndex{}, m_memberList.count(), m_memberList.count() + (int)members.size() - 1);
 
-    auto thisRoom = ChatPage::instance()->timelineManager()->rooms()->getRoomById(room_id_);
-    if (thisRoom.isNull())
-        nhlog::ui()->error("Could not load the current room");
-    else
-        for (const auto &member : members)
-            m_memberList.push_back({member, thisRoom->avatarUrl(member.user_id)});
+    for (const auto &member : members)
+        m_memberList.push_back({member, thisRoom->avatarUrl(member.user_id)});
 
     endInsertRows();
 }


### PR DESCRIPTION
It's Hacktoberfest time, and I'm kicking my campaign off with a fix to a crash that could occur if you opened a room separately (but had no room open in the main window) and tried to open its room members.