### PR TITLE
Fix room settings and emoji verification being cut off

### DIFF
--- a/resources/qml/device-verification/EmojiVerification.qml
+++ b/resources/qml/device-verification/EmojiVerification.qml
@@ -13,7 +13,7 @@ ColumnLayout {
     spacing: 16
 
     Label {
-        Layout.preferredWidth: 400
+        Layout.preferredWidth: scroll.availableWidth
         Layout.fillWidth: true
         wrapMode: Text.Wrap
         text: qsTr("Please verify the following emoji. You should see the same emoji on both sides. If they differ, please press 'They do not match!' to abort verification!")

--- a/resources/qml/dialogs/RoomSettingsDialog.qml
+++ b/resources/qml/dialogs/RoomSettingsDialog.qml
@@ -20,6 +20,7 @@ ApplicationWindow {
     minimumHeight: 450
     width: 450
     height: 680
+    Layout.preferredWidth: scroll.availableWidth
     color: palette.window
     modality: Qt.NonModal
     flags: Qt.Dialog | Qt.WindowCloseButtonHint | Qt.WindowTitleHint


### PR DESCRIPTION
Just creating my first PR with a small fix for the room settings being cut off. The width will now adjust to the size it needs.

Previously:
![image](https://github.com/Nheko-Reborn/nheko/assets/116094473/96885f68-3ef3-42c0-8cc7-d8ca7852eb1f)

After this fix:
![image](https://github.com/Nheko-Reborn/nheko/assets/116094473/0f48413b-2975-421f-8a7e-9043181a6438)
