### PR TITLE
make name and attribution in image pack settings plain text

### DIFF
--- a/resources/qml/dialogs/ImagePackSettingsDialog.qml
+++ b/resources/qml/dialogs/ImagePackSettingsDialog.qml
@@ -165,6 +165,7 @@ ApplicationWindow {
                         horizontalAlignment: TextEdit.AlignHCenter
                         Layout.alignment: Qt.AlignHCenter
                         Layout.preferredWidth: packinfoC.width - Nheko.paddingLarge * 2
+                        textFormat: TextEdit.PlainText
                     }
 
                     MatrixText {
@@ -173,6 +174,7 @@ ApplicationWindow {
                         horizontalAlignment: TextEdit.AlignHCenter
                         Layout.alignment: Qt.AlignHCenter
                         Layout.preferredWidth: packinfoC.width - Nheko.paddingLarge * 2
+                        textFormat: TextEdit.PlainText
                     }
 
                     GridLayout {


### PR DESCRIPTION
Otherwise, `<foo>` would be swallowed.