### PR TITLE
Use dynamic properties for NhekoFixupPaletteEventFilter

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -201,14 +201,12 @@ NhekoFixupPaletteEventFilter::eventFilter(QObject *obj, QEvent *event)
     // reason?!?
     if (event->type() == QEvent::ChildAdded &&
         obj->metaObject()->className() == QStringLiteral("QQuickRootItem")) {
-        QSet<QWindow *> newWindows;
         for (const auto window : QGuiApplication::topLevelWindows()) {
-            newWindows.insert(window);
-            if (m_postedWindows.contains(window))
+            if (window->property("posted").isValid())
                 continue;
             QGuiApplication::postEvent(window, new QEvent(QEvent::ApplicationPaletteChange));
+            window->setProperty("posted", true);
         }
-        m_postedWindows.swap(newWindows);
     }
     return false;
 }

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -45,9 +45,6 @@ public:
     }
 
     bool eventFilter(QObject *obj, QEvent *event) override;
-
-private:
-    QSet<QWindow *> m_postedWindows;
 };
 
 class MainWindow : public QQuickView


### PR DESCRIPTION
A new window could have the same `QWindow *` value as an already free'ed window, so using a `QSet<QWindow *>` with potentially free'ed windows might not be reliable. Use dynamic properties instead.