### PR TITLE
feat/ui/confirm-dialog-pin-or-unpin-msg

### DIFF
--- a/resources/qml/MessageView.qml
+++ b/resources/qml/MessageView.qml
@@ -436,11 +436,19 @@ Item {
 
             P.MessageDialog {
                 property string eventId
+                property var targetRoom
+
+                Component.onCompleted: {
+                    targetRoom = room;
+                }
 
                 title: qsTr("Pin Message")
                 text: qsTr("Are you sure you want to pin this message?")
                 buttons: P.MessageDialog.Ok | P.MessageDialog.Cancel
-                onOkClicked: room.pin(eventId)
+                onOkClicked: {
+                    if (targetRoom)
+                        targetRoom.pin(eventId)
+                }
             }
         }
 
@@ -449,11 +457,19 @@ Item {
 
             P.MessageDialog {
                 property string eventId
+                property var targetRoom
+
+                Component.onCompleted: {
+                    targetRoom = room;
+                }
 
                 title: qsTr("Unpin Message")
                 text: qsTr("Are you sure you want to unpin this message?")
                 buttons: P.MessageDialog.Ok | P.MessageDialog.Cancel
-                onOkClicked: room.unpin(eventId)
+                onOkClicked: {
+                    if (targetRoom)
+                        targetRoom.unpin(eventId)
+                }
             }
         }
 

--- a/resources/qml/TopBar.qml
+++ b/resources/qml/TopBar.qml
@@ -292,11 +292,16 @@ Pane {
                 id: unpinDialog
 
                 property string eventId
+                property var roomAtOpen
 
                 title: qsTr("Unpin")
                 text: qsTr("Are you sure you want to unpin this message?")
                 buttons: P.MessageDialog.Ok | P.MessageDialog.Cancel
-                onOkClicked: room.unpin(eventId)
+                onOkClicked: {
+                    if (roomAtOpen) {
+                        roomAtOpen.unpin(eventId);
+                    }
+                }
             }
 
             ScrollView {
@@ -353,6 +358,7 @@ Pane {
 
                             onClicked: {
                                 unpinDialog.eventId = modelData;
+                                unpinDialog.roomAtOpen = room;
                                 unpinDialog.open();
                             }
                         }


### PR DESCRIPTION
Adds a confirmation dialog before pinning or unpinning messages, since accidentally clicking it have undesired behavior.

Feature was requested on official matrix server for the app a few days ago.

-----------------------

I had a bug briefly (now fixed & not in git history here) that caused the dialog to open every startup/app launch.

Application behavior now seems good after playing with/testing it :+1:

<img width="324" height="125" alt="Screenshot_20260319_155410-1" src="https://github.com/user-attachments/assets/98c57acb-eec5-461f-bd52-1bb8ed182fc9" />
<img width="338" height="121" alt="Screenshot_20260319_155801" src="https://github.com/user-attachments/assets/df4a9c6e-6bb9-43ab-a218-a92521734a38" />