### PR TITLE
add user search to invite dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,6 +493,8 @@ set(SRC_FILES
 	src/SingleImagePackModel.h
 	src/TrayIcon.cpp
 	src/TrayIcon.h
+	src/UserDirectoryModel.cpp
+	src/UserDirectoryModel.h
 	src/UserSettingsPage.cpp
 	src/UserSettingsPage.h
 	src/UsersModel.cpp
@@ -594,14 +596,14 @@ if(USE_BUNDLED_MTXCLIENT)
 	include(FetchContent)
 	FetchContent_Declare(
 		MatrixClient
-                GIT_REPOSITORY https://github.com/Nheko-Reborn/mtxclient.git
-                GIT_TAG        d187c63a27710fa87a44ab44d43b7cfa2023132a
+		GIT_REPOSITORY https://github.com/Nheko-Reborn/mtxclient.git
+		GIT_TAG        d187c63a27710fa87a44ab44d43b7cfa2023132a
 		)
 	set(BUILD_LIB_EXAMPLES OFF CACHE INTERNAL "")
 	set(BUILD_LIB_TESTS OFF CACHE INTERNAL "")
 	FetchContent_MakeAvailable(MatrixClient)
 else()
-	find_package(MatrixClient 0.8.1 REQUIRED)
+	find_package(MatrixClient 0.8.3 REQUIRED)
 endif()
 
 if (VOIP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -603,7 +603,7 @@ if(USE_BUNDLED_MTXCLIENT)
 	set(BUILD_LIB_TESTS OFF CACHE INTERNAL "")
 	FetchContent_MakeAvailable(MatrixClient)
 else()
-	find_package(MatrixClient 0.8.3 REQUIRED)
+	find_package(MatrixClient 0.8.1 REQUIRED)
 endif()
 
 if (VOIP)

--- a/resources/qml/Root.qml
+++ b/resources/qml/Root.qml
@@ -201,11 +201,15 @@ Pane {
         }
 
         function onOpenInviteUsersDialog(invitees) {
-            var dialog = Qt.createComponent("qrc:/qml/dialogs/InviteDialog.qml").createObject(timelineRoot, {
+            var component = Qt.createComponent("qrc:/qml/dialogs/InviteDialog.qml")
+            var dialog = component.createObject(timelineRoot, {
                 "roomId": Rooms.currentRoom.roomId,
                 "plainRoomName": Rooms.currentRoom.plainRoomName,
                 "invitees": invitees
             });
+            if (component.status != Component.Ready) {
+                console.log("Failed to create component: " + component.errorString());
+            }
             dialog.show();
             destroyOnClose(dialog);
         }

--- a/resources/qml/Root.qml
+++ b/resources/qml/Root.qml
@@ -33,6 +33,10 @@ Pane {
         id: publicRooms
     }
 
+    UserDirectoryModel {
+        id: userDirectory
+    }
+
     //Timer {
     //    onTriggered: gc()
     //    interval: 1000

--- a/resources/qml/components/UserListRow.qml
+++ b/resources/qml/components/UserListRow.qml
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2021 Nheko Contributors
 // SPDX-FileCopyrightText: 2022 Nheko Contributors
+// SPDX-FileCopyrightText: 2023 Nheko Contributors
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/resources/qml/components/UserListRow.qml
+++ b/resources/qml/components/UserListRow.qml
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2021 Nheko Contributors
+// SPDX-FileCopyrightText: 2022 Nheko Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import ".."
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.12
+import im.nheko 1.0
+
+ItemDelegate {
+    property alias bgColor: background.color
+    property alias userid: avatar.userid
+    property alias displayName: avatar.displayName
+    property string avatarUrl
+    implicitHeight: layout.implicitHeight + Nheko.paddingSmall * 2
+    background: Rectangle {id: background}
+    GridLayout {
+        id: layout
+        anchors.centerIn: parent
+        width: parent.width - Nheko.paddingSmall * 2
+        rows: 2
+        columns: 2
+        rowSpacing: Nheko.paddingSmall
+        columnSpacing: Nheko.paddingMedium
+
+        Avatar {
+            id: avatar
+            Layout.rowSpan: 2
+            Layout.preferredWidth: Nheko.avatarSize
+            Layout.preferredHeight: Nheko.avatarSize
+            Layout.alignment: Qt.AlignLeft
+            url: avatarUrl.replace("mxc://", "image://MxcImage/")
+            enabled: false
+        }
+        Label {
+            Layout.fillWidth: true
+            text: displayName
+            color: TimelineManager.userColor(userid, Nheko.colors.window)
+            font.pointSize: fontMetrics.font.pointSize
+        }
+
+        Label {
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignTop
+            text: userid
+            color: Nheko.colors.buttonText
+            font.pointSize: fontMetrics.font.pointSize * 0.9
+        }
+    }
+}

--- a/resources/qml/dialogs/InviteDialog.qml
+++ b/resources/qml/dialogs/InviteDialog.qml
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import ".."
+import "../components"
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
@@ -67,13 +68,13 @@ ApplicationWindow {
             Layout.fillWidth: true
             Layout.preferredHeight: implicitHeight
             spacing: 4
+            visible: !inviteesList.visible
             Repeater {
                 id: inviteesRepeater
                 model: invitees
                 delegate: ItemDelegate {
                     onClicked: invitees.removeUser(model.mxid)
                     id: inviteeButton
-                    visible: !inviteesList.visible
                     contentItem: Label {
                         anchors.centerIn: parent
                         id: inviteeUserid
@@ -92,7 +93,7 @@ ApplicationWindow {
         }
 
         Label {
-            text: qsTr("User to invite")
+            text: qsTr("Search user")
             Layout.fillWidth: true
             color: Nheko.colors.text
         }
@@ -145,51 +146,17 @@ ApplicationWindow {
 
         }
         RowLayout {
-            ItemDelegate {
+            UserListRow {
                 visible: inviteeEntry.isValidMxid
                 id: del3
                 Layout.preferredWidth: inviteDialogRoot.width/2
                 Layout.alignment: Qt.AlignTop
-                Layout.preferredHeight: layout3.implicitHeight + Nheko.paddingSmall * 2
-                onClicked: addInvite(inviteeEntry.text, profile? profile.displayName : "", profile? profile.avatarUrl : "")
-                background: Rectangle {
-                color: del3.hovered ? Nheko.colors.dark : inviteDialogRoot.color
-                clip: true
-                }
-                GridLayout {
-                    id: layout3
-                    anchors.centerIn: parent
-                    width: del3.width - Nheko.paddingSmall * 2
-                    rows: 2
-                    columns: 2
-                    rowSpacing: Nheko.paddingSmall
-                    columnSpacing: Nheko.paddingMedium
-
-                    Avatar {
-                        Layout.rowSpan: 2
-                        Layout.preferredWidth: Nheko.avatarSize
-                        Layout.preferredHeight: Nheko.avatarSize
-                        Layout.alignment: Qt.AlignLeft
-                        userid: inviteeEntry.text
-                        url: profile? profile.avatarUrl.replace("mxc://", "image://MxcImage/") : ""
-                        displayName: profile? profile.displayName : ""
-                        enabled: false
-                    }
-                    Label {
-                        Layout.fillWidth: true
-                        text: profile? profile.displayName : ""
-                        color: TimelineManager.userColor(inviteeEntry.text, Nheko.colors.window)
-                        font.pointSize: fontMetrics.font.pointSize
-                    }
-
-                    Label {
-                        Layout.fillWidth: true
-                        Layout.alignment: Qt.AlignTop
-                        text: inviteeEntry.text
-                        color: Nheko.colors.buttonText
-                        font.pointSize: fontMetrics.font.pointSize * 0.9
-                    }
-                }
+                Layout.preferredHeight: implicitHeight
+                displayName: profile? profile.displayName : ""
+                avatarUrl: profile? profile.avatarUrl : ""
+                userid: inviteeEntry.text
+                onClicked: addInvite(inviteeEntry.text, displayName, avatarUrl)
+                bgColor: del3.hovered ? Nheko.colors.dark : inviteDialogRoot.color
             }
             ListView {
                 visible: !inviteeEntry.isValidMxid
@@ -198,48 +165,15 @@ ApplicationWindow {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
                 clip: true
-                delegate: ItemDelegate {
+                delegate: UserListRow {
                     id: del2
                     width: ListView.view.width
-                    height: layout2.implicitHeight + Nheko.paddingSmall * 2
-                    onClicked: addInvite(model.userid, model.displayName, model.avatarUrl)
-                    background: Rectangle {
-                    color: del2.hovered ? Nheko.colors.dark : inviteDialogRoot.color
-                    }
-                    GridLayout {
-                        id: layout2
-                        anchors.centerIn: parent
-                        width: del2.width - Nheko.paddingSmall * 2
-                        rows: 2
-                        columns: 2
-                        rowSpacing: Nheko.paddingSmall
-                        columnSpacing: Nheko.paddingMedium
-
-                        Avatar {
-                            Layout.rowSpan: 2
-                            Layout.preferredWidth: Nheko.avatarSize
-                            Layout.preferredHeight: Nheko.avatarSize
-                            Layout.alignment: Qt.AlignLeft
-                            userid: model.userid
-                            url: model.avatarUrl.replace("mxc://", "image://MxcImage/")
-                            displayName: model.displayName
-                            enabled: false
-                        }
-                        Label {
-                            Layout.fillWidth: true
-                            text: model.displayName
-                            color: TimelineManager.userColor(model.userid, Nheko.colors.window)
-                            font.pointSize: fontMetrics.font.pointSize
-                        }
-
-                        Label {
-                            Layout.fillWidth: true
-                            Layout.alignment: Qt.AlignTop
-                            text: model.userid
-                            color: Nheko.colors.buttonText
-                            font.pointSize: fontMetrics.font.pointSize * 0.9
-                        }
-                    }
+                    height: implicitHeight
+                    displayName: model.displayName
+                    userid: model.userid
+                    avatarUrl: model.avatarUrl
+                    onClicked: addInvite(userid, displayName, avatarUrl)
+                    bgColor: del2.hovered ? Nheko.colors.dark : inviteDialogRoot.color
                 }
             }
             ListView {
@@ -251,57 +185,24 @@ ApplicationWindow {
                 clip: true
                 visible: inviteDialogRoot.width >= 500
 
-                delegate: ItemDelegate {
+                delegate: UserListRow {
                     id: del
-
                     hoverEnabled: true
                     width: ListView.view.width
-                    height: layout.implicitHeight + Nheko.paddingSmall * 2
+                    height: implicitHeight
                     onClicked: TimelineManager.openGlobalUserProfile(model.mxid)
-                    background: Rectangle {
-                        color: del.hovered ? Nheko.colors.dark : inviteDialogRoot.color
-                    }
-                    GridLayout {
-                        id: layout
-                        anchors.centerIn: parent
-                        width: del.width - Nheko.paddingSmall * 2
-                        rows: 2
-                        columns: 3
-                        rowSpacing: Nheko.paddingSmall
-                        columnSpacing: Nheko.paddingMedium
-
-                        Avatar {
-                            Layout.rowSpan: 2
-                            Layout.preferredWidth: Nheko.avatarSize
-                            Layout.preferredHeight: Nheko.avatarSize
-                            Layout.alignment: Qt.AlignLeft
-                            userid: model.mxid
-                            url: model.avatarUrl.replace("mxc://", "image://MxcImage/")
-                            displayName: model.displayName
-                            enabled: false
-                        }
-                        Label {
-                            Layout.fillWidth: true
-                            text: model.displayName
-                            color: TimelineManager.userColor(model.mxid, Nheko.colors.window)
-                            font.pointSize: fontMetrics.font.pointSize
-                        }
-
-                        ImageButton {
-                            Layout.rowSpan: 2
-                            id: removeButton
-                            image: ":/icons/icons/ui/dismiss.svg"
-                            onClicked: invitees.removeUser(model.mxid)
-                        }
-
-                        Label {
-                            Layout.fillWidth: true
-                            Layout.alignment: Qt.AlignTop
-                            text: model.mxid
-                            color: Nheko.colors.buttonText
-                            font.pointSize: fontMetrics.font.pointSize * 0.9
-                        }
-
+                    userid: model.mxid
+                    avatarUrl: model.avatarUrl
+                    displayName: model.displayName
+                    bgColor: del.hovered ? Nheko.colors.dark : inviteDialogRoot.color
+                    ImageButton {
+                        anchors.right: parent.right
+                        anchors.rightMargin: Nheko.paddingSmall
+                        anchors.top: parent.top
+                        anchors.topMargin: Nheko.paddingSmall
+                        id: removeButton
+                        image: ":/icons/icons/ui/dismiss.svg"
+                        onClicked: invitees.removeUser(model.mxid)
                     }
 
                     CursorShape {

--- a/resources/qml/dialogs/InviteDialog.qml
+++ b/resources/qml/dialogs/InviteDialog.qml
@@ -77,7 +77,7 @@ ApplicationWindow {
                     contentItem: Label {
                         anchors.centerIn: parent
                         id: inviteeUserid
-                        text: model.displayName
+                        text: model.displayName != "" ? model.displayName : model.userid
                         color: inviteeButton.hovered ? Nheko.colors.highlightedText: Nheko.colors.text
                         maximumLineCount: 1
                     }

--- a/resources/qml/dialogs/InviteDialog.qml
+++ b/resources/qml/dialogs/InviteDialog.qml
@@ -15,17 +15,26 @@ ApplicationWindow {
     property string roomId
     property string plainRoomName
     property InviteesModel invitees
+    property var friendsCompleter
+    property var profile
+    minimumWidth: 500
 
-    function addInvite() {
-        if (inviteeEntry.isValidMxid) {
-            invitees.addUser(inviteeEntry.text);
-            inviteeEntry.clear();
-        }
+    Component.onCompleted: {
+        friendsCompleter = TimelineManager.completerFor("user", "friends")
+    }
+
+    function addInvite(mxid) {
+        if (mxid.match("@.+?:.{3,}")) {
+            invitees.addUser(mxid);
+            if (mxid == inviteeEntry.text)
+                inviteeEntry.clear();
+        } else
+            console.log("invalid mxid: " + mxid)
     }
 
     function cleanUpAndClose() {
         if (inviteeEntry.isValidMxid)
-            addInvite();
+            addInvite(inviteeEntry.text);
 
         invitees.accept();
         close();
@@ -72,7 +81,7 @@ ApplicationWindow {
                 Layout.fillWidth: true
                 onAccepted: {
                     if (isValidMxid)
-                        addInvite();
+                        addInvite(text);
 
                 }
                 Component.onCompleted: forceActiveFocus()
@@ -82,85 +91,198 @@ ApplicationWindow {
                         cleanUpAndClose();
 
                 }
+                onTextChanged: {
+                    searchTimer.restart()
+                    if(isValidMxid) {
+                        profile = TimelineManager.getGlobalUserProfile(text);
+                    } else
+                        profile = null;
+                }
+                Timer {
+                    id: searchTimer
+
+                    interval: 350
+                    onTriggered: {
+                        userSearch.model.setSearchString(parent.text)
+                    }
+                }
             }
 
-            Button {
-                text: qsTr("Add")
-                enabled: inviteeEntry.isValidMxid
-                onClicked: addInvite()
+            CheckBox {
+                id: searchOnServer
+                text: qsTr("Search on Server")
+                checked: false
+                onClicked: userSearch.model.setSearchString(inviteeEntry.text)
             }
 
         }
-
-        ListView {
-            id: inviteesList
-
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-            model: invitees
-
-            delegate: ItemDelegate {
-                id: del
-
-                hoverEnabled: true
-                width: ListView.view.width
-                height: layout.implicitHeight + Nheko.paddingSmall * 2
-                onClicked: TimelineManager.openGlobalUserProfile(model.mxid)
+        RowLayout {
+            ItemDelegate {
+                visible: inviteeEntry.isValidMxid
+                id: del3
+                Layout.preferredWidth: inviteDialogRoot.width/2
+                Layout.alignment: Qt.AlignTop
+                Layout.preferredHeight: layout3.implicitHeight + Nheko.paddingSmall * 2
+                onClicked: addInvite(inviteeEntry.text)
                 background: Rectangle {
-                    color: del.hovered ? Nheko.colors.dark : inviteDialogRoot.color
+                color: del3.hovered ? Nheko.colors.dark : inviteDialogRoot.color
+                clip: true
                 }
-
-                RowLayout {
-                    id: layout
-
-                    spacing: Nheko.paddingMedium
+                GridLayout {
+                    id: layout3
                     anchors.centerIn: parent
-                    width: del.width - Nheko.paddingSmall * 2
+                    width: del3.width - Nheko.paddingSmall * 2
+                    rows: 2
+                    columns: 2
+                    rowSpacing: Nheko.paddingSmall
+                    columnSpacing: Nheko.paddingMedium
 
                     Avatar {
-                        width: Nheko.avatarSize
-                        height: Nheko.avatarSize
-                        userid: model.mxid
-                        url: model.avatarUrl.replace("mxc://", "image://MxcImage/")
-                        displayName: model.displayName
+                        Layout.rowSpan: 2
+                        Layout.preferredWidth: Nheko.avatarSize
+                        Layout.preferredHeight: Nheko.avatarSize
+                        Layout.alignment: Qt.AlignLeft
+                        userid: inviteeEntry.text
+                        url: profile? profile.avatarUrl.replace("mxc://", "image://MxcImage/") : ""
+                        displayName: profile? profile.displayName : ""
                         enabled: false
                     }
+                    Label {
+                        Layout.fillWidth: true
+                        text: profile? profile.displayName : ""
+                        color: TimelineManager.userColor(inviteeEntry.text, Nheko.colors.window)
+                        font.pointSize: fontMetrics.font.pointSize
+                    }
 
-                    ColumnLayout {
-                        spacing: Nheko.paddingSmall
+                    Label {
+                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignTop
+                        text: inviteeEntry.text
+                        color: Nheko.colors.buttonText
+                        font.pointSize: fontMetrics.font.pointSize * 0.9
+                    }
+                }
+            }
+            ListView {
+                visible: !inviteeEntry.isValidMxid
+                id: userSearch
+                model: searchOnServer.checked? userDirectory : friendsCompleter
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                clip: true
+                delegate: ItemDelegate {
+                    id: del2
+                    width: ListView.view.width
+                    height: layout2.implicitHeight + Nheko.paddingSmall * 2
+                    onClicked: addInvite(model.userid)
+                    background: Rectangle {
+                    color: del2.hovered ? Nheko.colors.dark : inviteDialogRoot.color
+                    }
+                    GridLayout {
+                        id: layout2
+                        anchors.centerIn: parent
+                        width: del2.width - Nheko.paddingSmall * 2
+                        rows: 2
+                        columns: 2
+                        rowSpacing: Nheko.paddingSmall
+                        columnSpacing: Nheko.paddingMedium
 
+                        Avatar {
+                            Layout.rowSpan: 2
+                            Layout.preferredWidth: Nheko.avatarSize
+                            Layout.preferredHeight: Nheko.avatarSize
+                            Layout.alignment: Qt.AlignLeft
+                            userid: model.userid
+                            url: model.avatarUrl.replace("mxc://", "image://MxcImage/")
+                            displayName: model.displayName
+                            enabled: false
+                        }
                         Label {
+                            Layout.fillWidth: true
                             text: model.displayName
-                            color: TimelineManager.userColor(model ? model.mxid : "", del.background.color)
+                            color: TimelineManager.userColor(model.userid, Nheko.colors.window)
                             font.pointSize: fontMetrics.font.pointSize
                         }
 
                         Label {
+                            Layout.fillWidth: true
+                            Layout.alignment: Qt.AlignTop
+                            text: model.userid
+                            color: Nheko.colors.buttonText
+                            font.pointSize: fontMetrics.font.pointSize * 0.9
+                        }
+                    }
+                }
+            }
+            ListView {
+                id: inviteesList
+
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                model: invitees
+                clip: true
+
+                delegate: ItemDelegate {
+                    id: del
+
+                    hoverEnabled: true
+                    width: ListView.view.width
+                    height: layout.implicitHeight + Nheko.paddingSmall * 2
+                    onClicked: TimelineManager.openGlobalUserProfile(model.mxid)
+                    background: Rectangle {
+                        color: del.hovered ? Nheko.colors.dark : inviteDialogRoot.color
+                    }
+                    GridLayout {
+                        id: layout
+                        anchors.centerIn: parent
+                        width: del.width - Nheko.paddingSmall * 2
+                        rows: 2
+                        columns: 3
+                        rowSpacing: Nheko.paddingSmall
+                        columnSpacing: Nheko.paddingMedium
+
+                        Avatar {
+                            Layout.rowSpan: 2
+                            Layout.preferredWidth: Nheko.avatarSize
+                            Layout.preferredHeight: Nheko.avatarSize
+                            Layout.alignment: Qt.AlignLeft
+                            userid: model.mxid
+                            url: model.avatarUrl.replace("mxc://", "image://MxcImage/")
+                            displayName: model.displayName
+                            enabled: false
+                        }
+                        Label {
+                            Layout.fillWidth: true
+                            text: model.displayName
+                            color: TimelineManager.userColor(model.mxid, Nheko.colors.window)
+                            font.pointSize: fontMetrics.font.pointSize
+                        }
+
+                        ImageButton {
+                            Layout.rowSpan: 2
+                            id: removeButton
+                            image: ":/icons/icons/ui/dismiss.svg"
+                            onClicked: invitees.removeUser(model.mxid)
+                        }
+
+                        Label {
+                            Layout.fillWidth: true
+                            Layout.alignment: Qt.AlignTop
                             text: model.mxid
-                            color: del.hovered ? Nheko.colors.brightText : Nheko.colors.buttonText
+                            color: Nheko.colors.buttonText
                             font.pointSize: fontMetrics.font.pointSize * 0.9
                         }
 
                     }
 
-                    Item {
-                        Layout.fillWidth: true
+                    CursorShape {
+                        anchors.fill: parent
+                        cursorShape: Qt.PointingHandCursor
                     }
 
-                    ImageButton {
-                        image: ":/icons/icons/ui/dismiss.svg"
-                        onClicked: invitees.removeUser(model.mxid)
-                    }
-
-                }
-
-                CursorShape {
-                    anchors.fill: parent
-                    cursorShape: Qt.PointingHandCursor
                 }
 
             }
-
         }
 
     }

--- a/resources/qml/dialogs/InviteDialog.qml
+++ b/resources/qml/dialogs/InviteDialog.qml
@@ -17,15 +17,16 @@ ApplicationWindow {
     property InviteesModel invitees
     property var friendsCompleter
     property var profile
-    minimumWidth: 500
+    minimumWidth: 300
 
     Component.onCompleted: {
         friendsCompleter = TimelineManager.completerFor("user", "friends")
+        width = 600
     }
 
-    function addInvite(mxid) {
+    function addInvite(mxid, displayName, avatarUrl) {
         if (mxid.match("@.+?:.{3,}")) {
-            invitees.addUser(mxid);
+            invitees.addUser(mxid, displayName, avatarUrl);
             if (mxid == inviteeEntry.text)
                 inviteeEntry.clear();
         } else
@@ -34,7 +35,7 @@ ApplicationWindow {
 
     function cleanUpAndClose() {
         if (inviteeEntry.isValidMxid)
-            addInvite(inviteeEntry.text);
+            addInvite(inviteeEntry.text, "", "");
 
         invitees.accept();
         close();
@@ -61,13 +62,40 @@ ApplicationWindow {
         anchors.fill: parent
         anchors.margins: Nheko.paddingMedium
         spacing: Nheko.paddingMedium
+        Flow {
+            layoutDirection: Qt.LeftToRight
+            Layout.fillWidth: true
+            Layout.preferredHeight: implicitHeight
+            spacing: 4
+            Repeater {
+                id: inviteesRepeater
+                model: invitees
+                delegate: ItemDelegate {
+                    onClicked: invitees.removeUser(model.mxid)
+                    id: inviteeButton
+                    visible: !inviteesList.visible
+                    contentItem: Label {
+                        anchors.centerIn: parent
+                        id: inviteeUserid
+                        text: model.displayName
+                        color: inviteeButton.hovered ? Nheko.colors.highlightedText: Nheko.colors.text
+                        maximumLineCount: 1
+                    }
+                    background: Rectangle {
+                        border.color: Nheko.colors.text
+                        color: inviteeButton.hovered ? Nheko.colors.highlight : Nheko.colors.window
+                        border.width: 1
+                        radius: inviteeButton.height / 2
+                    }
+                }
+            }
+        }
 
         Label {
-            text: qsTr("User ID to invite")
+            text: qsTr("User to invite")
             Layout.fillWidth: true
             color: Nheko.colors.text
         }
-
         RowLayout {
             spacing: Nheko.paddingMedium
 
@@ -81,7 +109,7 @@ ApplicationWindow {
                 Layout.fillWidth: true
                 onAccepted: {
                     if (isValidMxid)
-                        addInvite(text);
+                        addInvite(text, "", "");
 
                 }
                 Component.onCompleted: forceActiveFocus()
@@ -123,7 +151,7 @@ ApplicationWindow {
                 Layout.preferredWidth: inviteDialogRoot.width/2
                 Layout.alignment: Qt.AlignTop
                 Layout.preferredHeight: layout3.implicitHeight + Nheko.paddingSmall * 2
-                onClicked: addInvite(inviteeEntry.text)
+                onClicked: addInvite(inviteeEntry.text, profile? profile.displayName : "", profile? profile.avatarUrl : "")
                 background: Rectangle {
                 color: del3.hovered ? Nheko.colors.dark : inviteDialogRoot.color
                 clip: true
@@ -174,7 +202,7 @@ ApplicationWindow {
                     id: del2
                     width: ListView.view.width
                     height: layout2.implicitHeight + Nheko.paddingSmall * 2
-                    onClicked: addInvite(model.userid)
+                    onClicked: addInvite(model.userid, model.displayName, model.avatarUrl)
                     background: Rectangle {
                     color: del2.hovered ? Nheko.colors.dark : inviteDialogRoot.color
                     }
@@ -221,6 +249,7 @@ ApplicationWindow {
                 Layout.fillHeight: true
                 model: invitees
                 clip: true
+                visible: inviteDialogRoot.width >= 500
 
                 delegate: ItemDelegate {
                     id: del

--- a/resources/qml/dialogs/InviteDialog.qml
+++ b/resources/qml/dialogs/InviteDialog.qml
@@ -29,8 +29,6 @@ ApplicationWindow {
     function addInvite(mxid, displayName, avatarUrl) {
         if (mxid.match("@.+?:.{3,}")) {
             invitees.addUser(mxid, displayName, avatarUrl);
-            if (mxid == inviteeEntry.text)
-                inviteeEntry.clear();
         } else
             console.log("invalid mxid: " + mxid)
     }
@@ -110,9 +108,14 @@ ApplicationWindow {
                 placeholderText: qsTr("@joe:matrix.org", "Example user id. The name 'joe' can be localized however you want.")
                 Layout.fillWidth: true
                 onAccepted: {
-                    if (isValidMxid)
+                    if (isValidMxid) {
                         addInvite(text, "", "");
-
+                        clear()
+                    }
+                    else if (userSearch.count > 0) {
+                        addInvite(userSearch.itemAtIndex(0).userid, userSearch.itemAtIndex(0).displayName, userSearch.itemAtIndex(0).avatarUrl)
+                        clear()
+                    }
                 }
                 Component.onCompleted: forceActiveFocus()
                 Keys.onShortcutOverride: event.accepted = ((event.key === Qt.Key_Return || event.key === Qt.Key_Enter) && (event.modifiers & Qt.ControlModifier))
@@ -181,6 +184,7 @@ ApplicationWindow {
             }
             Rectangle {
                 Layout.fillHeight: true
+                visible: inviteesList.visible
                 width: 1
                 color: Nheko.theme.separator
             }

--- a/resources/qml/dialogs/InviteDialog.qml
+++ b/resources/qml/dialogs/InviteDialog.qml
@@ -138,11 +138,13 @@ ApplicationWindow {
                 }
             }
 
-            CheckBox {
+            ToggleButton {
                 id: searchOnServer
-                text: qsTr("Search on Server")
                 checked: false
                 onClicked: userSearch.model.setSearchString(inviteeEntry.text)
+            }
+            MatrixText {
+                text: qsTr("Search on Server")
             }
 
         }

--- a/resources/qml/dialogs/InviteDialog.qml
+++ b/resources/qml/dialogs/InviteDialog.qml
@@ -179,6 +179,11 @@ ApplicationWindow {
                     bgColor: del2.hovered ? Nheko.colors.dark : inviteDialogRoot.color
                 }
             }
+            Rectangle {
+                Layout.fillHeight: true
+                width: 1
+                color: Nheko.theme.separator
+            }
             ListView {
                 id: inviteesList
 

--- a/resources/res.qrc
+++ b/resources/res.qrc
@@ -132,6 +132,7 @@
         <file>qml/components/ReorderableListview.qml</file>
         <file>qml/components/SpaceMenuLevel.qml</file>
         <file>qml/components/TextButton.qml</file>
+        <file>qml/components/UserListRow.qml</file>
         <file>qml/delegates/Encrypted.qml</file>
         <file>qml/delegates/FileMessage.qml</file>
         <file>qml/delegates/ImageMessage.qml</file>

--- a/src/InviteesModel.cpp
+++ b/src/InviteesModel.cpp
@@ -91,7 +91,7 @@ Invitee::Invitee(QString mxid, QString displayName, QString avatarUrl, QObject *
 {
     // checking for empty avatarUrl will cause profiles that don't have an avatar
     // to needlessly be loaded. Can we make sure we either provide both or none?
-    if (displayName == "") {
+    if (displayName == "" && avatarUrl == "") {
         http::client()->get_profile(
           mxid_.toStdString(),
           [this](const mtx::responses::Profile &res, mtx::http::RequestErr err) {

--- a/src/InviteesModel.cpp
+++ b/src/InviteesModel.cpp
@@ -89,7 +89,7 @@ Invitee::Invitee(QString mxid, QString displayName, QString avatarUrl, QObject *
   : QObject{parent}
   , mxid_{std::move(mxid)}
 {
-    // checking for empty avatarUrl will cause profiles to be loaded that don't have an avatar
+    // checking for empty avatarUrl will cause profiles that don't have an avatar
     // to needlessly be loaded. Can we make sure we either provide both or none?
     if (displayName == "") {
         http::client()->get_profile(

--- a/src/InviteesModel.cpp
+++ b/src/InviteesModel.cpp
@@ -88,7 +88,9 @@ Invitee::Invitee(QString mxid, QString displayName, QString avatarUrl, QObject *
   : QObject{parent}
   , mxid_{std::move(mxid)}
 {
-    if (displayName == "" || avatarUrl == "") {
+    // checking for empty avatarUrl will cause profiles to be loaded that don't have an avatar
+    // to needlessly be loaded. Can we make sure we either provide both or none?
+    if (displayName == "") {
         http::client()->get_profile(
           mxid_.toStdString(),
           [this](const mtx::responses::Profile &res, mtx::http::RequestErr err) {

--- a/src/InviteesModel.h
+++ b/src/InviteesModel.h
@@ -14,7 +14,10 @@ class Invitee final : public QObject
     Q_OBJECT
 
 public:
-    Invitee(QString mxid, QObject *parent = nullptr);
+    Invitee(QString mxid,
+            QString displayName = "",
+            QString avatarUrl   = "",
+            QObject *parent     = nullptr);
 
 signals:
     void userInfoLoaded();
@@ -43,7 +46,7 @@ public:
 
     InviteesModel(QObject *parent = nullptr);
 
-    Q_INVOKABLE void addUser(QString mxid);
+    Q_INVOKABLE void addUser(QString mxid, QString displayName = "", QString avatarUrl = "");
     Q_INVOKABLE void removeUser(QString mxid);
 
     [[nodiscard]] QHash<int, QByteArray> roleNames() const override;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -37,6 +37,7 @@
 #include "RoomsModel.h"
 #include "SingleImagePackModel.h"
 #include "TrayIcon.h"
+#include "UserDirectoryModel.h"
 #include "UserSettingsPage.h"
 #include "UsersModel.h"
 #include "Utils.h"
@@ -69,6 +70,7 @@ Q_DECLARE_METATYPE(std::vector<DeviceInfo>)
 Q_DECLARE_METATYPE(std::vector<mtx::responses::PublicRoomsChunk>)
 Q_DECLARE_METATYPE(mtx::responses::PublicRoom)
 Q_DECLARE_METATYPE(mtx::responses::Profile)
+Q_DECLARE_METATYPE(mtx::responses::User)
 
 MainWindow *MainWindow::instance_ = nullptr;
 
@@ -147,6 +149,7 @@ MainWindow::registerQmlTypes()
     qRegisterMetaType<mtx::events::msg::KeyVerificationRequest>();
     qRegisterMetaType<mtx::events::msg::KeyVerificationStart>();
     qRegisterMetaType<mtx::responses::PublicRoom>();
+    qRegisterMetaType<mtx::responses::User>();
     qRegisterMetaType<mtx::responses::Profile>();
     qRegisterMetaType<CombinedImagePackModel *>();
     qRegisterMetaType<RoomSettingsAllowedRoomsModel *>();
@@ -154,7 +157,9 @@ MainWindow::registerQmlTypes()
     qRegisterMetaType<std::vector<DeviceInfo>>();
 
     qRegisterMetaType<std::vector<mtx::responses::PublicRoomsChunk>>();
+    qRegisterMetaType<std::vector<mtx::responses::User>>();
 
+    qRegisterMetaType<mtx::responses::User>();
     qmlRegisterUncreatableMetaObject(qml_mtx_events::staticMetaObject,
                                      "im.nheko",
                                      1,
@@ -184,6 +189,7 @@ MainWindow::registerQmlTypes()
     qmlRegisterType<MxcAnimatedImage>("im.nheko", 1, 0, "MxcAnimatedImage");
     qmlRegisterType<MxcMediaProxy>("im.nheko", 1, 0, "MxcMedia");
     qmlRegisterType<RoomDirectoryModel>("im.nheko", 1, 0, "RoomDirectoryModel");
+    qmlRegisterType<UserDirectoryModel>("im.nheko", 1, 0, "UserDirectoryModel");
     qmlRegisterType<LoginPage>("im.nheko", 1, 0, "Login");
     qmlRegisterType<RegisterPage>("im.nheko", 1, 0, "Registration");
     qmlRegisterType<HiddenEvents>("im.nheko", 1, 0, "HiddenEvents");

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -58,10 +58,7 @@ public:
     void showChatPage();
 
 #ifdef NHEKO_DBUS_SYS
-    bool dbusAvailable() const
-    {
-        return dbusAvailable_;
-    }
+    bool dbusAvailable() const { return dbusAvailable_; }
 #endif
 
     Q_INVOKABLE void addPerRoomWindow(const QString &room, QWindow *window);

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -57,7 +57,10 @@ public:
     void showChatPage();
 
 #ifdef NHEKO_DBUS_SYS
-    bool dbusAvailable() const { return dbusAvailable_; }
+    bool dbusAvailable() const
+    {
+        return dbusAvailable_;
+    }
 #endif
 
     Q_INVOKABLE void addPerRoomWindow(const QString &room, QWindow *window);

--- a/src/UserDirectoryModel.cpp
+++ b/src/UserDirectoryModel.cpp
@@ -34,6 +34,10 @@ UserDirectoryModel::roleNames() const
 void
 UserDirectoryModel::setSearchString(const QString &f)
 {
+    if (f == "") {
+        nhlog::ui()->debug("Rejecting empty search string");
+        return;
+    }
     userSearchString_ = f.toStdString();
     nhlog::ui()->debug("Received user directory query: {}", userSearchString_);
     beginResetModel();
@@ -89,7 +93,7 @@ void
 UserDirectoryModel::displaySearchResults(std::vector<mtx::responses::User> results)
 {
     if (results.empty()) {
-        nhlog::net()->error("mtxclient helper thread yielded empty chunk!");
+        nhlog::net()->error("mtxclient helper thread yielded no results!");
         return;
     }
     beginInsertRows(QModelIndex(), 0, static_cast<int>(results_.size()) - 1);

--- a/src/UserDirectoryModel.cpp
+++ b/src/UserDirectoryModel.cpp
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2021 Nheko Contributors
 // SPDX-FileCopyrightText: 2022 Nheko Contributors
+// SPDX-FileCopyrightText: 2023 Nheko Contributors
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/UserDirectoryModel.cpp
+++ b/src/UserDirectoryModel.cpp
@@ -77,11 +77,11 @@ UserDirectoryModel::data(const QModelIndex &index, int role) const
 void
 UserDirectoryModel::displaySearchResults(std::vector<mtx::responses::User> results)
 {
-    results_ = results;
     if (results_.empty()) {
         nhlog::net()->error("mtxclient helper thread yielded empty chunk!");
         return;
     }
     beginInsertRows(QModelIndex(), 0, static_cast<int>(results_.size()) - 1);
+    results_ = results;
     endInsertRows();
 }

--- a/src/UserDirectoryModel.cpp
+++ b/src/UserDirectoryModel.cpp
@@ -69,7 +69,7 @@ UserDirectoryModel::fetchMore(const QModelIndex &)
               emit fetchedSearchResults(res.results);
           }
       },
-      -1);
+      50);
 }
 
 QVariant

--- a/src/UserDirectoryModel.cpp
+++ b/src/UserDirectoryModel.cpp
@@ -34,15 +34,14 @@ UserDirectoryModel::roleNames() const
 void
 UserDirectoryModel::setSearchString(const QString &f)
 {
-    if (f == "") {
-        nhlog::ui()->debug("Rejecting empty search string");
-        return;
-    }
     userSearchString_ = f.toStdString();
     nhlog::ui()->debug("Received user directory query: {}", userSearchString_);
     beginResetModel();
     results_.clear();
-    canFetchMore_ = true;
+    if (userSearchString_ == "")
+        nhlog::ui()->debug("Rejecting empty search string");
+    else
+        canFetchMore_ = true;
     endResetModel();
 }
 
@@ -93,7 +92,7 @@ void
 UserDirectoryModel::displaySearchResults(std::vector<mtx::responses::User> results)
 {
     if (results.empty()) {
-        nhlog::net()->error("mtxclient helper thread yielded no results!");
+        nhlog::net()->debug("mtxclient helper thread yielded no results!");
         return;
     }
     beginInsertRows(QModelIndex(), 0, static_cast<int>(results.size()) - 1);

--- a/src/UserDirectoryModel.cpp
+++ b/src/UserDirectoryModel.cpp
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2021 Nheko Contributors
+// SPDX-FileCopyrightText: 2022 Nheko Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "UserDirectoryModel.h"
+
+#include "Cache.h"
+#include "Logging.h"
+#include "MatrixClient.h"
+#include "mtx/responses/users.hpp"
+
+UserDirectoryModel::UserDirectoryModel(QObject *parent)
+  : QAbstractListModel{parent}
+{
+    connect(this,
+            &UserDirectoryModel::fetchedSearchResults,
+            this,
+            &UserDirectoryModel::displaySearchResults,
+            Qt::QueuedConnection);
+}
+
+QHash<int, QByteArray>
+UserDirectoryModel::roleNames() const
+{
+    return {
+      {Roles::DisplayName, "displayName"},
+      {Roles::Mxid, "userid"},
+      {Roles::AvatarUrl, "avatarUrl"},
+    };
+}
+
+void
+UserDirectoryModel::setSearchString(const QString &f)
+{
+    userSearchString_ = f.toStdString();
+    nhlog::ui()->debug("Received user directory query: {}", userSearchString_);
+    beginResetModel();
+    results_.clear();
+    endResetModel();
+    searchingUsers_ = true;
+    emit searchingUsersChanged();
+    http::client()->search_user_directory(
+      userSearchString_,
+      [this](const mtx::responses::Users &res, mtx::http::RequestErr err) {
+          searchingUsers_ = false;
+          emit searchingUsersChanged();
+
+          if (err) {
+              nhlog::net()->error("Failed to retrieve users from mtxclient - {} - {} - {}",
+                                  mtx::errors::to_string(err->matrix_error.errcode),
+                                  err->matrix_error.error,
+                                  err->parse_error);
+          } else {
+              emit fetchedSearchResults(res.results);
+          }
+      },
+      -1);
+}
+
+QVariant
+UserDirectoryModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid() || index.row() >= (int)results_.size() || index.row() < 0)
+        return {};
+    switch (role) {
+    case Roles::DisplayName:
+        return QString::fromStdString(results_[index.row()].display_name);
+    case Roles::Mxid:
+        return QString::fromStdString(results_[index.row()].user_id);
+    case Roles::AvatarUrl:
+        return QString::fromStdString(results_[index.row()].avatar_url);
+    }
+    return {};
+}
+
+void
+UserDirectoryModel::displaySearchResults(std::vector<mtx::responses::User> results)
+{
+    results_ = results;
+    if (results_.empty()) {
+        nhlog::net()->error("mtxclient helper thread yielded empty chunk!");
+        return;
+    }
+    beginInsertRows(QModelIndex(), 0, static_cast<int>(results_.size()) - 1);
+    endInsertRows();
+}

--- a/src/UserDirectoryModel.cpp
+++ b/src/UserDirectoryModel.cpp
@@ -96,7 +96,7 @@ UserDirectoryModel::displaySearchResults(std::vector<mtx::responses::User> resul
         nhlog::net()->error("mtxclient helper thread yielded no results!");
         return;
     }
-    beginInsertRows(QModelIndex(), 0, static_cast<int>(results_.size()) - 1);
+    beginInsertRows(QModelIndex(), 0, static_cast<int>(results.size()) - 1);
     results_ = results;
     endInsertRows();
     canFetchMore_ = false;

--- a/src/UserDirectoryModel.h
+++ b/src/UserDirectoryModel.h
@@ -13,6 +13,17 @@
 
 #include <mtx/responses/users.hpp>
 
+class FetchUsersFromDirectoryJob final : public QObject
+{
+    Q_OBJECT
+public:
+    explicit FetchUsersFromDirectoryJob(QObject *p = nullptr)
+    : QObject(p)
+    {
+    }
+signals:
+    void fetchedSearchResults(std::vector<mtx::responses::User> results, const std::string &searchTerm);
+};
 class UserDirectoryModel : public QAbstractListModel
 {
     Q_OBJECT
@@ -48,12 +59,11 @@ private:
 
 signals:
     void searchingUsersChanged();
-    void fetchedSearchResults(std::vector<mtx::responses::User> results);
 
 public slots:
     void setSearchString(const QString &f);
     bool searchingUsers() const { return searchingUsers_; }
 
 private slots:
-    void displaySearchResults(std::vector<mtx::responses::User> results);
+    void displaySearchResults(std::vector<mtx::responses::User> results, const std::string &searchTerm);
 };

--- a/src/UserDirectoryModel.h
+++ b/src/UserDirectoryModel.h
@@ -37,11 +37,14 @@ public:
         (void)parent;
         return static_cast<int>(results_.size());
     }
+    bool canFetchMore(const QModelIndex &) const override { return canFetchMore_; }
+    void fetchMore(const QModelIndex &) override;
 
 private:
     std::vector<mtx::responses::User> results_;
     std::string userSearchString_;
     bool searchingUsers_{false};
+    bool canFetchMore_{true};
 
 signals:
     void searchingUsersChanged();

--- a/src/UserDirectoryModel.h
+++ b/src/UserDirectoryModel.h
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2021 Nheko Contributors
+// SPDX-FileCopyrightText: 2022 Nheko Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QAbstractListModel>
+#include <QString>
+#include <string>
+#include <vector>
+
+#include <mtx/responses/users.hpp>
+
+class UserDirectoryModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+    Q_PROPERTY(bool searchingUsers READ searchingUsers NOTIFY searchingUsersChanged)
+
+public:
+    explicit UserDirectoryModel(QObject *parent = nullptr);
+
+    enum Roles
+    {
+        DisplayName,
+        Mxid,
+        AvatarUrl,
+    };
+    QHash<int, QByteArray> roleNames() const override;
+
+    QVariant data(const QModelIndex &index, int role) const override;
+
+    inline int rowCount(const QModelIndex &parent = QModelIndex()) const override
+    {
+        (void)parent;
+        return static_cast<int>(results_.size());
+    }
+
+private:
+    std::vector<mtx::responses::User> results_;
+    std::string userSearchString_;
+    bool searchingUsers_{false};
+
+signals:
+    void searchingUsersChanged();
+    void fetchedSearchResults(std::vector<mtx::responses::User> results);
+
+public slots:
+    void setSearchString(const QString &f);
+    bool searchingUsers() const { return searchingUsers_; }
+
+private slots:
+    void displaySearchResults(std::vector<mtx::responses::User> results);
+};

--- a/src/UserDirectoryModel.h
+++ b/src/UserDirectoryModel.h
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2021 Nheko Contributors
 // SPDX-FileCopyrightText: 2022 Nheko Contributors
+// SPDX-FileCopyrightText: 2023 Nheko Contributors
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/UserDirectoryModel.h
+++ b/src/UserDirectoryModel.h
@@ -44,7 +44,7 @@ private:
     std::vector<mtx::responses::User> results_;
     std::string userSearchString_;
     bool searchingUsers_{false};
-    bool canFetchMore_{true};
+    bool canFetchMore_{false};
 
 signals:
     void searchingUsersChanged();

--- a/src/UsersModel.h
+++ b/src/UsersModel.h
@@ -22,13 +22,13 @@ public:
     int rowCount(const QModelIndex &parent = QModelIndex()) const override
     {
         (void)parent;
-        return (int)roomMembers_.size();
+        return (int)userids.size();
     }
     QVariant data(const QModelIndex &index, int role) const override;
 
 private:
     std::string room_id;
-    std::vector<std::string> roomMembers_;
+    std::vector<QString> avatarUrls;
     std::vector<QString> displayNames;
     std::vector<QString> userids;
 };


### PR DESCRIPTION
Please have a look, it probably needs a lot of improvements. Among other things, I hijacked the UsersModel, not sure if you're happy with that. What I'm still planning to do:
- improve local search to include more, possibly all, rooms (not in this PR)
- add the search to CreateDirect.qml (not in this PR)
- add a narrow mode since it should work on mobile

Are there better ways of displaying the result for direct mxid entry? it currently needs its own code block, would be nicer if it could work with the same code, but that would require a new model or changes to the existing ones.