### PR TITLE
Use @user:example.com for all sample mxids

### DIFF
--- a/resources/qml/dialogs/InviteDialog.qml
+++ b/resources/qml/dialogs/InviteDialog.qml
@@ -100,7 +100,7 @@ ApplicationWindow {
                 property bool isValidMxid: text.match("@.+?:.{3,}")
 
                 backgroundColor: palette.window
-                placeholderText: qsTr("@joe:matrix.org", "Example user id. The name 'joe' can be localized however you want.")
+                placeholderText: qsTr("@user:yourserver.example.com", "Example user id. The name 'user' can be localized however you want.")
                 Layout.fillWidth: true
                 onAccepted: {
                     if (isValidMxid) {

--- a/resources/qml/pages/LoginPage.qml
+++ b/resources/qml/pages/LoginPage.qml
@@ -56,10 +56,10 @@ Item {
                 MatrixTextField {
                     id: matrixIdLabel
                     label: qsTr("Matrix ID")
-                    placeholderText: qsTr("e.g @joe:matrix.org")
+                    placeholderText: qsTr("e.g @user:yourserver.example.com")
                     onEditingFinished: login.mxid = text
 
-                    ToolTip.text: qsTr("Your login name. A mxid should start with @ followed by the user ID. After the user ID you need to include your server name after a :.\nYou can also put your homeserver address there if your server doesn't support .well-known lookup.\nExample: @user:server.my\nIf Nheko fails to discover your homeserver, it will show you a field to enter the server manually.")
+                    ToolTip.text: qsTr("Your login name. A mxid should start with @ followed by the user ID. After the user ID you need to include your server name after a :.\nYou can also put your homeserver address there if your server doesn't support .well-known lookup.\nExample: @user:yourserver.example.com\nIf Nheko fails to discover your homeserver, it will show you a field to enter the server manually.")
                     Keys.forwardTo: [pwBtn, ssoRepeater]
                 }
 
@@ -109,10 +109,10 @@ Item {
 
                 Layout.fillWidth: true
                 label: qsTr("Homeserver address")
-                placeholderText: qsTr("server.my:8787")
+                placeholderText: qsTr("yourserver.example.com:8787")
                 text: login.homeserver
                 onEditingFinished: login.homeserver = text
-                ToolTip.text: qsTr("The address that can be used to contact you homeserver's client API.\nExample: https://server.my:8787")
+                ToolTip.text: qsTr("The address that can be used to contact your homeserver's client API.\nExample: https://yourserver.example.com:8787")
                 Keys.forwardTo: [pwBtn, ssoRepeater]
             }
 

--- a/src/LoginPage.cpp
+++ b/src/LoginPage.cpp
@@ -76,13 +76,13 @@ LoginPage::onMatrixIdEntered()
     try {
         user = parse<User>(mxid_.toStdString());
     } catch (const std::exception &) {
-        mxidError_ = tr("You have entered an invalid Matrix ID  e.g @joe:matrix.org");
+        mxidError_ = tr("You have entered an invalid Matrix ID e.g. @user:yourserver.example.com");
         emit mxidErrorChanged();
         return;
     }
 
     if (user.hostname().empty() || user.localpart().empty()) {
-        mxidError_ = tr("You have entered an invalid Matrix ID  e.g @joe:matrix.org");
+        mxidError_ = tr("You have entered an invalid Matrix ID e.g. @user:yourserver.example.com");
         emit mxidErrorChanged();
         return;
     } else {
@@ -146,7 +146,7 @@ LoginPage::checkHomeserverVersion()
     try {
         User user = parse<User>(mxid_.toStdString());
     } catch (const std::exception &) {
-        mxidError_ = tr("You have entered an invalid Matrix ID  e.g @joe:matrix.org");
+        mxidError_ = tr("You have entered an invalid Matrix ID e.g. @user:yourserver.example.com");
         emit mxidErrorChanged();
         return;
     }
@@ -273,7 +273,7 @@ LoginPage::onLoginButtonClicked(LoginMethod loginMethod,
     try {
         user = parse<User>(userid.toStdString());
     } catch (const std::exception &) {
-        mxidError_ = tr("You have entered an invalid Matrix ID  e.g @joe:matrix.org");
+        mxidError_ = tr("You have entered an invalid Matrix ID e.g. @user:yourserver.example.com");
         emit mxidErrorChanged();
         return;
     }


### PR DESCRIPTION
As mentioned in #1494, the domain name server.my is already taken. Furthermore, there were multiple sample usernames used in different places. Using @user:example.com clearly conveys that this is an example user; furthermore, example.com is a [reserved site maintained by IANA](https://www.iana.org/help/example-domains) that will make it clear to any confused users that it is not a "real" website.

Closes #1494
