### PR TITLE
feat: hide all popup menus when press leftbutton on somewhere else

### DIFF
--- a/resources/qml/MessageView.qml
+++ b/resources/qml/MessageView.qml
@@ -25,6 +25,14 @@ Item {
 
     property string searchString: ""
 
+    // HACK: https://bugreports.qt.io/browse/QTBUG-83972, qtwayland cannot auto hide menu
+    Connections {
+        function onHideMenu() {
+            messageContextMenu.close()
+        }
+        target: MainWindow
+    }
+
     ScrollBar {
         id: scrollbar
         parent: chat.parent

--- a/resources/qml/RoomList.qml
+++ b/resources/qml/RoomList.qml
@@ -20,6 +20,15 @@ Page {
     property int avatarSize: Math.ceil(fontMetrics.lineSpacing * 2.3)
     property bool collapsed: false
 
+    // HACK: https://bugreports.qt.io/browse/QTBUG-83972, qtwayland cannot auto hide menu
+    Connections {
+        function onHideMenu() {
+            userInfoMenu.close()
+            roomContextMenu.close()
+        }
+        target: MainWindow
+    }
+
     Component {
         id: roomDirectoryComponent
 

--- a/resources/qml/TopBar.qml
+++ b/resources/qml/TopBar.qml
@@ -30,6 +30,14 @@ Pane {
 
     property string searchString: ""
 
+    // HACK: https://bugreports.qt.io/browse/QTBUG-83972, qtwayland cannot auto hide menu
+    Connections {
+        function onHideMenu() {
+            roomOptionsMenu.close()
+        }
+        target: MainWindow
+    }
+
     onRoomIdChanged: {
         searchString = "";
         searchButton.searchActive = false;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -359,6 +359,16 @@ MainWindow::event(QEvent *event)
     return QQuickView::event(event);
 }
 
+// HACK: https://bugreports.qt.io/browse/QTBUG-83972, qtwayland cannot auto hide menu
+void
+MainWindow::mousePressEvent(QMouseEvent *event)
+{
+    if (event->button() == Qt::LeftButton) {
+        emit hideMenu();
+    }
+    return QQuickView::mousePressEvent(event);
+}
+
 void
 MainWindow::restoreWindowSize()
 {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -365,9 +365,7 @@ MainWindow::mousePressEvent(QMouseEvent *event)
 {
 #if defined(Q_OS_LINUX)
     if (QGuiApplication::platformName() == "wayland") {
-        if (event->button() == Qt::LeftButton) {
-            emit hideMenu();
-        }
+        emit hideMenu();
     }
 #endif
     return QQuickView::mousePressEvent(event);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -363,9 +363,13 @@ MainWindow::event(QEvent *event)
 void
 MainWindow::mousePressEvent(QMouseEvent *event)
 {
-    if (event->button() == Qt::LeftButton) {
-        emit hideMenu();
+#if defined(Q_OS_LINUX)
+    if (QGuiApplication::platformName() == "wayland") {
+        if (event->button() == Qt::LeftButton) {
+            emit hideMenu();
+        }
     }
+#endif
     return QQuickView::mousePressEvent(event);
 }
 

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -69,6 +69,8 @@ public:
 protected:
     void closeEvent(QCloseEvent *event);
     bool event(QEvent *event) override;
+    // HACK: https://bugreports.qt.io/browse/QTBUG-83972, qtwayland cannot auto hide menu
+    void mousePressEvent(QMouseEvent *) override;
 
 private slots:
     //! Handle interaction with the tray icon.
@@ -77,6 +79,8 @@ private slots:
     virtual void setWindowTitle(int notificationCount);
 
 signals:
+    // HACK: https://bugreports.qt.io/browse/QTBUG-83972, qtwayland cannot auto hide menu
+    void hideMenu();
     void reload();
     void secretsChanged();
 


### PR DESCRIPTION
According to the bug on https://bugreports.qt.io/browse/QTBUG-83972, The menu will always stay if not click one of the item. So I try to make a hack for it, wait qt solve it someday
