### PR TITLE
Trim whitespace characters before adding Matrix address to model

### DIFF
--- a/src/AliasEditModel.cpp
+++ b/src/AliasEditModel.cpp
@@ -146,7 +146,7 @@ AliasEditingModel::deleteAlias(int row)
 void
 AliasEditingModel::addAlias(QString newAlias)
 {
-    const auto aliasStr = newAlias.toStdString();
+    const auto aliasStr = newAlias.trimmed().toStdString();
     for (const auto &e : std::as_const(aliases)) {
         if (e.alias == aliasStr) {
             return;


### PR DESCRIPTION
I had to add a bunch of addresses to some rooms and noticed that copying entire lines from a text document using Ctrl+C didn't work because the newline character wasn't being trimmed off. You could even see the list elements being offset because of it.