### PR TITLE
Set AppStream id to im.nheko.Nheko.desktop

### DIFF
--- a/resources/nheko.appdata.xml.in
+++ b/resources/nheko.appdata.xml.in
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2020-2022 mujx, nheko reborn developers -->
 <component type="desktop">
-  <id>@APPID@.desktop</id>
-  <launchable type="desktop-id">im.nheko.Nheko.desktop</launchable>
+  <id>im.nheko.Nheko.desktop</id>
+  <launchable type="desktop-id">@APPID@.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
   <name>nheko</name>

--- a/resources/nheko.appdata.xml.in
+++ b/resources/nheko.appdata.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2020-2022 mujx, nheko reborn developers -->
 <component type="desktop">
-  <id>im.nheko.Nheko.desktop</id>
+  <id>im.nheko.Nheko</id>
   <launchable type="desktop-id">@APPID@.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>

--- a/resources/nheko.appdata.xml.in
+++ b/resources/nheko.appdata.xml.in
@@ -2,7 +2,7 @@
 <!-- Copyright 2020-2022 mujx, nheko reborn developers -->
 <component type="desktop">
   <id>@APPID@.desktop</id>
-  <launchable type="desktop-id">@APPID@.desktop</launchable>
+  <launchable type="desktop-id">im.nheko.Nheko.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
   <name>nheko</name>


### PR DESCRIPTION
Hi, and thanks for the great app!

This commit changes the `<id>` in the AppStream metadata to `im.nheko.Nheko.desktop` regardless of what APPID is. The purpose of the AppStream `<id>` is to be a single unique identifier for the application, so having it depend on anything is not recommended, and results in two separate entries in popular software stores. This should fix that.
 
![image](https://github.com/Nheko-Reborn/nheko/assets/48839377/201e0e8e-f8d3-4a30-9d06-9d927bd74273)
