### PR TITLE
Fix LMDB link in the README since the previous one led to an error page

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ KDE has similar plugins, that can extend the supported image types even more.
 - CMake 3.15 or greater. (Lower version may work, but may break boost linking)
 - [mtxclient](https://github.com/Nheko-Reborn/mtxclient)
 - [coeurl](https://nheko.im/nheko-reborn/coeurl)
-- [LMDB](https://symas.com/lightning-memory-mapped-database/)
+- [LMDB](https://www.symas.com/lmdb)
 - [lmdb++](https://github.com/hoytech/lmdbxx) (0.9.14 too old)
 - [cmark](https://github.com/commonmark/cmark) 0.29 or greater.
 - [libolm](https://gitlab.matrix.org/matrix-org/olm)


### PR DESCRIPTION
I found out by accident that the LMDB link in the README led me to an error page. I seem to have found the working link via Google, so here's a pull request to fix it. I hope I did this change in a way that is useful.