### PR TITLE
Changed the UI order of the ImagePack editor

### DIFF
--- a/resources/qml/dialogs/ImagePackEditorDialog.qml
+++ b/resources/qml/dialogs/ImagePackEditorDialog.qml
@@ -49,8 +49,24 @@ ApplicationWindow {
 
                 model: imagePack
 
+                header: Button {
+                    onClicked: addFilesDialog.open()
+                    width: ListView.view.width
+                    text: qsTr("Add images")
 
-                header: AvatarListTile {
+                    FileDialog {
+                        id: addFilesDialog
+
+                        folder: StandardPaths.writableLocation(StandardPaths.PicturesLocation)
+                        fileMode: FileDialog.OpenFiles
+                        nameFilters: [qsTr("Images (*.png *.webp *.gif *.jpg *.jpeg)")]
+                        title: qsTr("Select images for pack")
+                        acceptLabel: qsTr("Add to pack")
+                        onAccepted: imagePack.addStickers(files)
+                    }
+                }
+
+                footer: AvatarListTile {
                     title: imagePack.packname
                     avatarUrl: imagePack.avatarUrl
                     roomid: imagePack.statekey
@@ -72,23 +88,6 @@ ApplicationWindow {
 
                 }
 
-                footer: Button {
-                    onClicked: addFilesDialog.open()
-                    width: ListView.view.width
-                    text: qsTr("Add images")
-
-                    FileDialog {
-                        id: addFilesDialog
-
-                        folder: StandardPaths.writableLocation(StandardPaths.PicturesLocation)
-                        fileMode: FileDialog.OpenFiles
-                        nameFilters: [qsTr("Images (*.png *.webp *.gif *.jpg *.jpeg)")]
-                        title: qsTr("Select images for pack")
-                        acceptLabel: qsTr("Add to pack")
-                        onAccepted: imagePack.addStickers(files)
-                    }
-
-                }
 
                 delegate: AvatarListTile {
                     id: packItem


### PR DESCRIPTION
Changed the order of the sticker editor dialogue, so the "Add images" button is at the top.
I attached an image of what it should look like now (my stickers have been covered with a rectangle for the image)
If a sticker pack has a lot of stickers in it, then you have to scroll all the way to the bottom to add a new sticker, which is annoying, so I moved it to the top.

<img width="300" height="300" alt="newui" src="https://github.com/user-attachments/assets/5a576994-dea4-4ae0-9540-d58bef2622b2" />
