### PR TITLE
Update README.md to reflect the keyring use flag for qtkeychain

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ sudo emaint sync -r guru
 sudo emerge -a nheko
 ```
 
-If you are using Gnome Keyring or KeepassXC as your secrets daemon, ensure that the `gnome-keyring` useflag is enabled on `dev-libs/qtkeychain`.
+If you are using Gnome Keyring or KeepassXC as your secrets daemon, ensure that the `keyring` useflag is enabled on `dev-libs/qtkeychain`.
 
 #### Mageia (9 and above)
 ```bash


### PR DESCRIPTION
On gentoo:
https://packages.gentoo.org/packages/dev-libs/qtkeychain
