### PR TITLE
refactor: replace QString constructors with QStringLiteral

### DIFF
--- a/src/FallbackAuth.cpp
+++ b/src/FallbackAuth.cpp
@@ -19,8 +19,8 @@ FallbackAuth::FallbackAuth(const QString &session, const QString &authType, QObj
 void
 FallbackAuth::openFallbackAuth()
 {
-    const auto url = QString("https://%1:%2/_matrix/client/r0/auth/%4/"
-                             "fallback/web?session=%3")
+    const auto url = QStringLiteral("https://%1:%2/_matrix/client/r0/auth/%4/"
+                                    "fallback/web?session=%3")
                        .arg(QString::fromStdString(http::client()->server()))
                        .arg(http::client()->port())
                        .arg(m_session, m_authType);

--- a/src/ReCaptcha.cpp
+++ b/src/ReCaptcha.cpp
@@ -19,8 +19,8 @@ ReCaptcha::ReCaptcha(const QString &session, const QString &context, QObject *pa
 void
 ReCaptcha::openReCaptcha()
 {
-    const auto url = QString("https://%1:%2/_matrix/client/r0/auth/m.login.recaptcha/"
-                             "fallback/web?session=%3")
+    const auto url = QStringLiteral("https://%1:%2/_matrix/client/r0/auth/m.login.recaptcha/"
+                                    "fallback/web?session=%3")
                        .arg(QString::fromStdString(http::client()->server()))
                        .arg(http::client()->port())
                        .arg(m_session);

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -1110,10 +1110,10 @@ utils::getFormattedQuoteBody(const RelatedInfo &related, const QString &html)
         }
         }
     };
-    return QString("<mx-reply><blockquote><a "
-                   "href=\"https://matrix.to/#/%1/%2\">In reply "
-                   "to</a> <a href=\"https://matrix.to/#/%3\">%4</a><br"
-                   "/>%5</blockquote></mx-reply>")
+    return QStringLiteral("<mx-reply><blockquote><a "
+                          "href=\"https://matrix.to/#/%1/%2\">In reply "
+                          "to</a> <a href=\"https://matrix.to/#/%3\">%4</a><br"
+                          "/>%5</blockquote></mx-reply>")
              .arg(related.room,
                   QString::fromStdString(related.related_event),
                   related.quoted_user,

--- a/src/timeline/InputBar.cpp
+++ b/src/timeline/InputBar.cpp
@@ -75,7 +75,7 @@ MediaUpload::thumbnailDataUrl() const
     buffer.open(QIODevice::WriteOnly);
     thumbnail_.save(&buffer, "PNG");
     QString base64 = QString::fromUtf8(byteArray.toBase64());
-    return QString("data:image/png;base64,") + base64;
+    return QStringLiteral("data:image/png;base64,") + base64;
 }
 
 bool


### PR DESCRIPTION
Replace QString constructors with ```QStringLiteral``` for better performance.