### PR TITLE
Show an indicator in the timeline for mods and admins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,7 @@ if(USE_BUNDLED_COEURL)
 	FetchContent_Declare(
 		coeurl
 		GIT_REPOSITORY https://nheko.im/Nheko-Reborn/coeurl.git
-		GIT_TAG        v0.3.0
+		GIT_TAG        831e2ee8e9cf08ea1ee9736cde8370f9d0312abc
 		)
 	FetchContent_MakeAvailable(coeurl)
 	set(COEURL_TARGET_NAME coeurl::coeurl)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -731,6 +731,7 @@ set(QML_SOURCES
         resources/qml/components/MainWindowDialog.qml
         resources/qml/components/NhekoTabButton.qml
         resources/qml/components/NotificationBubble.qml
+        resources/qml/components/PowerlevelIndicator.qml
         resources/qml/components/ReorderableListview.qml
         resources/qml/components/SpaceMenuLevel.qml
         resources/qml/components/TextButton.qml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -601,7 +601,7 @@ if(USE_BUNDLED_MTXCLIENT)
 	FetchContent_Declare(
 		MatrixClient
                 GIT_REPOSITORY https://github.com/Nheko-Reborn/mtxclient.git
-                GIT_TAG        0a4cc9421a97bea81a8921f3f5e040f0a34278fc
+                GIT_TAG        928ac33a0d0359464ac37716559a687fdc39f0de
 		)
 	set(BUILD_LIB_EXAMPLES OFF CACHE INTERNAL "")
 	set(BUILD_LIB_TESTS OFF CACHE INTERNAL "")

--- a/im.nheko.Nheko.yaml
+++ b/im.nheko.Nheko.yaml
@@ -214,7 +214,7 @@ modules:
     buildsystem: cmake-ninja
     name: mtxclient
     sources:
-      - commit: 0a4cc9421a97bea81a8921f3f5e040f0a34278fc
+      - commit: 928ac33a0d0359464ac37716559a687fdc39f0de
         #tag: v0.9.2
         type: git
         url: https://github.com/Nheko-Reborn/mtxclient.git

--- a/resources/qml/MessageView.qml
+++ b/resources/qml/MessageView.qml
@@ -564,14 +564,25 @@ Item {
 
                         target: room
                     }
+
                     AbstractButton {
                         id: userNameButton
+
+                        PowerlevelIndicator {
+                            id: powerlevelIndicator
+                            anchors.left: parent.left
+                            //anchors.horizontalCenter: parent.horizontalCenter
+
+                            powerlevel: userPowerlevel
+                            permissions: room ? room.permissions : null
+                            visible: isAdmin || isModerator
+                        }
 
                         ToolTip.delay: Nheko.tooltipDelay
                         ToolTip.text: userId
                         ToolTip.visible: hovered
+                        leftPadding: powerlevelIndicator.visible ? 16 : 0
                         leftInset: 0
-                        leftPadding: 0
                         rightInset: 0
                         rightPadding: 0
 
@@ -626,13 +637,6 @@ Item {
 
                             target: Presence
                         }
-                    }
-
-                    PowerlevelIndicator {
-                        Layout.alignment: Qt.AlignVCenter
-                        powerlevel: userPowerlevel
-                        permissions: room ? room.permissions : null
-                        visible: isAdmin || isModerator
                     }
                 }
             }

--- a/resources/qml/MessageView.qml
+++ b/resources/qml/MessageView.qml
@@ -100,6 +100,7 @@ Item {
             required property string url
             required property string userId
             required property string userName
+            required property int userPowerlevel
 
             ListView.delayRemove: true
             anchors.horizontalCenter: parent ? parent.horizontalCenter : undefined
@@ -119,6 +120,7 @@ Item {
                 property date timestamp: wrapper.timestamp
                 property string userId: wrapper.userId
                 property string userName: wrapper.userName
+                property int userPowerlevel: wrapper.userPowerlevel
 
                 active: previousMessageUserId !== userId || previousMessageDay !== day || previousMessageIsStateEvent !== isStateEvent
                 //asynchronous: true
@@ -624,6 +626,13 @@ Item {
 
                             target: Presence
                         }
+                    }
+
+                    PowerlevelIndicator {
+                        Layout.alignment: Qt.AlignVCenter
+                        powerlevel: userPowerlevel
+                        permissions: room ? room.permissions : null
+                        visible: isAdmin || isModerator
                     }
                 }
             }

--- a/resources/qml/Reactions.qml
+++ b/resources/qml/Reactions.qml
@@ -77,6 +77,7 @@ Flow {
                     source: modelData.key.startsWith("mxc://") ? (modelData.key.replace("mxc://", "image://MxcImage/") + "?scale") : ""
                     visible: modelData.key.startsWith("mxc://")
                     width: textMetrics.height
+                    mipmap: true
                 }
                 Rectangle {
                     id: divider

--- a/resources/qml/RoomList.qml
+++ b/resources/qml/RoomList.qml
@@ -727,6 +727,11 @@ Page {
                 }
             }
             Platform.MenuItem {
+                text: qsTr("Mark as read")
+                onTriggered: Rooms.getRoomById(roomContextMenu.roomid).markRoomAsRead()
+            }
+
+            Platform.MenuItem {
                 text: qsTr("Room settings")
 
                 onTriggered: TimelineManager.openRoomSettings(roomContextMenu.roomid)

--- a/resources/qml/components/PowerlevelIndicator.qml
+++ b/resources/qml/components/PowerlevelIndicator.qml
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Nheko Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Controls
+import im.nheko
+
+Image {
+    required property int powerlevel
+    required property var permissions
+
+    readonly property bool isAdmin: permissions ? permissions.changeLevel(MtxEvent.PowerLevels) <= powerlevel : false
+    readonly property bool isModerator: permissions ? permissions.redactLevel() <= powerlevel : false
+    readonly property bool isDefault: permissions ? permissions.defaultLevel() <= powerlevel : false
+
+    readonly property string sourceUrl: {
+        if (isAdmin)
+             return "image://colorimage/:/icons/icons/ui/ribbon_star.svg?";
+        else if (isModerator)
+            return "image://colorimage/:/icons/icons/ui/ribbon.svg?";
+        else
+            return "image://colorimage/:/icons/icons/ui/person.svg?";
+    }
+
+    sourceSize.width: 16
+    sourceSize.height: 16
+    source: sourceUrl + (ma.hovered ? palette.highlight : palette.buttonText)
+    ToolTip.visible: ma.hovered
+    ToolTip.text: {
+        if (isAdmin)
+            return qsTr("Administrator: %1").arg(powerlevel);
+        else if (isModerator)
+            return qsTr("Moderator: %1").arg(powerlevel);
+        else
+            return qsTr("User: %1").arg(powerlevel);
+    }
+
+    HoverHandler {
+        id: ma
+    }
+}

--- a/resources/qml/dialogs/RoomMembers.qml
+++ b/resources/qml/dialogs/RoomMembers.qml
@@ -4,6 +4,7 @@
 
 import ".."
 import "../ui"
+import "../components"
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
@@ -159,39 +160,9 @@ ApplicationWindow {
 
                         }
 
-                        Image {
-                            property bool isAdmin: room.permissions.changeLevel(MtxEvent.PowerLevels) <= model.powerlevel
-                            property bool isModerator: room.permissions.redactLevel() <= model.powerlevel
-                            //property bool isDefault: room.permissions.defaultLevel() <= model.powerlevel
-
-                            property string sourceUrl: {
-                                if (isAdmin)
-                                return "image://colorimage/:/icons/icons/ui/ribbon_star.svg?";
-                                else if (isModerator)
-                                return "image://colorimage/:/icons/icons/ui/ribbon.svg?";
-                                else
-                                return "image://colorimage/:/icons/icons/ui/person.svg?";
-                            }
-
-                            Layout.preferredWidth: 16
-                            Layout.preferredHeight: 16
-                            sourceSize.width: width
-                            sourceSize.height: height
-                            source: sourceUrl + (ma.hovered ? palette.highlight : palette.buttonText)
-                            ToolTip.visible: ma.hovered
-                            ToolTip.text: {
-                                if (isAdmin)
-                                return qsTr("Administrator: %1").arg(model.powerlevel);
-                                else if (isModerator)
-                                return qsTr("Moderator: %1").arg(model.powerlevel);
-                                else
-                                return qsTr("User: %1").arg(model.powerlevel);
-                            }
-
-                            HoverHandler {
-                                id: ma
-                            }
-
+                        PowerlevelIndicator {
+                            powerlevel: model.powerlevel
+                            permissions: room.permissions
                         }
 
                         EncryptionIndicator {

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -535,6 +535,7 @@ TimelineModel::roleNames() const
       {IsSender, "isSender"},
       {UserId, "userId"},
       {UserName, "userName"},
+      {UserPowerlevel, "userPowerlevel"},
       {Day, "day"},
       {Timestamp, "timestamp"},
       {Url, "url"},
@@ -597,6 +598,14 @@ TimelineModel::data(const mtx::events::collections::TimelineEvents &event, int r
         return QVariant(QString::fromStdString(acc::sender(event)));
     case UserName:
         return QVariant(displayName(QString::fromStdString(acc::sender(event))));
+    case UserPowerlevel: {
+        return static_cast<qlonglong>(mtx::events::state::PowerLevels{
+          cache::client()
+            ->getStateEvent<mtx::events::state::PowerLevels>(room_id_.toStdString())
+            .value_or(mtx::events::StateEvent<mtx::events::state::PowerLevels>{})
+            .content}
+                                        .user_level(acc::sender(event)));
+    }
 
     case Day: {
         QDateTime prevDate = origin_server_ts(event);

--- a/src/timeline/TimelineModel.cpp
+++ b/src/timeline/TimelineModel.cpp
@@ -1284,13 +1284,20 @@ TimelineModel::updateLastMessage()
 void
 TimelineModel::setCurrentIndex(int index)
 {
+    setCurrentIndex(index, false);
+}
+
+void
+TimelineModel::setCurrentIndex(int index, bool ignoreInactiveState)
+{
     auto oldIndex = idToIndex(currentId);
     currentId     = indexToId(index);
     if (index != oldIndex)
         emit currentIndexChanged(index);
 
-    if (!QGuiApplication::focusWindow() || !QGuiApplication::focusWindow()->isActive() ||
-        MainWindow::instance()->windowForRoom(roomId()) != QGuiApplication::focusWindow())
+    if (!ignoreInactiveState &&
+        (!QGuiApplication::focusWindow() || !QGuiApplication::focusWindow()->isActive() ||
+         MainWindow::instance()->windowForRoom(roomId()) != QGuiApplication::focusWindow()))
         return;
 
     if (!currentId.startsWith('m')) {
@@ -1559,6 +1566,12 @@ TimelineModel::markEventsAsRead(const std::vector<QString> &event_ids)
         }
         emit dataChanged(index(idx, 0), index(idx, 0));
     }
+}
+
+void
+TimelineModel::markRoomAsRead()
+{
+    setCurrentIndex(0, true);
 }
 
 void

--- a/src/timeline/TimelineModel.h
+++ b/src/timeline/TimelineModel.h
@@ -241,6 +241,7 @@ public:
         IsSender,
         UserId,
         UserName,
+        UserPowerlevel,
         Day,
         Timestamp,
         Url,

--- a/src/timeline/TimelineModel.h
+++ b/src/timeline/TimelineModel.h
@@ -386,9 +386,11 @@ public:
 
 public slots:
     void setCurrentIndex(int index);
+    void setCurrentIndex(int index, bool ignoreInactiveState);
     int currentIndex() const { return idToIndex(currentId); }
     void eventShown();
     void markEventsAsRead(const std::vector<QString> &event_ids);
+    void markRoomAsRead();
     void updateLastReadId(const QString &currentRoomId);
     void lastReadIdOnWindowFocus();
     void checkAfterFetch();

--- a/src/ui/NhekoGlobalObject.cpp
+++ b/src/ui/NhekoGlobalObject.cpp
@@ -153,7 +153,6 @@ Nheko::createRoom(bool space,
     if (space) {
         req.creation_content       = mtx::events::state::Create{};
         req.creation_content->type = mtx::events::state::room_type::space;
-        req.creation_content->creator.clear();
         req.creation_content->room_version.clear();
     }
 


### PR DESCRIPTION
The other day somebody suggested in #nheko:nheko.im that usernames should be colored differently if the user is a mod or admin. I decided to try implementing this instead.

I have no idea if this actually a feature we want to merge, but I'll throw it out there anyway :)
