### PR TITLE
Add a setting to send messages with Enter, Shift+Enter or Ctrl+Enter

### DIFF
--- a/resources/qml/MessageInput.qml
+++ b/resources/qml/MessageInput.qml
@@ -170,15 +170,13 @@ Rectangle {
                     } else if (event.matches(StandardKey.SelectAll) && popup.opened) {
                         completer.completerName = "";
                         popup.close();
-                    } else if (event.matches(StandardKey.InsertLineSeparator)) {
-                        if (popup.opened)
-                            popup.close();
-                        if (Settings.invertEnterKey) {
-                            room.input.send();
-                            event.accepted = true;
-                        }
-                    } else if (event.matches(StandardKey.InsertParagraphSeparator)) {
-                        if (popup.opened) {
+                    } else if (event.key == Qt.Key_Enter || event.key == Qt.Key_Return) {
+                        // Handling popup takes priority over newline and sending message.
+                        if (popup.opened &&
+                            (event.modifiers == Qt.NoModifier
+                            || event.modifiers == Qt.ShiftModifier
+                            || event.modifiers == Qt.ControlModifier)
+                        ) {
                             var currentCompletion = completer.currentCompletion();
                             let userid = completer.currentUserid();
 
@@ -191,14 +189,26 @@ Rectangle {
                                     console.log(userid);
                                     room.input.addMention(userid, currentCompletion);
                                 }
-                                event.accepted = true;
-                                return;
                             }
+                            event.accepted = true;
                         }
-                        if (!Settings.invertEnterKey) {
+                        // Send message Enter key combination event.
+                        else if (Settings.sendMessageKey == 0 && event.modifiers == Qt.NoModifier
+                              || Settings.sendMessageKey == 1 && event.modifiers == Qt.ShiftModifier
+                              || Settings.sendMessageKey == 2 && event.modifiers == Qt.ControlModifier
+                        ) {
                             room.input.send();
                             event.accepted = true;
                         }
+                        // Add newline Enter key combination event.
+                        else if (Settings.sendMessageKey == 0 && event.modifiers == Qt.ShiftModifier
+                              || Settings.sendMessageKey == 1 && event.modifiers == Qt.NoModifier
+                              || Settings.sendMessageKey == 2 && event.modifiers == Qt.ShiftModifier
+                        ) {
+                            messageInput.insert(messageInput.cursorPosition, "\n");
+                            event.accepted = true;
+                        }
+                        // Any other Enter key combo is ignored here.
                     } else if (event.key == Qt.Key_Tab && (event.modifiers == Qt.NoModifier || event.modifiers == Qt.ShiftModifier)) {
                         event.accepted = true;
                         if (popup.opened) {

--- a/src/UserSettingsPage.h
+++ b/src/UserSettingsPage.h
@@ -29,8 +29,8 @@ class UserSettings final : public QObject
     Q_PROPERTY(bool scrollbarsInRoomlist READ scrollbarsInRoomlist WRITE setScrollbarsInRoomlist
                  NOTIFY scrollbarsInRoomlistChanged)
     Q_PROPERTY(bool markdown READ markdown WRITE setMarkdown NOTIFY markdownChanged)
-    Q_PROPERTY(
-      bool invertEnterKey READ invertEnterKey WRITE setInvertEnterKey NOTIFY invertEnterKeyChanged)
+    Q_PROPERTY(SendMessageKey sendMessageKey READ sendMessageKey WRITE setSendMessageKey NOTIFY
+                 sendMessageKeyChanged)
     Q_PROPERTY(bool bubbles READ bubbles WRITE setBubbles NOTIFY bubblesChanged)
     Q_PROPERTY(bool smallAvatars READ smallAvatars WRITE setSmallAvatars NOTIFY smallAvatarsChanged)
     Q_PROPERTY(bool animateImagesOnHover READ animateImagesOnHover WRITE setAnimateImagesOnHover
@@ -166,6 +166,14 @@ public:
     };
     Q_ENUM(ShowImage)
 
+    enum class SendMessageKey
+    {
+        Enter,
+        ShiftEnter,
+        CtrlEnter,
+    };
+    Q_ENUM(SendMessageKey)
+
     void save();
     void load(std::optional<QString> profile);
     void applyTheme();
@@ -182,7 +190,7 @@ public:
     void setGroupView(bool state);
     void setScrollbarsInRoomlist(bool state);
     void setMarkdown(bool state);
-    void setInvertEnterKey(bool state);
+    void setSendMessageKey(SendMessageKey key);
     void setBubbles(bool state);
     void setSmallAvatars(bool state);
     void setAnimateImagesOnHover(bool state);
@@ -255,7 +263,7 @@ public:
     bool privacyScreen() const { return privacyScreen_; }
     int privacyScreenTimeout() const { return privacyScreenTimeout_; }
     bool markdown() const { return markdown_; }
-    bool invertEnterKey() const { return invertEnterKey_; }
+    SendMessageKey sendMessageKey() const { return sendMessageKey_; }
     bool bubbles() const { return bubbles_; }
     bool smallAvatars() const { return smallAvatars_; }
     bool animateImagesOnHover() const { return animateImagesOnHover_; }
@@ -328,7 +336,7 @@ signals:
     void trayChanged(bool state);
     void startInTrayChanged(bool state);
     void markdownChanged(bool state);
-    void invertEnterKeyChanged(bool state);
+    void sendMessageKeyChanged(SendMessageKey key);
     void bubblesChanged(bool state);
     void smallAvatarsChanged(bool state);
     void animateImagesOnHoverChanged(bool state);
@@ -399,7 +407,7 @@ private:
     bool groupView_;
     bool scrollbarsInRoomlist_;
     bool markdown_;
-    bool invertEnterKey_;
+    SendMessageKey sendMessageKey_;
     bool bubbles_;
     bool smallAvatars_;
     bool animateImagesOnHover_;
@@ -510,7 +518,7 @@ class UserSettingsModel : public QAbstractListModel
         TypingNotifications,
         ReadReceipts,
         Markdown,
-        InvertEnterKey,
+        SendMessageKey,
         Bubbles,
         SmallAvatars,
 


### PR DESCRIPTION
I'm used to sending messages with Ctrl+Enter, but other users may prefer Shift+Enter or just plain Enter. Previously the option was just `invertEnterKey` boolean, which didn't allow any flexibility, so I replaced it with a three-choice option: Enter, Shift+Enter and Ctrl+Enter being the send message choices. Add newline combos are Shift+Enter, Enter and Shift+Enter respectively.

I ended up fixing the emoji/mention pop-up behavior as a side product. If any of the three combos are pressed, the pop-up is handled and the event is accepted. This makes it impossible to accidentally send the message if a pop-up is open.

If an Enter combo didn't match, it's passed to the next event handler.

The old `invertEnterKey` is migrated to the new `sendMessageKey`, so this change doesn't change the existing preference.

Tested with Linux only, but this should work fine with other platforms as well, thanks to Qt keypress abstraction.

Fixes: #1445 #788 if I'm not mistaken.