### PR TITLE
Readme: Clarify and fill in missing information for Nix(OS) install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ nix-env -iA nixpkgs.nheko
 
 # In an ephemeral shell: (recommended if you just want to try it out without committing to a full installation)
 nix-shell -p nheko --run nheko
+# Note: The above command will both install and run Nheko.
+# To stop it from running immediately, just remove the `--run nheko` from the end.
 ```
 Alternatively, add it to your config in one of the following ways: (recommended for long-term installation)
 

--- a/README.md
+++ b/README.md
@@ -110,10 +110,36 @@ sudo urpmi nheko
 #### Nix(os)
 
 ```bash
+# Imperatively: (not recommended)
 nix-env -iA nixpkgs.nheko
-# or
+
+# In an ephemeral shell: (recommended if you just want to try it out without committing to a full installation)
 nix-shell -p nheko --run nheko
 ```
+Alternatively, add it to your config in one of the following ways: (recommended for long-term installation)
+
+**System-wide:**
+```nix
+environment.systemPackages = with pkgs; [
+    # ...
+    nheko
+    # ...
+];
+```
+**User-specific:**
+```nix
+users.users.<user>.packages = with pkgs; [
+    # ...
+    nheko
+    # ...
+];
+```
+**via `home-manager`:**
+```nix
+programs.nheko.enable = true;
+```
+
+
 
 #### Alpine Linux (and postmarketOS)
 


### PR DESCRIPTION
Installation of software via `nix-env` on NixOS is generally not recommended, and is actually mostly discouraged.

The recommended way to install software is by adding it to the system configuration. I have added all the ways this may be done.

I have also added additional clarification as to the difference between `nix-env -iA` and `nix-shell -p`, which was previously sorely lacking.