### PR TITLE
.{gitattributes,editorconfig} take two

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4
+max_line_length = 100

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Explicitly disable EOL normalization
+* -text diff
+third_party/** linguist-vendored


### PR DESCRIPTION
This is the second attempt on https://github.com/Nheko-Reborn/nheko/pull/1583 although this time with explicit disabling of EOL normalization and thus also the committers global gitconfig.

I do still think this is a bad idea and the correct way would be enabling the normalization and marking those files that shouldn't get it as `binary` in `.gitattributes` separately, but thought I would open the PR as I had these committed and we did discuss this being the desired Nheko way on Matrix.