### PR TITLE
Fix windows UI rendering pallette

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include <QLibraryInfo>
 #include <QMessageBox>
 #include <QPoint>
+#include <QQuickStyle>
 #include <QQuickView>
 #include <QScreen>
 #include <QStandardPaths>
@@ -183,6 +184,11 @@ main(int argc, char *argv[])
             matrixUri = arg;
         }
     }
+#if defined(Q_OS_WIN)
+    // Windows default Qt theme does not support Dark Mode breaking color palette.
+    // https://qt-project.atlassian.net/browse/QTBUG-72028#icft=QTBUG-72028
+    QQuickStyle::setStyle(QStringLiteral("Fusion"));
+#endif
 
     QApplication app(argc, argv);
 


### PR DESCRIPTION
Default Qt rendering style has issue with Windows dark mode (https://qt-project.atlassian.net/browse/QTBUG-72028#icft=QTBUG-72028)

This PR switches windows build to "Fusion" to fix broken UI colora.

# Original

Original "System":
<img width="661" height="551" alt="Снимок экрана 2026-03-12 234506" src="https://github.com/user-attachments/assets/37c7689e-0be5-4d50-a674-47fe663f5349" />

Original "Dark":
<img width="680" height="559" alt="Снимок экрана 2026-03-12 234512" src="https://github.com/user-attachments/assets/f71820b0-21b2-40b4-8e8b-05472304da7f" />

# After fix

Updated "Dark":
<img width="1745" height="1251" alt="изображение" src="https://github.com/user-attachments/assets/003c32d1-6250-41ef-bc18-c6b70ff1bfc0" />

Updated "System":
<img width="1807" height="1240" alt="изображение" src="https://github.com/user-attachments/assets/4cf828e9-1f5f-4d8f-98b4-27f1a77aaf10" />
