### PR TITLE
Fix row spacing in the command completer

### DIFF
--- a/resources/qml/Completer.qml
+++ b/resources/qml/Completer.qml
@@ -153,7 +153,7 @@ Control {
 
                     RowLayout {
                         anchors.centerIn: centerRowContent ? parent : undefined
-                        spacing: rowSpacing
+                        spacing: Nheko.paddingSmall
 
                         Avatar {
                             displayName: model.displayName
@@ -178,7 +178,7 @@ Control {
 
                     RowLayout {
                         anchors.centerIn: parent
-                        spacing: rowSpacing
+                        spacing: Nheko.paddingSmall
 
                         Label {
                             color: model.index == popup.currentIndex ? palette.highlightedText : palette.text
@@ -213,7 +213,7 @@ Control {
 
                     RowLayout {
                         anchors.centerIn: parent
-                        spacing: rowSpacing
+                        spacing: Nheko.paddingSmall
 
                         Label {
                             color: model.index == popup.currentIndex ? palette.highlightedText : palette.text
@@ -231,7 +231,7 @@ Control {
 
                     RowLayout {
                         anchors.centerIn: centerRowContent ? parent : undefined
-                        spacing: rowSpacing
+                        spacing: Nheko.paddingSmall
 
                         Avatar {
                             displayName: model.roomName
@@ -256,7 +256,7 @@ Control {
 
                     RowLayout {
                         anchors.centerIn: parent
-                        spacing: rowSpacing
+                        spacing: Nheko.paddingSmall
 
                         Avatar {
                             displayName: model.roomName


### PR DESCRIPTION
Currently no row spacing exists in the command completer. Add row spacing to make it prettier.

Before:
![Screenshot_20250312_230553](https://github.com/user-attachments/assets/419231b3-1fae-4b94-967b-925d139e0f07)

After:
![image](https://github.com/user-attachments/assets/5419e577-5bf6-407b-9ad6-cb069e3b7de4)
