### PR TITLE
Fix system theme with kvantum theme manager

### DIFF
--- a/src/ui/Theme.cpp
+++ b/src/ui/Theme.cpp
@@ -2,12 +2,14 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include <QGuiApplication>
+
 #include "Theme.h"
 
 QPalette
 Theme::paletteFromTheme(QStringView theme)
 {
-    static QPalette original;
+    static QPalette original = QGuiApplication::palette();
     if (theme == u"light") {
         static QPalette lightActive = [] {
             QPalette lightActive(


### PR DESCRIPTION
It seems that QPalette defaults to a basic light theme on kvantum which nheko will then add some colors to. This doesn’t match the system theme I have set up and is actually entirely unusable.

As recommended in the QT Docs:

> We strongly recommend that you use the default palette of the current
> style (returned by QGuiApplication::palette()) and modify that as
> necessary. This is done by Qt's widgets when they are drawn.
https://doc.qt.io/qt-6/qpalette.html#:~:text=QGuiApplication%3A%3Apalette%28%29%29

This commit will set the default value of the application palette to QGuiApplication::palette().

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a24db7cf-95e6-4139-b646-e9c79b8f0c83" />
Before the patch

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0162f7b4-2ed2-44e5-a18e-9efdb3f0669a" />
After the patch

The issue has been described before here: https://github.com/Nheko-Reborn/nheko/issues/759#issuecomment-2561103133