### PR TITLE
No wayland on Haiku, fixes build errors

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -250,7 +250,8 @@ main(int argc, char *argv[])
 
 #if __has_include(<QtGui/qpa/qplatformwindow_p.h>) && \
         ((QT_VERSION >= QT_VERSION_CHECK(6, 7, 0) &&  QT_CONFIG(wayland)) || \
-         (QT_VERSION < QT_VERSION_CHECK(6, 7, 0) && defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)))
+         (QT_VERSION < QT_VERSION_CHECK(6, 7, 0) && defined(Q_OS_UNIX) && !defined(Q_OS_MACOS) \
+         && !defined(Q_OS_HAIKU)))
         // getting a valid activation token on wayland is a bit of a pain, it works most reliably
         // when you have an actual window, that has the focus...
         auto waylandApp = app.nativeInterface<QNativeInterface::QWaylandApplication>();


### PR DESCRIPTION
Small change after checkout on latest release.

Partial error list:

```
[ 73%] Building CXX object CMakeFiles/nheko.dir/src/UserDirectoryModel.cpp.o
/sources/nheko-0.12.0/src/main.cpp: In function 'int main(int, char**)':
/sources/nheko-0.12.0/src/main.cpp:254:65: error: 'QWaylandApplication' is not a member of 'QNativeInterface'
  254 |         auto waylandApp = app.nativeInterface<QNativeInterface::QWaylandApplication>();
      |                                                                 ^~~~~~~~~~~~~~~~~~~
/sources/nheko-0.12.0/src/main.cpp:254:85: error: no matching function for call to 'QApplication::nativeInterface<<expression error> >()'
  254 |         auto waylandApp = app.nativeInterface<QNativeInterface::QWaylandApplication>();
      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
In file included from /boot/system/develop/headers/Qt6/QtCore/qcoreapplication.h:17,
                 from /boot/system/develop/headers/Qt6/QtWidgets/qapplication.h:8,
                 from /boot/system/develop/headers/Qt6/QtWidgets/QApplication:1,
                 from /sources/nheko-0.12.0/src/main.cpp:7:
/boot/system/develop/headers/Qt6/QtWidgets/qapplication.h:125:5: note: candidate: 'template<class NativeInterface, class TypeInfo, class BaseType, typename std::enable_if<TypeInfo::isCompatibleWith<QApplication>, bool>::type <anonymous> > NativeInterface* QApplication::nativeInterface() const'
  125 |     QT_DECLARE_NATIVE_INTERFACE_ACCESSOR(QApplication)
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/boot/system/develop/headers/Qt6/QtWidgets/qapplication.h:125:5: note:   template argument deduction/substitution failed:
/sources/nheko-0.12.0/src/main.cpp:254:85: error: template argument 1 is invalid
  254 |         auto waylandApp = app.nativeInterface<QNativeInterface::QWaylandApplication>();
      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```