### PR TITLE
Fix binding loop warnings in UserSettingsPage

### DIFF
--- a/resources/qml/pages/UserSettingsPage.qml
+++ b/resources/qml/pages/UserSettingsPage.qml
@@ -89,7 +89,7 @@ Rectangle {
                             roleValue: UserSettingsModel.Toggle
                             ToggleButton {
                                 checked: model.value
-                                onCheckedChanged: model.value = checked
+                                onClicked: model.value = checked
                                 enabled: model.enabled
                             }
                         }
@@ -100,7 +100,7 @@ Rectangle {
                                 model: r.model.values
                                 currentIndex: r.model.value
                                 width: Math.min(implicitWidth, scroll.availableWidth - Nheko.paddingMedium)
-                                onCurrentIndexChanged: r.model.value = currentIndex
+                                onActivated: r.model.value = currentIndex
                                 implicitContentWidthPolicy: ComboBox.WidestTextWhenCompleted
 
                                 WheelHandler{} // suppress scrolling changing values
@@ -135,7 +135,7 @@ Rectangle {
                                 to: model.valueUpperBound * div
                                 stepSize: model.valueStep * div
                                 value: model.value * div
-                                onValueChanged: model.value = value/div
+                                onValueModified: model.value = value/div
                                 editable: true
 
                                 property real realValue: value / div


### PR DESCRIPTION
When opening UserSettingsPage, the following warnings appear:
```
[2025-08-20 22:52:59.752] [qml] [warning] qrc:/resources/qml/pages/UserSettingsPage.qml:98:29: QML ComboBox: Binding loop detected for property "currentIndex":
qrc:/resources/qml/pages/UserSettingsPage.qml:101:33 (qrc:/resources/qml/pages/UserSettingsPage.qml:98, )
[2025-08-20 22:52:59.758] [qml] [warning] qrc:/resources/qml/pages/UserSettingsPage.qml:90:29: QML ToggleButton: Binding loop detected for property "checked":
qrc:/resources/qml/pages/UserSettingsPage.qml:91:33 (qrc:/resources/qml/pages/UserSettingsPage.qml:90, )
[2025-08-20 22:52:59.784] [qml] [warning] qrc:/resources/qml/pages/UserSettingsPage.qml:127:29: QML SpinBox: Binding loop detected for property "value":
qrc:/resources/qml/pages/UserSettingsPage.qml:137:33 (qrc:/resources/qml/pages/UserSettingsPage.qml:127, )
```

This pull request fixes these warnings.