### PR TITLE
Add `setTheme` to the D-Bus API

### DIFF
--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -25,6 +25,12 @@
 
 #include "config/nheko.h"
 
+QStringList themes{
+  QStringLiteral("light"),
+  QStringLiteral("dark"),
+  QStringLiteral("system"),
+};
+
 QSharedPointer<UserSettings> UserSettings::instance_;
 
 UserSettings::UserSettings()
@@ -640,7 +646,7 @@ UserSettings::setShowImage(ShowImage state)
 void
 UserSettings::setTheme(QString theme)
 {
-    if (theme == theme_)
+    if (theme == theme_ || !themes.contains(theme))
         return;
     theme_ = theme;
     save();
@@ -1182,12 +1188,7 @@ UserSettingsModel::data(const QModelIndex &index, int role) const
     } else if (role == Value) {
         switch (index.row()) {
         case Theme:
-            return QStringList{
-              QStringLiteral("light"),
-              QStringLiteral("dark"),
-              QStringLiteral("system"),
-            }
-              .indexOf(i->theme());
+            return themes.indexOf(i->theme());
         case ScaleFactor:
             return utils::scaleFactor();
         case MessageHoverHighlight:
@@ -1741,14 +1742,10 @@ UserSettingsModel::setData(const QModelIndex &index, const QVariant &value, int 
     if (role == Value) {
         switch (index.row()) {
         case Theme: {
-            if (value == 0) {
-                i->setTheme("light");
-                return true;
-            } else if (value == 1) {
-                i->setTheme("dark");
-                return true;
-            } else if (value == 2) {
-                i->setTheme("system");
+            auto idx = value.toInt();
+
+            if (idx >= 0 && idx < themes.size()) {
+                i->setTheme(themes[idx]);
                 return true;
             } else
                 return false;

--- a/src/dbus/NhekoDBusApi.cpp
+++ b/src/dbus/NhekoDBusApi.cpp
@@ -170,6 +170,14 @@ setStatusMessage(const QString &message)
         interface.call(QDBus::NoBlock, QStringLiteral("setStatusMessage"), message);
 }
 
+void
+setTheme(const QString &theme)
+{
+    if (QDBusInterface interface{QStringLiteral(NHEKO_DBUS_SERVICE_NAME), QStringLiteral("/")};
+        interface.isValid())
+        interface.call(QDBus::NoBlock, QStringLiteral("setTheme"), theme);
+}
+
 } // nheko::dbus
 
 /**

--- a/src/dbus/NhekoDBusApi.h
+++ b/src/dbus/NhekoDBusApi.h
@@ -85,6 +85,9 @@ statusMessage();
 //! Sets the user's status message (if supported by the homeserver).
 void
 setStatusMessage(const QString &message);
+//! Sets the current theme (supported values: "light", "dark" or "system")
+void
+setTheme(const QString &theme);
 
 QDBusArgument &
 operator<<(QDBusArgument &arg, const RoomInfoItem &item);

--- a/src/dbus/NhekoDBusBackend.cpp
+++ b/src/dbus/NhekoDBusBackend.cpp
@@ -11,6 +11,7 @@
 #include "Logging.h"
 #include "MainWindow.h"
 #include "MxcImageProvider.h"
+#include "UserSettingsPage.h"
 #include "timeline/RoomlistModel.h"
 #include "timeline/TimelineModel.h"
 
@@ -110,6 +111,12 @@ void
 NhekoDBusBackend::setStatusMessage(const QString &message)
 {
     ChatPage::instance()->setStatus(message);
+}
+
+void
+NhekoDBusBackend::setTheme(const QString &theme)
+{
+    UserSettings::instance()->setTheme(theme);
 }
 
 void

--- a/src/dbus/NhekoDBusBackend.h
+++ b/src/dbus/NhekoDBusBackend.h
@@ -40,6 +40,8 @@ public slots:
     Q_SCRIPTABLE QString statusMessage() const;
     //! Sets the user's status message.
     Q_SCRIPTABLE void setStatusMessage(const QString &message);
+    //! Sets the current theme (supported values: "light", "dark" or "system")
+    Q_SCRIPTABLE void setTheme(const QString &theme);
 
 private:
     void bringWindowToTop() const;


### PR DESCRIPTION
Best to be reviewed commit-wise. To prevent people from sending invalid theme value over the API, the first commit extracts the list of valid theme values into one place. This list is then used to validate the values to set. The second commit implements the new `setTheme` D-Bus API to set the theme value.