### PR TITLE
Room list: add scrollbar when not collapsed

### DIFF
--- a/resources/qml/RoomList.qml
+++ b/resources/qml/RoomList.qml
@@ -51,6 +51,12 @@ Page {
         model: Rooms
         reuseItems: true
 
+        ScrollBar.vertical: ScrollBar {
+            id: roomlistscrollbar
+            active: true
+            visible: (! collapsed) && (parent.contentHeight > parent.height)
+        }
+
         ScrollHelper {
             flickable: parent
             anchors.fill: parent
@@ -249,7 +255,7 @@ Page {
             }
 
             height: avatarSize + 2 * Nheko.paddingMedium
-            width: ListView.view.width
+            width: ListView.view.width - roomlistscrollbar.width
             state: "normal"
             ToolTip.visible: hovered && collapsed
             ToolTip.delay: Nheko.tooltipDelay


### PR DESCRIPTION
It's sometimes more convenient for mouse users to use a scrollbar rather than a
mouse wheel or flicking. Add a scrollbar to the room list when it's not
collapsed.