### PR TITLE
Status Message Improvements

### DIFF
--- a/resources/qml/MessageView.qml
+++ b/resources/qml/MessageView.qml
@@ -348,6 +348,7 @@ Item {
                     }
                     property int remainingWidth: chat.delegateMaxWidth - spacing - messageUserAvatar.width
                     AbstractButton {
+                        id: userNameButton
                         contentItem: ElidedLabel {
                             id: userName_
                             fullText: userName
@@ -373,12 +374,14 @@ Item {
 
                     Label {
                         id: statusMsg
+                        anchors.baseline: userNameButton.baseline
                         color: Nheko.colors.buttonText
                         text: Presence.userStatus(userId)
                         textFormat: Text.PlainText
                         elide: Text.ElideRight
                         width: userInfo.remainingWidth - userName_.width - parent.spacing
                         font.italic: true
+                        font.pointSize: fontMetrics.font.pointSize * 0.8
 
                         Connections {
                             target: Presence

--- a/resources/qml/MessageView.qml
+++ b/resources/qml/MessageView.qml
@@ -379,9 +379,16 @@ Item {
                         text: Presence.userStatus(userId)
                         textFormat: Text.PlainText
                         elide: Text.ElideRight
-                        width: userInfo.remainingWidth - userName_.width - parent.spacing
+                        width: Math.min(implicitWidth, userInfo.remainingWidth - userName_.width - parent.spacing)
                         font.italic: true
-                        font.pointSize: fontMetrics.font.pointSize * 0.8
+                        font.pointSize: Math.floor(fontMetrics.font.pointSize * 0.8)
+                        ToolTip.text: qsTr("%1's status message").arg(userName)
+                        ToolTip.visible: statusMsgHoverHandler.hovered
+                        ToolTip.delay: Nheko.tooltipDelay
+
+                        HoverHandler {
+                            id: statusMsgHoverHandler
+                        }
 
                         Connections {
                             target: Presence

--- a/resources/qml/dialogs/UserProfile.qml
+++ b/resources/qml/dialogs/UserProfile.qml
@@ -177,6 +177,21 @@ ApplicationWindow {
                 Layout.alignment: Qt.AlignHCenter
             }
 
+            MatrixText {
+                id: statusMsg
+                text: qsTr("Status: %1").arg(Presence.userStatus(profile.userid))
+                visible: Presence.userStatus(profile.userid) != ""
+                Layout.alignment: Qt.AlignHCenter
+                font.italic: true
+                font.pointSize: Math.floor(fontMetrics.font.pointSize * 0.9)
+                Connections {
+                    target: Presence
+                    function onPresenceChanged(id) {
+                        if (id == profile.userid) statusMsg.text = Presence.userStatus(profile.userid);
+                    }
+                }
+            }
+
             RowLayout {
                 visible: !profile.isGlobalUserProfile
                 Layout.alignment: Qt.AlignHCenter

--- a/resources/qml/dialogs/UserProfile.qml
+++ b/resources/qml/dialogs/UserProfile.qml
@@ -179,15 +179,22 @@ ApplicationWindow {
 
             MatrixText {
                 id: statusMsg
-                text: qsTr("Status: %1").arg(Presence.userStatus(profile.userid))
+                text: updateStatus()
                 visible: Presence.userStatus(profile.userid) != ""
                 Layout.alignment: Qt.AlignHCenter
-                font.italic: true
+                Layout.fillWidth: true
+                horizontalAlignment: TextEdit.AlignHCenter
+                Layout.leftMargin: Nheko.paddingMedium
+                Layout.rightMargin: Nheko.paddingMedium
                 font.pointSize: Math.floor(fontMetrics.font.pointSize * 0.9)
+
+                function updateStatus(){
+                    return qsTr("<i><b>Status:</b> %1</i>").arg(Presence.userStatus(profile.userid))
+                }
                 Connections {
                     target: Presence
                     function onPresenceChanged(id) {
-                        if (id == profile.userid) statusMsg.text = Presence.userStatus(profile.userid);
+                        if (id == profile.userid) statusMsg.text = statusMsg.updateStatus();
                     }
                 }
             }

--- a/resources/qml/dialogs/UserProfile.qml
+++ b/resources/qml/dialogs/UserProfile.qml
@@ -317,6 +317,8 @@ ApplicationWindow {
             ColumnLayout {
                 spacing: 0
 
+                Layout.leftMargin: Nheko.paddingMedium
+                Layout.rightMargin: Nheko.paddingMedium
                 RowLayout {
                     Text {
                         Layout.fillWidth: true

--- a/resources/qml/dialogs/UserProfile.qml
+++ b/resources/qml/dialogs/UserProfile.qml
@@ -56,7 +56,7 @@ ApplicationWindow {
             id: contentL
 
             width: devicelist.width
-            spacing: 10
+            spacing: Nheko.paddingMedium
 
             Avatar {
                 id: displayAvatar


### PR DESCRIPTION
~~Put the status in parenthesis, which is the usual presentation for a user status i.e. UserX (Away).~~

Also significantly reduce the font size as to visually indicate this is additional information and not part of the username or message text.

Add a hover text to indicate this is a status message.

Screenshots:

| Before         | After     |
|--------------|-----------|
| ![image](https://user-images.githubusercontent.com/105185/219418485-f7ad5efd-6274-4b6f-8b00-dd0bd8b752e8.png) | ![image](https://user-images.githubusercontent.com/105185/219497721-e1da6369-a0d0-401f-8a85-1cc3a43c6020.png)      |


UserProfile:

![image](https://user-images.githubusercontent.com/105185/219497338-845be874-cd1a-4dfb-9f9f-5fbec74c304e.png)
