### PR TITLE
Search for private modules with Qt 6.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,9 @@ endif()
 # Discover Qt dependencies.
 #
 find_package(Qt6 6.5 COMPONENTS Core Widgets Gui LinguistTools Svg Multimedia Qml QuickControls2 REQUIRED)
+if (Qt6Qml_VERSION VERSION_GREATER_EQUAL "6.10.0")
+    find_package(Qt6 REQUIRED COMPONENTS GuiPrivate QmlPrivate)
+endif()
 find_package(Qt6DBus)
 
 if(USE_BUNDLED_QTKEYCHAIN)


### PR DESCRIPTION
Usage of private Qt modules requires a call to

`find_package(Qt6 COMPONENTS FooPrivate)` since 6.10 [1].

The  build complains about

'CMake Error at CMakeLists.txt:909 (target_link_libraries):
  Target "nheko" links to:

    Qt::QmlPrivate

    but the target was not found.'

otherwise.

[1] https://doc-snapshots.qt.io/qt6-dev/whatsnew610.html#build-system-changes