### PR TITLE
Expand room settings dialog to fit available screen space

### DIFF
--- a/resources/qml/dialogs/RoomSettings.qml
+++ b/resources/qml/dialogs/RoomSettings.qml
@@ -21,7 +21,10 @@ ApplicationWindow {
     minimumWidth: 340
     minimumHeight: 450
     width: 450
-    height: Screen.height >= contentLayout1.height + footer.height + Nheko.titlebarHeight() ? contentLayout1.height + footer.height : 680
+    height: {
+        var maxHeight = Math.min(Screen.height - 100, 900)
+        return maxHeight >= contentLayout1.height + footer.height + Nheko.titlebarHeight() ? contentLayout1.height + footer.height : maxHeight
+    }
     palette: Nheko.colors
     color: Nheko.colors.window
     modality: Qt.NonModal

--- a/resources/qml/dialogs/RoomSettings.qml
+++ b/resources/qml/dialogs/RoomSettings.qml
@@ -21,7 +21,7 @@ ApplicationWindow {
     minimumWidth: 340
     minimumHeight: 450
     width: 450
-    height: 680
+    height: Screen.height >= contentLayout1.height + footer.height + Nheko.titlebarHeight() ? contentLayout1.height + footer.height : 680
     palette: Nheko.colors
     color: Nheko.colors.window
     modality: Qt.NonModal
@@ -44,6 +44,7 @@ ApplicationWindow {
         flickableDirection: Flickable.VerticalFlick
         contentWidth: roomSettingsDialog.width
         contentHeight: contentLayout1.height
+
         ColumnLayout {
             id: contentLayout1
             width: parent.width

--- a/src/ui/NhekoGlobalObject.h
+++ b/src/ui/NhekoGlobalObject.h
@@ -6,9 +6,11 @@
 
 #pragma once
 
+#include <QApplication>
 #include <QFontDatabase>
 #include <QObject>
 #include <QPalette>
+#include <QStyle>
 #include <QWindow>
 
 #include "AliasEditModel.h"
@@ -73,6 +75,10 @@ public:
     }
     Q_INVOKABLE void setTransientParent(QWindow *window, QWindow *parentWindow) const;
     Q_INVOKABLE void setWindowRole(QWindow *win, QString newRole) const;
+    Q_INVOKABLE int titlebarHeight() const
+    {
+        return QApplication::style()->pixelMetric(QStyle::PM_TitleBarHeight);
+    }
 
 public slots:
     void updateUserProfile();


### PR DESCRIPTION
I was going to implement this fix for the user profile dialog as well, but it ended up not working very well and I decided that it would probably be fine to leave that dialog as-is for now.

Fixes #1143. Note that I did not add scrollbars as was suggested; I decided that that was (a) too complex and (b) most people normally don't have to look at device lists anyway.
