### PR TITLE
Add width to device verification window

### DIFF
--- a/resources/qml/device-verification/DeviceVerification.qml
+++ b/resources/qml/device-verification/DeviceVerification.qml
@@ -21,6 +21,7 @@ ApplicationWindow {
     minimumHeight: stack.currentItem.implicitHeight + 2 * Nheko.paddingLarge
     height: stack.currentItem.implicitHeight + 2 * Nheko.paddingMedium
     minimumWidth: 400
+    width: 400
     flags: Qt.Dialog | Qt.WindowCloseButtonHint | Qt.WindowTitleHint
 
     background: Rectangle {


### PR DESCRIPTION
Fixes the device verification window being 0 or 1 pixels wide on some tiling window managers.