### PR TITLE
Don't send desktop notifications for events sent while absent

### DIFF
--- a/src/notifications/ManagerLinux.cpp
+++ b/src/notifications/ManagerLinux.cpp
@@ -187,11 +187,14 @@ NotificationsManager::systemPostNotification(const QString &room_id,
     // The list of actions has always the action name and then a localized version of that
     // action. Currently we just use an empty string for that.
     // TODO(Nico): Look into what to actually put there.
-    argumentList << (QStringList(QStringLiteral("default"))
-                     << QLatin1String("") << QStringLiteral("inline-reply")
-                     << QLatin1String("")); // actions
-    argumentList << hints;                  // hints
-    argumentList << (int)-1;                // timeout in ms
+    QStringList actions;
+    actions << QStringList(QStringLiteral("default")) << QLatin1String("");
+    if (!room_id.isEmpty()) {
+        actions << QStringLiteral("inline-reply") << QLatin1String("");
+    }
+    argumentList << actions; // actions
+    argumentList << hints;   // hints
+    argumentList << (int)-1; // timeout in ms
 
     QDBusPendingCall call = dbus.asyncCallWithArgumentList(QStringLiteral("Notify"), argumentList);
     auto watcher          = new QDBusPendingCallWatcher{call, this};

--- a/src/notifications/ManagerMac.mm
+++ b/src/notifications/ManagerMac.mm
@@ -106,10 +106,18 @@ void NotificationsManager::objCxxPostNotification(
                                                                                 textInputButtonTitle:sendStr.toNSString()
                                                                                 textInputPlaceholder:placeholder.toNSString()];
 
-    UNNotificationCategory* category = [UNNotificationCategory categoryWithIdentifier:@"ReplyCategory"
-                                                                              actions:@[ replyAction ]
-                                                                    intentIdentifiers:@[]
-                                                                              options:UNNotificationCategoryOptionNone];
+    UNNotificationCategory* category;
+    if(!room_id.isEmpty()){
+        category = [UNNotificationCategory categoryWithIdentifier:@"ReplyCategory"
+                                                          actions:@[ replyAction ]
+                                                intentIdentifiers:@[]
+                                                          options:UNNotificationCategoryOptionNone];
+    }else{
+        category = [UNNotificationCategory categoryWithIdentifier:@"ReplyCategory"
+                                                          actions:@[]
+                                                intentIdentifiers:@[]
+                                                          options:UNNotificationCategoryOptionNone];
+    }
 
     NSString* title = room_name.toNSString();
     NSString* sub = subtitle.toNSString();


### PR DESCRIPTION
When Nheko is launched, it syncs its state from the homeserver and sends desktop notifications for every events sent while absent. This is undesirable: I would expect notifications to show up for messages sent while Nheko is running, not for messages sent while I was absent, the notification badge is sufficient for that. In KDE, if there are hundred messages sent while absent, it takes around one full minute for the notification swarm to pass.

These changes check the timestamp of the events sent, and sends a desktop notification only if it is more recent than the process first sync.

When the application is launched, it will send a desktop notification containing a recap of all missed events, similar to the following:
![screenshot_notifications_recap](https://user-images.githubusercontent.com/25854770/226443920-f7d46186-307d-40f5-a626-32cfffd123a4.png)
