### PR TITLE
Always allow sending messages by enter even with IMEs

### DIFF
--- a/resources/qml/MessageInput.qml
+++ b/resources/qml/MessageInput.qml
@@ -173,7 +173,7 @@ Rectangle {
                     } else if (event.matches(StandardKey.InsertLineSeparator)) {
                         if (popup.opened)
                             popup.close();
-                        if (Settings.invertEnterKey && (!Qt.inputMethod.visible || Qt.platform.os === "windows")) {
+                        if (Settings.invertEnterKey) {
                             room.input.send();
                             event.accepted = true;
                         }
@@ -195,7 +195,7 @@ Rectangle {
                                 return;
                             }
                         }
-                        if (!Settings.invertEnterKey && (!Qt.inputMethod.visible || Qt.platform.os === "windows")) {
+                        if (!Settings.invertEnterKey) {
                             room.input.send();
                             event.accepted = true;
                         }


### PR DESCRIPTION
Qt.inputMethod.visible is true in kwin_wayland when maliit is enabled and activated, however kwin does not actually show maliit w/o touch input [1].

Moreover, having send by enter might still be desired even for virtual keyboards.

Remove the check for virtual keyboards as suggested by @deepbluev7, people could still use Settings.invertEnterKey for newlines.

[1]: https://invent.kde.org/plasma/kwin/-/blob/v6.1.4/src/inputmethod.cpp?ref_type=tags#L185

Fixes #1474 