### PR TITLE
Fix color of emoji picker category text in dark theme (issue #1865)

### DIFF
--- a/resources/qml/emoji/StickerPicker.qml
+++ b/resources/qml/emoji/StickerPicker.qml
@@ -130,6 +130,7 @@ Menu {
                         anchors.right: parent.right
                         text: parent.section
                         font.bold: true
+			            color: palette.text
                     }
                 }
                 section.labelPositioning: ViewSection.InlineLabels | ViewSection.CurrentLabelAtStart


### PR DESCRIPTION
When using dark system theme, the category text in emoji & sticker picker is black on a dark background, making it difficult to read.

This pull request fixes issue #1865.