### PR TITLE
Fix UploadBox thumbnail size

### DIFF
--- a/resources/qml/UploadBox.qml
+++ b/resources/qml/UploadBox.qml
@@ -48,8 +48,8 @@ Page {
                     Layout.fillHeight: true
                     Layout.fillWidth: true
 
-                    sourceSize.height: height
-                    sourceSize.width: width
+                    sourceSize.height: parent.availableHeight - namefield.height
+                    sourceSize.width: parent.availableWidth
                     fillMode: Image.PreserveAspectFit
                     smooth: true
                     mipmap: true
@@ -63,6 +63,7 @@ Page {
                     source: (modelData.thumbnail != "") ? modelData.thumbnail : ("image://colorimage/:/icons/icons/ui/"+typeStr+".svg?" + Nheko.colors.buttonText)
                 }
                 MatrixTextField {
+                    id: namefield
                     Layout.fillWidth: true
                     text: modelData.filename
                     onTextEdited: modelData.filename = text


### PR DESCRIPTION
Calculate `sourceSize` according to available space.

Setting `sourceSize.height` to `height` will cause problem for rendering svg, which leads to this issue #1139.