### PR TITLE
Use `XDG_ACTIVATION_TOKEN` from environment variables by default

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -259,7 +259,10 @@ main(int argc, char *argv[])
         // getting a valid activation token on wayland is a bit of a pain, it works most reliably
         // when you have an actual window, that has the focus...
         auto waylandApp = app.nativeInterface<QNativeInterface::QWaylandApplication>();
-        if (waylandApp) {
+        // When the token is set in the env, use it by default as that's what we're supposed to do
+        // But leave a env knob so users can workaround terminal emulators that leak tokens
+        if (waylandApp &&
+            (!qEnvironmentVariableIsEmpty("NHEKO_FORCE_ACTIVATION_SPLASH") || token.isEmpty())) {
             QQuickView window;
             window.setTitle("Activate main instance");
             window.setMaximumSize(QSize(100, 50));


### PR DESCRIPTION
When the `XDG_ACTIVATION_TOKEN` env is not empty, the workaround was only really needed when a user launches nheko from a terminal emulator that leaks tokens, e.g. Konsole.
However we're certainly supposed to use the token and the workaround can break things in other cases, such as in sway 1.9+ which has https://github.com/swaywm/sway/pull/7880.
As such, default to using the token from the `XDG_ACTIVATION_TOKEN` env var but leave a knob behind in case a user really needs to workaround things.