### PR TITLE
Windows screenshare/video call support, general call improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -810,6 +810,7 @@ set(QML_SOURCES
     resources/qml/voip/PlaceCall.qml
     resources/qml/voip/ScreenShare.qml
     resources/qml/voip/VideoCall.qml
+	resources/qml/voip/VideoCallD3D11.qml
     resources/qml/delegates/EncryptionEnabled.qml
     resources/qml/ui/TimelineEffects.qml
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,8 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "macos deployment target")
 option(HUNTER_ENABLED "Enable Hunter package manager" OFF)
 include("cmake/HunterGate.cmake")
 HunterGate(
-    URL "https://github.com/cpp-pm/hunter/archive/v0.25.2.tar.gz"
-    SHA1 "560c000d5b6c972d41c2caf44f24189c868cc404"
+    URL "https://github.com/cpp-pm/hunter/archive/v0.25.5.tar.gz"
+    SHA1 "a20151e4c0740ee7d0f9994476856d813cdead29"
     LOCAL
 )
 
@@ -618,6 +618,9 @@ endif()
 if(VOIP)
     include(FindPkgConfig)
     pkg_check_modules(GSTREAMER REQUIRED IMPORTED_TARGET gstreamer-sdp-1.0>=1.18 gstreamer-webrtc-1.0>=1.18 gstreamer-gl-1.0)
+    if (WIN32)
+        pkg_check_modules(GSTREAMER REQUIRED IMPORTED_TARGET gstreamer-d3d11-1.0)
+    endif()
 endif()
 
 if(X11 AND NOT WIN32 AND NOT APPLE AND NOT HAIKU)
@@ -839,6 +842,7 @@ qt_add_translations(nheko RESOURCE_PREFIX "/translations" TS_FILES
 
 if(WIN32)
     target_compile_definitions(nheko PRIVATE WIN32_LEAN_AND_MEAN)
+    target_link_libraries(nheko PRIVATE Qt6::DBus)
     if(MSVC)
         target_compile_options(nheko PUBLIC "/Zc:__cplusplus")
     endif()

--- a/resources/qml/TimelineView.qml
+++ b/resources/qml/TimelineView.qml
@@ -119,7 +119,7 @@ Item {
                         searchString: topBar.searchString
                     }
                     Loader {
-                        source: CallManager.isOnCall && CallManager.callType != Voip.VOICE ? "voip/VideoCall.qml" : ""
+                        source: CallManager.isOnCall && CallManager.callType != Voip.VOICE ? (Qt.platform.os != "windows" ? "voip/VideoCall.qml" : "voip/VideoCallD3D11.qml") : ""
 
                         onLoaded: TimelineManager.setVideoCallItem()
                     }

--- a/resources/qml/voip/ScreenShare.qml
+++ b/resources/qml/voip/ScreenShare.qml
@@ -63,7 +63,7 @@ Popup {
             }
 
             ComboBox {
-                visible: CallManager.screenShareType == Voip.X11
+                visible: CallManager.screenShareType == Voip.X11 || CallManager.screenShareType == Voip.D3D11
                 id: windowCombo
 
                 Layout.fillWidth: true

--- a/resources/qml/voip/VideoCallD3D11.qml
+++ b/resources/qml/voip/VideoCallD3D11.qml
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: Nheko Contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import org.freedesktop.gstreamer.Qt6D3D11VideoItem 1.0
+
+GstD3D11Qt6VideoItem {
+    objectName: "videoCallItem"
+}

--- a/src/voip/CallManager.cpp
+++ b/src/voip/CallManager.cpp
@@ -86,12 +86,9 @@ CallManager::CallManager(QObject *parent)
 {
 #ifdef GSTREAMER_AVAILABLE
     std::string errorMessage;
-    if (session_.havePlugins(true, true, ScreenShareType::XDP, &errorMessage)) {
-        screenShareTypes_.push_back(ScreenShareType::XDP);
-        screenShareType_ = ScreenShareType::XDP;
-    }
 
-    if (QGuiApplication::platformName() == QStringLiteral("windows")) {
+    if (QGuiApplication::platformName() == QStringLiteral("windows") &&
+        session_.havePlugins(true, true, ScreenShareType::D3D11, &errorMessage)) {
         screenShareType_ = ScreenShareType::D3D11;
         screenShareTypes_.push_back(ScreenShareType::D3D11);
     } else if (std::getenv("DISPLAY")) {
@@ -102,6 +99,12 @@ CallManager::CallManager(QObject *parent)
             if (screenShareTypes_.size() >= 2)
                 std::swap(screenShareTypes_[0], screenShareTypes_[1]);
         }
+    }
+
+    if (QGuiApplication::platformName() != QStringLiteral("windows") &&
+        session_.havePlugins(true, true, ScreenShareType::XDP, &errorMessage)) {
+        screenShareTypes_.push_back(ScreenShareType::XDP);
+        screenShareType_ = ScreenShareType::XDP;
     }
 #endif
 

--- a/src/voip/CallManager.cpp
+++ b/src/voip/CallManager.cpp
@@ -975,6 +975,15 @@ CallManager::windowList()
         if (titleLength == 0)
             continue;
 
+        if (GetWindowLong(windowHandle, GWL_EXSTYLE) & WS_EX_TOOLWINDOW)
+            continue;
+
+        TITLEBARINFO titleInfo;
+        titleInfo.cbSize = sizeof(titleInfo);
+        GetTitleBarInfo(windowHandle, &titleInfo);
+        if (titleInfo.rgstate[0] & STATE_SYSTEM_INVISIBLE)
+            continue;
+
         wchar_t *windowTitle = new wchar_t[titleLength + 1];
         GetWindowTextW(windowHandle, windowTitle, titleLength + 1);
 

--- a/src/voip/CallManager.h
+++ b/src/voip/CallManager.h
@@ -133,7 +133,11 @@ private:
     QTimer turnServerTimer_;
     QMediaPlayer player_;
     std::vector<webrtc::ScreenShareType> screenShareTypes_;
+#ifndef Q_OS_WINDOWS
     std::vector<std::pair<QString, uint32_t>> windows_;
+#else
+    std::vector<std::pair<QString, uint64_t>> windows_;
+#endif
     std::vector<std::string> rejectCallPartyIDs_;
 
     template<typename T>

--- a/src/voip/WebRTCSession.cpp
+++ b/src/voip/WebRTCSession.cpp
@@ -1390,8 +1390,7 @@ WebRTCSession::acceptAnswer(const std::string &)
 void
 WebRTCSession::acceptICECandidates(
   const std::vector<mtx::events::voip::CallCandidates::Candidate> &)
-{
-}
+{}
 
 bool
 WebRTCSession::isMicMuted() const
@@ -1407,13 +1406,11 @@ WebRTCSession::toggleMicMute()
 
 void
 WebRTCSession::toggleLocalPiP()
-{
-}
+{}
 
 void
 WebRTCSession::end()
-{
-}
+{}
 
 #endif
 

--- a/src/voip/WebRTCSession.cpp
+++ b/src/voip/WebRTCSession.cpp
@@ -331,10 +331,13 @@ GstElement *
 newVideoSinkChain(GstElement *pipe)
 {
     // use compositor for now; acceleration needs investigation
-    GstElement *queue      = gst_element_factory_make("queue", nullptr);
-    GstElement *compositor = gst_element_factory_make("d3d11compositor", "compositor");
+    GstElement *queue = gst_element_factory_make("queue", nullptr);
+
+    auto graphicsApi       = MainWindow::instance()->graphicsApi();
+    GstElement *compositor = gst_element_factory_make(
+      graphicsApi == QSGRendererInterface::OpenGL ? "compositor" : "d3d11compositor", "compositor");
     g_object_set(compositor, "background", 1, nullptr);
-    switch (MainWindow::instance()->graphicsApi()) {
+    switch (graphicsApi) {
     case QSGRendererInterface::OpenGL: {
         GstElement *glupload       = gst_element_factory_make("glupload", nullptr);
         GstElement *glcolorconvert = gst_element_factory_make("glcolorconvert", nullptr);

--- a/src/voip/WebRTCSession.cpp
+++ b/src/voip/WebRTCSession.cpp
@@ -638,18 +638,18 @@ WebRTCSession::havePlugins(bool isVideo,
     if (!initialised_ && !init(errorMessage))
         return false;
 
-    static constexpr std::initializer_list<const char *> audio_elements = {
-      "audioconvert",
-      "audioresample",
-      "autoaudiosink",
-      "capsfilter",
-      "decodebin",
-      "opusenc",
-      "queue",
-      "rtpopuspay",
-      "volume",
-      "webrtcbin",
-    };
+    static constexpr std::initializer_list<const char *> audio_elements = {"audioconvert",
+                                                                           "audioresample",
+                                                                           "autoaudiosink",
+                                                                           "capsfilter",
+                                                                           "decodebin",
+                                                                           "opusenc",
+                                                                           "queue",
+                                                                           "rtpopuspay",
+                                                                           "volume",
+                                                                           "webrtcbin",
+                                                                           "nicesrc",
+                                                                           "nicesink"};
 
     static constexpr std::initializer_list<const char *> gl_video_elements = {
       "compositor",

--- a/src/voip/WebRTCSession.cpp
+++ b/src/voip/WebRTCSession.cpp
@@ -389,6 +389,8 @@ newVideoSinkChain(GstElement *pipe)
         // to propagate context (hopefully)
         gst_element_set_state(qmld3d11sink, GST_STATE_READY);
     } break;
+    default:
+        break;
     }
 
     return queue;
@@ -756,6 +758,8 @@ WebRTCSession::havePlugins(bool isVideo,
             GstElement *qmld3d11sink = gst_element_factory_make("qml6d3d11sink", nullptr);
             gst_object_unref(qmld3d11sink);
         } break;
+        default:
+            break;
         }
     }
     return true;

--- a/src/voip/WebRTCSession.cpp
+++ b/src/voip/WebRTCSession.cpp
@@ -724,7 +724,7 @@ WebRTCSession::havePlugins(bool isVideo,
         if (haveScreensharePlugins) {
             if (QGuiApplication::platformName() == QStringLiteral("wayland")) {
                 haveScreensharePlugins = check_plugins({"waylandsink"});
-            } else if (QGuiApplication::platformName() == QStringLiteral("wayland")) {
+            } else if (QGuiApplication::platformName() == QStringLiteral("windows")) {
                 haveScreensharePlugins = check_plugins({"d3d11videosink"});
             } else {
                 haveScreensharePlugins = check_plugins({"ximagesink"});
@@ -734,7 +734,8 @@ WebRTCSession::havePlugins(bool isVideo,
             if (screenShareType == ScreenShareType::X11) {
                 haveScreensharePlugins = check_plugins({"ximagesrc"});
             } else if (screenShareType == ScreenShareType::D3D11) {
-                haveScreensharePlugins = check_plugins({"d3d11screencapturesrc"});
+                haveScreensharePlugins =
+                  check_plugins({"d3d11screencapturesrc", "d3d11download", "d3d11convert"});
             } else {
                 haveScreensharePlugins = check_plugins({"pipewiresrc"});
             }

--- a/src/voip/WebRTCSession.cpp
+++ b/src/voip/WebRTCSession.cpp
@@ -1390,7 +1390,8 @@ WebRTCSession::acceptAnswer(const std::string &)
 void
 WebRTCSession::acceptICECandidates(
   const std::vector<mtx::events::voip::CallCandidates::Candidate> &)
-{}
+{
+}
 
 bool
 WebRTCSession::isMicMuted() const
@@ -1406,11 +1407,13 @@ WebRTCSession::toggleMicMute()
 
 void
 WebRTCSession::toggleLocalPiP()
-{}
+{
+}
 
 void
 WebRTCSession::end()
-{}
+{
+}
 
 #endif
 

--- a/src/voip/WebRTCSession.h
+++ b/src/voip/WebRTCSession.h
@@ -31,7 +31,8 @@ Q_ENUM_NS(CallType)
 enum class ScreenShareType
 {
     X11,
-    XDP
+    XDP,
+    D3D11
 };
 Q_ENUM_NS(ScreenShareType)
 


### PR DESCRIPTION
Closes #641

Todo:
- [x] Working screenshare support
- [x] Working VOIP support
- [x] Formatting fixes
- [ ] Resolve pre-existing master issue causing `glcolorconvert` to fail on screenshare receipt for Linux client?
- [ ] CI GStreamer build so this can actually be rolled out to Windows users?

Also adds libnice dependencies to plugins check since webrtcbin requires them silently and the error only gets printed to gst debug log if we dont have them (friend on NixOS had this issue)

Needs:
- [ ] Code review

major credit to @redsky17 for the initial implementation