### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ sudo emerge -a nheko
 
 If you are using Gnome Keyring or KeepassXC as your secrets daemon, ensure that the `gnome-keyring` useflag is enabled on `dev-libs/qtkeychain`.
 
+#### Mageia (9 and above)
+```bash
+sudo urpmi nheko
+```
+
 #### Nix(os)
 
 ```bash


### PR DESCRIPTION
Add instruction to install on Mageia, as Nheko is now part of the official repo of the distribution.