### PR TITLE
make scroll-down button (toEndButton) focus message input

### DIFF
--- a/resources/qml/MessageView.qml
+++ b/resources/qml/MessageView.qml
@@ -821,7 +821,7 @@ Item {
         width: 0
         height: width
         radius: width/2
-        onClicked: chat.positionViewAtBeginning();
+        onClicked: function() { chat.positionViewAtBeginning(); TimelineManager.focusMessageInput(); }
         flat: true
         hoverEnabled: true
 


### PR DESCRIPTION
Clicking the scroll-down button removes focus from the message input right now. This change focuses it even if it wasn't focused before. I think that's fine.