### PR TITLE
Add width to PowerLevelEditor, fixes 0/1px wide window on tiling WMs

### DIFF
--- a/resources/qml/dialogs/PowerLevelEditor.qml
+++ b/resources/qml/dialogs/PowerLevelEditor.qml
@@ -21,6 +21,7 @@ ApplicationWindow {
     minimumWidth: 300
     minimumHeight: 400
     height: 600
+    width: 300
 
     title: qsTr("Permissions in %1").arg(roomSettings.roomName);
 


### PR DESCRIPTION
Same fix as device verification window