### PR TITLE
Properly render special characters in status_msg labels above messages

### DIFF
--- a/resources/qml/TimelineSectionHeader.qml
+++ b/resources/qml/TimelineSectionHeader.qml
@@ -144,7 +144,7 @@ Column {
             font.italic: true
             font.pointSize: Math.floor(fontMetrics.font.pointSize * 0.8)
             text: userStatus.replace(/\n/g, " ")
-            textFormat: Text.PlainText
+            textFormat: Text.RichText
             width: Math.min(implicitWidth, userInfo.remainingWidth - userName_.width - parent.spacing)
 
             HoverHandler {


### PR DESCRIPTION
This fixes cases like the one below, in which special characters are shown as their html codes (e.g., < = `&lt;`, > = `&gt;`, etc), after being set as the plain text version.
<img width="445" height="94" alt="image" src="https://github.com/user-attachments/assets/312eabe0-64d7-4103-a588-c24e3712e51b" />

The specific patch is derived from the fact the status field in UserProfile.qml implicitly uses RichText through its use of MatrixText.qml, which seems close enough to be safe but there may be unknown side effects, as is often the case with text rendering.