### PR TITLE
HiDPI Fixes

### DIFF
--- a/resources/qml/Avatar.qml
+++ b/resources/qml/Avatar.qml
@@ -64,8 +64,16 @@ AbstractButton {
         } else {
             return "";
         }
-        sourceSize.height: avatar.height * Screen.devicePixelRatio
-        sourceSize.width: avatar.width * Screen.devicePixelRatio
+        sourceSize.height: if (!avatar.url.startsWith('image://MxcImage/') && avatar.url.endsWith('.svg')){
+            return avatar.height
+        } else {
+            return avatar.height * Screen.devicePixelRatio
+        }
+        sourceSize.width: if (!avatar.url.startsWith('image://MxcImage/') && avatar.url.endsWith('.svg')){
+            return avatar.width
+        } else {
+            return avatar.width * Screen.devicePixelRatio
+        }
     }
     Rectangle {
         id: onlineIndicator

--- a/resources/qml/TimelineMetadata.qml
+++ b/resources/qml/TimelineMetadata.qml
@@ -40,8 +40,8 @@ RowLayout {
         ToolTip.text: qsTr("Edited")
         ToolTip.visible: editHovered.hovered
         source: "image://colorimage/:/icons/icons/ui/edit.svg?" + ((metadata.eventId == metadata.room.edit) ? palette.highlight : palette.buttonText)
-        sourceSize.height: parent.iconSize * Screen.devicePixelRatio
-        sourceSize.width: parent.iconSize * Screen.devicePixelRatio
+        sourceSize.height: parent.iconSize
+        sourceSize.width: parent.iconSize
         visible: metadata.isEdited || metadata.eventId == metadata.room.edit
         HoverHandler {
             id: editHovered
@@ -66,8 +66,8 @@ RowLayout {
         Layout.preferredHeight: parent.iconSize
         Layout.preferredWidth: parent.iconSize
         encrypted: metadata.isEncrypted
-        sourceSize.height: parent.iconSize * Screen.devicePixelRatio
-        sourceSize.width: parent.iconSize * Screen.devicePixelRatio
+        sourceSize.height: parent.iconSize
+        sourceSize.width: parent.iconSize
         trust: metadata.trustlevel
         visible: metadata.room.isEncrypted
     }

--- a/resources/qml/TimelineSectionHeader.qml
+++ b/resources/qml/TimelineSectionHeader.qml
@@ -92,8 +92,8 @@ Column {
                 height: fontMetrics.ascent
                 width: height
 
-                sourceSize.width: fontMetrics.lineSpacing
-                sourceSize.height: fontMetrics.lineSpacing
+                sourceSize.width: width
+                sourceSize.height: height
 
                 permissions: room ? room.permissions : null
                 visible: isAdmin || isModerator

--- a/resources/qml/delegates/ImageMessage.qml
+++ b/resources/qml/delegates/ImageMessage.qml
@@ -141,8 +141,8 @@ AbstractButton {
         source: blurhash ? ("image://blurhash/" + blurhash) : ("image://colorimage/:/icons/icons/ui/image-failed.svg?" + palette.buttonText)
         asynchronous: true
         fillMode: Image.PreserveAspectFit
-        sourceSize.width: parent.width * Screen.devicePixelRatio
-        sourceSize.height: parent.height * Screen.devicePixelRatio
+        sourceSize.width: blurhash ? parent.width * Screen.devicePixelRatio : Math.min(parent.width, parent.height)
+        sourceSize.height: blurhash ? parent.height * Screen.devicePixelRatio : Math.min(parent.width, parent.height)
 
         anchors.fill: parent
     }

--- a/resources/qml/dialogs/RoomMembers.qml
+++ b/resources/qml/dialogs/RoomMembers.qml
@@ -162,6 +162,10 @@ ApplicationWindow {
                         }
 
                         PowerlevelIndicator {
+                            Layout.preferredWidth: fontMetrics.lineSpacing * 2
+                            Layout.preferredHeight: fontMetrics.lineSpacing * 2
+                            sourceSize.width: width
+                            sourceSize.height: height
                             powerlevel: model.powerlevel
                             permissions: room.permissions
                         }
@@ -169,8 +173,10 @@ ApplicationWindow {
                         EncryptionIndicator {
                             id: encryptInd
 
-                            Layout.preferredWidth: 16
-                            Layout.preferredHeight: 16
+                            Layout.preferredWidth: fontMetrics.lineSpacing * 2
+                            Layout.preferredHeight: fontMetrics.lineSpacing * 2
+                            sourceSize.width: width
+                            sourceSize.height: height
                             Layout.alignment: Qt.AlignRight
                             visible: room.isEncrypted
                             encrypted: room.isEncrypted

--- a/resources/qml/dialogs/UserProfile.qml
+++ b/resources/qml/dialogs/UserProfile.qml
@@ -232,6 +232,8 @@ ApplicationWindow {
             EncryptionIndicator {
                 Layout.preferredHeight: 32
                 Layout.preferredWidth: 32
+                sourceSize.width: width
+                sourceSize.height: height
                 encrypted: profile.userVerificationEnabled
                 trust: profile.userVerified
                 Layout.alignment: Qt.AlignHCenter
@@ -364,8 +366,8 @@ ApplicationWindow {
                             Layout.preferredHeight: 16
                             Layout.preferredWidth: 16
                             visible: profile.isSelf && verificationStatus != VerificationStatus.NOT_APPLICABLE
-                            sourceSize.height: 16 * Screen.devicePixelRatio
-                            sourceSize.width: 16 * Screen.devicePixelRatio
+                            sourceSize.height: height
+                            sourceSize.width: width
                             source: {
                                 switch (verificationStatus) {
                                     case VerificationStatus.VERIFIED:
@@ -446,6 +448,8 @@ ApplicationWindow {
                 Image {
                     Layout.preferredHeight: 16
                     Layout.preferredWidth: 16
+                    sourceSize.height: height
+                    sourceSize.width: width
                     visible: !profile.isSelf && verificationStatus != VerificationStatus.NOT_APPLICABLE
                     source: {
                         switch (verificationStatus) {

--- a/resources/qml/pages/RegisterPage.qml
+++ b/resources/qml/pages/RegisterPage.qml
@@ -112,8 +112,8 @@ Item {
                     visible: regis.usernameAvailable || regis.usernameUnavailable
                     ToolTip.visible: ma.hovered
                     ToolTip.text: qsTr("Back")
-                    sourceSize.height: height * Screen.devicePixelRatio
-                    sourceSize.width: width * Screen.devicePixelRatio
+                    sourceSize.height: height
+                    sourceSize.width: width
                     HoverHandler {
                         id: ma
                     }


### PR DESCRIPTION
Fix various downscaled icons by removing undeeded multiplications by devicePixelRatio in sourceSize.

Fix downscaled PL indicator in the timeline by using the actual preferred size as sourceSize.

Fix various blurry icons by specifying sourceSize.

Note that this PR does not change the actual design in any way, those will come as seperate PRs.