### PR TITLE
Don't show inaccessible private rooms in spaces

### DIFF
--- a/resources/qml/TimelineView.qml
+++ b/resources/qml/TimelineView.qml
@@ -252,7 +252,7 @@ Item {
             Layout.rightMargin: Nheko.paddingLarge
 
             TextArea {
-                text: TimelineManager.escapeEmoji(preview.roomTopic)
+                text: preview.roomName != "" ? TimelineManager.escapeEmoji(preview.roomTopic) : qsTr("This room is possibly inaccessible. If this room is private, you should remove it from the child list of this space.")
                 wrapMode: TextEdit.WordWrap
                 textFormat: TextEdit.RichText
                 readOnly: true

--- a/resources/qml/TimelineView.qml
+++ b/resources/qml/TimelineView.qml
@@ -211,7 +211,7 @@ Item {
             Layout.alignment: Qt.AlignHCenter
 
             MatrixText {
-                text: preview.roomName == "" ? qsTr("No preview available") : preview.roomName
+                text: !roomPreview.isFetched ? qsTr("No preview available") : preview.roomName
                 font.pixelSize: 24
             }
 
@@ -252,7 +252,7 @@ Item {
             Layout.rightMargin: Nheko.paddingLarge
 
             TextArea {
-                text: preview.roomName != "" ? TimelineManager.escapeEmoji(preview.roomTopic) : qsTr("This room is possibly inaccessible. If this room is private, you should remove it from the child list of this space.")
+                text: roomPreview.isFetched ? TimelineManager.escapeEmoji(preview.roomTopic) : qsTr("This room is possibly inaccessible. If this room is private, you should remove it from the child list of this space.")
                 wrapMode: TextEdit.WordWrap
                 textFormat: TextEdit.RichText
                 readOnly: true

--- a/src/timeline/RoomlistModel.cpp
+++ b/src/timeline/RoomlistModel.cpp
@@ -1100,6 +1100,15 @@ FilteredRoomlistModel::filterAcceptsRow(int sourceRow, const QModelIndex &) cons
                       .toBool();
         }
 
+        // If it is a preview but it can't be fetched, it is probably an inaccessible private room.
+        // Hide it if the user isn't an admin.
+        auto index = sourceModel()->index(sourceRow, 0);
+        if (sourceModel()->data(index, RoomlistModel::IsPreview).toBool() &&
+            !sourceModel()->data(index, RoomlistModel::IsPreviewFetched).toBool() &&
+            !Permissions(filterStr).canChange(qml_mtx_events::SpaceChild)) {
+            return false;
+        }
+
         return true;
     } else {
         return true;

--- a/src/timeline/RoomlistModel.cpp
+++ b/src/timeline/RoomlistModel.cpp
@@ -222,7 +222,7 @@ RoomlistModel::data(const QModelIndex &index, int role) const
             case Roles::RoomName:
                 return tr("No preview available");
             case Roles::LastMessage:
-                return QString();
+                return tr("This room is possibly inaccessible");
             case Roles::Time:
                 return QString();
             case Roles::Timestamp:

--- a/src/timeline/RoomlistModel.cpp
+++ b/src/timeline/RoomlistModel.cpp
@@ -796,11 +796,13 @@ RoomlistModel::setCurrentRoom(const QString &roomid)
             p.roomName_         = QString::fromStdString(i->name);
             p.roomTopic_        = QString::fromStdString(i->topic);
             p.roomAvatarUrl_    = QString::fromStdString(i->avatar_url);
+            p.isFetched_        = true;
             currentRoomPreview_ = std::move(p);
             nhlog::ui()->debug("Switched to (preview): {}",
                                currentRoomPreview_->roomid_.toStdString());
         } else {
             p.roomid_           = roomid;
+            p.isFetched_        = false;
             currentRoomPreview_ = p;
             nhlog::ui()->debug("Switched to (empty): {}",
                                currentRoomPreview_->roomid_.toStdString());

--- a/src/timeline/RoomlistModel.h
+++ b/src/timeline/RoomlistModel.h
@@ -32,6 +32,7 @@ class RoomPreview
     Q_PROPERTY(QString roomAvatarUrl READ roomAvatarUrl CONSTANT)
     Q_PROPERTY(QString reason READ reason CONSTANT)
     Q_PROPERTY(bool isInvite READ isInvite CONSTANT)
+    Q_PROPERTY(bool isFetched READ isFetched CONSTANT)
 
 public:
     RoomPreview() {}
@@ -42,9 +43,10 @@ public:
     QString roomAvatarUrl() const { return roomAvatarUrl_; }
     QString reason() const { return reason_; }
     bool isInvite() const { return isInvite_; }
+    bool isFetched() const { return isFetched_; }
 
     QString roomid_, roomName_, roomAvatarUrl_, roomTopic_, reason_;
-    bool isInvite_ = false;
+    bool isInvite_ = false, isFetched_ = true;
 };
 
 class RoomlistModel final : public QAbstractListModel


### PR DESCRIPTION
In the room list of a space, all the rooms are displayed, including inaccessible private rooms, whose room name becomes "No preview available". It is pretty confusing, other clients such as Element and FluffyChat hide them. Look at FluffyChat space for example: 
![nheko_inaccessible_private_rooms_visible](https://user-images.githubusercontent.com/25854770/222958434-caddcce5-c808-4dbe-ab12-127319cddfc9.png)
In this space, there is three public rooms: "FluffyChat", "FluffyChat Translations" and "FluffyChat Deutschsprachig", and four private rooms whose is name is displayed as "No preview available" with autogenerated avatars.

I can't think of a use case where it is needed to know whether there are private rooms in spaces. My changes simply hide them. The previous example then becomes:
![nheko_inaccessible_private_rooms_invisible](https://user-images.githubusercontent.com/25854770/222958562-e8a69a11-37ec-4392-99e7-9ca8fd9066ca.png)
Only the three public rooms are displayed. "FluffyChat Deutschsprachig" is still displayed though I didn't join it, since it's a public room.

Apparently, these rooms shouldn't appear in the first place; a private room shouldn't appear in the list of children of a space (the child room should make the space its parent, but the reverse relationship shouldn't exist). These rooms will therefore still appear for admins, so that they can fix the situation.