### PR TITLE
Add support for custom matrix.to domains

### DIFF
--- a/resources/qml/pages/UserSettingsPage.qml
+++ b/resources/qml/pages/UserSettingsPage.qml
@@ -257,6 +257,48 @@ Rectangle {
                                 text: model.value
                             }
                         }
+
+                        DelegateChoice {
+                            roleValue: UserSettingsModel.MultiLineText
+
+                            ColumnLayout {
+                                width: parent.width
+                                spacing: Nheko.paddingSmall
+                                ScrollView {
+                                    Layout.fillWidth: true
+                                    Layout.preferredHeight: 150
+                                    clip: true
+
+                                    TextArea {
+                                        id: multiLineInput
+
+                                        text: {
+                                            if (model.value === undefined || model.value === null) return "";
+                                            if (typeof model.value === "string") return model.value;
+                                            return model.value.join("\n");
+                                        }
+
+                                        color: palette.text
+                                        wrapMode: TextEdit.WrapAnywhere
+                                        selectByMouse: true
+
+                                        background: Rectangle {
+                                            color: palette.base
+                                            border.color: multiLineInput.activeFocus ? palette.highlight : palette.mid
+                                            border.width: 1
+                                            radius: 3
+                                        }
+
+                                        onEditingFinished: {
+                                            let lines = text.split("\n")
+                                                .map(line => line.trim())
+                                                .filter(line => line.length > 0);
+                                            model.value = lines;
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/src/UserSettingsPage.cpp
+++ b/src/UserSettingsPage.cpp
@@ -94,6 +94,8 @@ UserSettings::load(std::optional<QString> profile)
     sortByAlphabet_       = settings.value("user/sort_by_alphabet", false).toBool();
     readReceipts_         = settings.value("user/read_receipts", true).toBool();
     theme_                = settings.value("user/theme", defaultTheme_).toString();
+    matrixToDomains_ =
+      settings.value("user/matrix_to_domains", defaultMatrixToDomains_).toStringList();
 
     font_ = settings.value("user/font_family", "").toString();
 
@@ -667,6 +669,16 @@ UserSettings::setTheme(QString theme)
 }
 
 void
+UserSettings::setMatrixToDomains(QStringList domains)
+{
+    if (domains == matrixToDomains_)
+        return;
+    matrixToDomains_ = domains;
+    save();
+    emit matrixToDomainsChanged(domains);
+}
+
+void
 UserSettings::setUseStunServer(bool useStunServer)
 {
     if (useStunServer == useStunServer_)
@@ -955,6 +967,7 @@ UserSettings::save()
     settings.setValue("desktop_notifications", hasDesktopNotifications_);
     settings.setValue("alert_on_notification", hasAlertOnNotification_);
     settings.setValue("theme", theme());
+    settings.setValue("matrix_to_domains", matrixToDomains_);
     settings.setValue("font_family", font_);
     settings.setValue("emoji_font_family", emojiFont_);
     settings.setValue("ringtone", ringtone_);
@@ -1046,6 +1059,8 @@ UserSettingsModel::data(const QModelIndex &index, int role) const
         switch (index.row()) {
         case Theme:
             return tr("Theme");
+        case MatrixToDomains:
+            return tr("matrix.to domains");
         case ScaleFactor:
             return tr("Scale factor");
         case MessageHoverHighlight:
@@ -1201,6 +1216,8 @@ UserSettingsModel::data(const QModelIndex &index, int role) const
         switch (index.row()) {
         case Theme:
             return themes.indexOf(i->theme());
+        case MatrixToDomains:
+            return i->matrixToDomains();
         case ScaleFactor:
             return utils::scaleFactor();
         case MessageHoverHighlight:
@@ -1346,6 +1363,8 @@ UserSettingsModel::data(const QModelIndex &index, int role) const
     } else if (role == Description) {
         switch (index.row()) {
         case Theme:
+        case MatrixToDomains:
+            return tr("Choose domains to handle as matrix.to links");
         case Font:
         case EmojiFont:
             return {};
@@ -1557,6 +1576,8 @@ UserSettingsModel::data(const QModelIndex &index, int role) const
         case ShowImage:
         case SendMessageKey:
             return Options;
+        case MatrixToDomains:
+            return MultiLineText;
         case TimelineMaxWidth:
         case PrivacyScreenTimeout:
             return Integer;
@@ -1765,6 +1786,13 @@ UserSettingsModel::setData(const QModelIndex &index, const QVariant &value, int 
 
             if (idx >= 0 && idx < themes.size()) {
                 i->setTheme(themes[idx]);
+                return true;
+            } else
+                return false;
+        }
+        case MatrixToDomains: {
+            if (value.canConvert<QStringList>()) {
+                i->setMatrixToDomains(value.toStringList());
                 return true;
             } else
                 return false;
@@ -2263,6 +2291,9 @@ UserSettingsModel::UserSettingsModel(QObject *p)
     auto s = UserSettings::instance();
     connect(s.get(), &UserSettings::themeChanged, this, [this]() {
         emit dataChanged(index(Theme), index(Theme), {Value});
+    });
+    connect(s.get(), &UserSettings::matrixToDomainsChanged, this, [this]() {
+        emit dataChanged(index(MatrixToDomains), index(MatrixToDomains), {Value});
     });
     connect(s.get(), &UserSettings::mobileModeChanged, this, [this]() {
         emit dataChanged(index(MobileMode), index(MobileMode), {Value});

--- a/src/UserSettingsPage.h
+++ b/src/UserSettingsPage.h
@@ -19,6 +19,8 @@ class UserSettings final : public QObject
     QML_SINGLETON
 
     Q_PROPERTY(QString theme READ theme WRITE setTheme NOTIFY themeChanged)
+    Q_PROPERTY(QStringList matrixToDomains READ matrixToDomains WRITE setMatrixToDomains NOTIFY
+                 matrixToDomainsChanged)
     Q_PROPERTY(bool messageHoverHighlight READ messageHoverHighlight WRITE setMessageHoverHighlight
                  NOTIFY messageHoverHighlightChanged)
     Q_PROPERTY(bool enlargeEmojiOnlyMessages READ enlargeEmojiOnlyMessages WRITE
@@ -178,6 +180,7 @@ public:
     void load(std::optional<QString> profile);
     void applyTheme();
     void setTheme(QString theme);
+    void setMatrixToDomains(QStringList domains);
     void setMessageHoverHighlight(bool state);
     void setEnlargeEmojiOnlyMessages(bool state);
     void setTray(bool state);
@@ -248,6 +251,10 @@ public:
     void setExpireEvents(bool state);
 
     QString theme() const { return !theme_.isEmpty() ? theme_ : defaultTheme_; }
+    QStringList matrixToDomains() const
+    {
+        return !matrixToDomains_.isEmpty() ? matrixToDomains_ : defaultMatrixToDomains_;
+    }
     bool messageHoverHighlight() const { return messageHoverHighlight_; }
     bool enlargeEmojiOnlyMessages() const { return enlargeEmojiOnlyMessages_; }
     bool tray() const { return tray_; }
@@ -331,6 +338,7 @@ signals:
     void roomSortingChangedImportance(bool state);
     void roomSortingChangedAlphabetical(bool state);
     void themeChanged(QString state);
+    void matrixToDomainsChanged(QStringList state);
     void messageHoverHighlightChanged(bool state);
     void enlargeEmojiOnlyMessagesChanged(bool state);
     void trayChanged(bool state);
@@ -400,6 +408,7 @@ private:
                               ? "light"
                               : "system";
     QString theme_;
+    QStringList matrixToDomains_;
     bool messageHoverHighlight_;
     bool enlargeEmojiOnlyMessages_;
     bool tray_;
@@ -461,6 +470,7 @@ private:
     QStringList hiddenPins_;
     QStringList hiddenWidgets_;
     QStringList recentReactions_;
+    QStringList defaultMatrixToDomains_ = {"matrix.to"};
     QList<QStringList> collapsedSpaces_;
     bool useIdenticon_;
     bool openImageExternal_;
@@ -484,6 +494,7 @@ class UserSettingsModel : public QAbstractListModel
     {
         GeneralSection,
         Theme,
+        MatrixToDomains,
         MobileMode,
         DisableSwipe,
 #ifndef Q_OS_MACOS
@@ -586,6 +597,7 @@ public:
     {
         Toggle,
         ReadOnlyText,
+        MultiLineText,
         Options,
         Integer,
         Double,

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -2171,9 +2171,11 @@ utils::parseMatrixUri(QString uri)
 {
     QUrl uri_{uri};
 
-    // Convert matrix.to URIs to proper format
-    if (uri_.scheme() == QLatin1String("https") && uri_.host() == QLatin1String("matrix.to")) {
+    QStringList domains = UserSettings::instance()->matrixToDomains();
+    if (uri_.scheme() == QLatin1String("https") && domains.contains(uri_.host())) {
         QString p = uri_.fragment(QUrl::FullyEncoded);
+        if (p.startsWith(QLatin1String("/room")) || p.startsWith(QLatin1String("/user")))
+            p.remove(0, 5);
         if (p.startsWith(QLatin1String("/")))
             p.remove(0, 1);
 


### PR DESCRIPTION
This adds support for custom matrix.to domains as well as Element's generated links when using custom domains.

I added a multiline text input that I then cut by newlines. I don't know if it's the most appropriate way in QT to manage this.

I added the removal of `/room` and `/user` that Element adds for some reason... Otherwise the generated links are usable.