### PR TITLE
fix: Remove 15fps limit for screensharing sources

### DIFF
--- a/src/voip/CallDevices.cpp
+++ b/src/voip/CallDevices.cpp
@@ -61,9 +61,7 @@ getFrameRate(const GValue *value)
 void
 addFrameRate(std::vector<std::string> &rates, const FrameRate &rate)
 {
-    constexpr double minimumFrameRate = 15.0;
-    if (static_cast<double>(rate.first) / rate.second >= minimumFrameRate)
-        rates.push_back(std::to_string(rate.first) + "/" + std::to_string(rate.second));
+    rates.push_back(std::to_string(rate.first) + "/" + std::to_string(rate.second));
 }
 
 void


### PR DESCRIPTION
Screensharing on Wayland was crashing, if the source only reports fps < 15fps.
Video sources may report their framerate as 0/1 in which case the framerate is variable, and low fps screenshare (5fps) is an option in the nheko UI, so there is no reason for the 15fps limit.