### PR TITLE
Check username and user ID when filtering timeline

### DIFF
--- a/src/timeline/TimelineFilter.cpp
+++ b/src/timeline/TimelineFilter.cpp
@@ -175,7 +175,9 @@ TimelineFilter::sourceDataChanged(const QModelIndex &topLeft,
                                   const QVector<int> &roles)
 {
     if (!roles.contains(TimelineModel::Roles::Body) && !roles.contains(TimelineModel::ThreadId) &&
-        !roles.contains(TimelineModel::Notificationlevel))
+        !roles.contains(TimelineModel::Notificationlevel) &&
+        !roles.contains(TimelineModel::UserId) &&
+        !roles.contains(TimelineModel::UserName))
         return;
 
     if (auto s = source()) {
@@ -278,10 +280,19 @@ TimelineFilter::filterAcceptsRow(int source_row, const QModelIndex &) const
     if (auto s = sourceModel()) {
         auto idx = s->index(source_row, 0);
 
-        if (!contentFilter.isEmpty() && !s->data(idx, TimelineModel::Body)
-                                           .toString()
-                                           .contains(contentFilter, Qt::CaseInsensitive)) {
-            return false;
+        if (!contentFilter.isEmpty()) {
+            // Check if filter matches sender's user ID, display name or message body.
+            if (!s->data(idx, TimelineModel::UserId)
+                    .toString()
+                    .contains(contentFilter, Qt::CaseInsensitive) &&
+                !s->data(idx, TimelineModel::UserName)
+                    .toString()
+                    .contains(contentFilter, Qt::CaseInsensitive) &&
+                !s->data(idx, TimelineModel::Body)
+                    .toString()
+                    .contains(contentFilter, Qt::CaseInsensitive)) {
+                return false;
+            }
         }
 
         if (filterByNotifications_ && s->data(idx, TimelineModel::Notificationlevel)


### PR DESCRIPTION
Search user name and user ID when invoking filter in chat room.
Implements https://github.com/Nheko-Reborn/nheko/issues/1907

Test:
<img width="389" height="100" alt="изображение" src="https://github.com/user-attachments/assets/6e7a2204-12ea-4103-83f0-30c199d81c11" />
