### PR TITLE
reaction: unescape user list displayed in tooltip

### DIFF
--- a/src/timeline/Reaction.h
+++ b/src/timeline/Reaction.h
@@ -19,7 +19,7 @@ struct Reaction
 public:
     QString key() const { return key_; }
     QString displayKey() const { return key_.toHtmlEscaped().remove(QStringLiteral(u"\ufe0f")); }
-    QString users() const { return users_.toHtmlEscaped(); }
+    QString users() const { return users_; }
     QString selfReactedEvent() const { return selfReactedEvent_; }
     int count() const { return count_; }
 


### PR DESCRIPTION
Unescapes ampersand characters in usernames shown in reaction tooltips. For example, `test1&2` will now display as that rather than `test1&amp;2`.