### PR TITLE
Trigger less QEvent::ApplicationPaletteChange

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -201,9 +201,14 @@ NhekoFixupPaletteEventFilter::eventFilter(QObject *obj, QEvent *event)
     // reason?!?
     if (event->type() == QEvent::ChildAdded &&
         obj->metaObject()->className() == QStringLiteral("QQuickRootItem")) {
+        QSet<QWindow *> newWindows;
         for (const auto window : QGuiApplication::topLevelWindows()) {
+            newWindows.insert(window);
+            if (m_postedWindows.contains(window))
+                continue;
             QGuiApplication::postEvent(window, new QEvent(QEvent::ApplicationPaletteChange));
         }
+        m_postedWindows.swap(newWindows);
     }
     return false;
 }

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -45,6 +45,9 @@ public:
     }
 
     bool eventFilter(QObject *obj, QEvent *event) override;
+
+private:
+    QSet<QWindow *> m_postedWindows;
 };
 
 class MainWindow : public QQuickView


### PR DESCRIPTION
The event seems to be very expensive on certain platform theme plugins.

Fixes #1639