### PR TITLE
Do not prevent login if .well-known response is invalid

### DIFF
--- a/src/LoginPage.cpp
+++ b/src/LoginPage.cpp
@@ -115,17 +115,16 @@ LoginPage::onMatrixIdEntered()
                   }
 
                   if (!err->parse_error.empty()) {
-                      emit versionErrorCb(tr("Autodiscovery failed. Received malformed response."));
                       nhlog::net()->error("Autodiscovery failed. Received malformed response. {}",
                                           err->parse_error);
+                      checkHomeserverVersion();
                       return;
                   }
 
-                  emit versionErrorCb(tr("Autodiscovery failed. Unknown error when "
-                                         "requesting .well-known."));
                   nhlog::net()->error("Autodiscovery failed. Unknown error when "
                                       "requesting .well-known. {}",
                                       *err);
+                  checkHomeserverVersion();
                   return;
               }
 


### PR DESCRIPTION
The current code results in confusing behavior under the following circumstances:

 - Homeserver is guessed correctly from the Matrix ID

- The server returns invalid (e.g. HTTP 200 with empty body) response for .well-known data

The user will be presented with "Autodiscovery failed. Received malformed response" message even though all details are entered correctly. Login button will not work. The only workaround is to edit the home server field a few times so that homeserverChanged() and checkHomeserverVersion() would be invoked.

This is not optimal, especially because autodiscovery based on .well-known is optional. The solution is to always invoke checkHomeserverVersion() even when autodiscovery fails due to any reason.

checkHomeserverVersion() will check the home server against required Matrix API endpoints. If this fails, user will be presented with error messages instructing to check home server URL. Accordingly, allowing to continue in case of failed autodiscovery does not reduce clarity of errors presented to the user.