### PR TITLE
Pause ParticleEmitter when not in use

### DIFF
--- a/resources/qml/TimelineView.qml
+++ b/resources/qml/TimelineView.qml
@@ -347,7 +347,7 @@ Item {
 
     ParticleSystem { id: confettiParticleSystem 
         Component.onCompleted: pause();
-        paused: shouldEffectsRun
+        paused: !shouldEffectsRun
     }
 
     Emitter {
@@ -406,6 +406,14 @@ Item {
         roomid: room ? room.roomId : ""
     }
 
+    Timer {
+        id: effectsTimer
+        onTriggered: shouldEffectsRun = false;
+        interval: confettiEmitter.lifeSpan
+        repeat: false
+        running: false
+    }
+
     Connections {
         function onOpenReadReceiptsDialog(rr) {
             var dialog = readReceiptsDialog.createObject(timelineRoot, {
@@ -439,7 +447,7 @@ Item {
             if (!Settings.fancyEffects)
                 return
 
-            shouldEffectsRun = false;
+            effectsTimer.start();
         }
 
         target: room

--- a/resources/qml/TimelineView.qml
+++ b/resources/qml/TimelineView.qml
@@ -25,6 +25,7 @@ Item {
     property var room: null
     property var roomPreview: null
     property bool showBackButton: false
+    property bool shouldEffectsRun: false
     clip: true
 
     onRoomChanged: if (room != null) room.triggerSpecialEffects()
@@ -344,7 +345,10 @@ Item {
         onClicked: Rooms.resetCurrentRoom()
     }
 
-    ParticleSystem { id: confettiParticleSystem }
+    ParticleSystem { id: confettiParticleSystem 
+        Component.onCompleted: pause();
+        paused: shouldEffectsRun
+    }
 
     Emitter {
         id: confettiEmitter
@@ -356,6 +360,7 @@ Item {
         emitRate: Math.min(400 * Math.sqrt(parent.width * parent.height) / 870, 1000)
         lifeSpan: 15000
         system: confettiParticleSystem
+        maximumEmitted: 500
         velocityFromMovement: 8
         size: 16
         sizeVariation: 4
@@ -365,27 +370,27 @@ Item {
             xVariation: Math.min(4 * parent.width / 7, 450)
             yVariation: 250
         }
+    }
 
-        ImageParticle {
-            system: confettiParticleSystem
-            source: "qrc:/confettiparticle.svg"
-            rotationVelocity: 0
-            rotationVelocityVariation: 360
-            colorVariation: 1
-            color: "white"
-            entryEffect: ImageParticle.None
-            xVector: PointDirection {
-                x: 1
-                y: 0
-                xVariation: 0.2
-                yVariation: 0.2
-            }
-            yVector: PointDirection {
-                x: 0
-                y: 0.5
-                xVariation: 0.2
-                yVariation: 0.2
-            }
+    ImageParticle {
+        system: confettiParticleSystem
+        source: "qrc:/confettiparticle.svg"
+        rotationVelocity: 0
+        rotationVelocityVariation: 360
+        colorVariation: 1
+        color: "white"
+        entryEffect: ImageParticle.None
+        xVector: PointDirection {
+            x: 1
+            y: 0
+            xVariation: 0.2
+            yVariation: 0.2
+        }
+        yVector: PointDirection {
+            x: 0
+            y: 0.5
+            xVariation: 0.2
+            yVariation: 0.2
         }
     }
 
@@ -424,8 +429,17 @@ Item {
             if (!Settings.fancyEffects)
                 return
 
+            shouldEffectsRun = true;
             confettiEmitter.pulse(parent.height * 2)
             room.markSpecialEffectsDone()
+        }
+
+        function onConfettiDone()
+        {
+            if (!Settings.fancyEffects)
+                return
+
+            shouldEffectsRun = false;
         }
 
         target: room

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -1998,6 +1998,7 @@ void
 TimelineModel::markSpecialEffectsDone()
 {
     needsSpecialEffects_ = false;
+    emit confettiDone();
 }
 
 QString

--- a/src/timeline/TimelineModel.h
+++ b/src/timeline/TimelineModel.h
@@ -451,6 +451,7 @@ signals:
     void newCallEvent(const mtx::events::collections::TimelineEvents &event);
     void scrollToIndex(int index);
     void confetti();
+    void confettiDone();
 
     void lastMessageChanged();
     void notificationsChanged();


### PR DESCRIPTION
Fixes a performance issue on macOS (and possibly other systems) where CPU usage remains fairly high even when particles aren't emitting.