### PR TITLE
feat: also support myroomnick to change roomnick

### DIFF
--- a/man/nheko.1.adoc
+++ b/man/nheko.1.adoc
@@ -210,7 +210,7 @@ Redacts all visible messages of the specified user. You will run into rate limit
 */redact* _<eventid>_ _[reason]_::
 Redacts a specific event.
 
-*/roomnick* _<roomname>_::
+*/myroomnick*, */roomnick* _<roomname>_::
 Change your nickname in a single room.
 
 === Emoticons

--- a/src/CommandCompleter.cpp
+++ b/src/CommandCompleter.cpp
@@ -55,6 +55,8 @@ CommandCompleter::data(const QModelIndex &index, int role) const
                 return QString("/unban @");
             case Redact:
                 return QString("/redact ");
+            case MyRoomnick:
+                return QString("/myroomnick ");
             case Roomnick:
                 return QString("/roomnick ");
             case Shrug:
@@ -124,6 +126,8 @@ CommandCompleter::data(const QModelIndex &index, int role) const
                 return tr("/unban @userid [reason]");
             case Redact:
                 return tr("/redact ($eventid|@userid)");
+            case MyRoomnick:
+                return tr("/myroomnick <displayname>");
             case Roomnick:
                 return tr("/roomnick <displayname>");
             case Shrug:

--- a/src/CommandCompleter.h
+++ b/src/CommandCompleter.h
@@ -31,6 +31,7 @@ public:
         Ban,
         Unban,
         Redact,
+        MyRoomnick,
         Roomnick,
         Shrug,
         Fliptable,

--- a/src/timeline/InputBar.cpp
+++ b/src/timeline/InputBar.cpp
@@ -776,7 +776,7 @@ InputBar::command(const QString &command, QString args)
         } else if (args.startsWith('$')) {
             room->redactEvent(args.section(' ', 0, 0), args.section(' ', 1, -1));
         }
-    } else if (command == QLatin1String("roomnick")) {
+    } else if (command == QLatin1String("myroomnick") || command == QLatin1String("roomnick")) {
         mtx::events::state::Member member;
         member.display_name = args.toStdString();
         member.avatar_url =


### PR DESCRIPTION
Related: https://invent.kde.org/network/neochat/-/merge_requests/780

Currently both Element, Cinny, FluffyChat and Quaternion supports `/myroomnick` to change user's room nick, leaves NeoChat and Nheko support `/roomnick`. When we introduce new user to the Matrix world and when they asking about how to change room nick, then we will need to state two answers to cover all these mainstream clients. It could be helpful to support a common command.

I'm not sure if there is a reason behind somewhere to keep supporting `/roomnick` so I add them both instead of replace `roomnick` to `myroomnick`. Hope that's okay and feel free to let me know if that needs to be changed.