### PR TITLE
chore: when save file, hide ImageOverlay window

### DIFF
--- a/resources/qml/dialogs/ImageOverlay.qml
+++ b/resources/qml/dialogs/ImageOverlay.qml
@@ -116,6 +116,7 @@ Window {
             //ToolTip.delay: Nheko.tooltipDelay
             //ToolTip.text: qsTr("Download")
             onClicked: {
+                imageOverlay.hide();
                 if (room) {
                     room.saveMedia(eventId);
                 } else {


### PR DESCRIPTION
On wm like sway, it will cover the whole screen, and I cannot get
the file save dialog, then the program will stay there, I must kill it,
so I think hide it is better, because after, it will be closed
