### PR TITLE
Move OpenSSL lookup before Libevent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,11 @@ if(BUILD_DOCS)
     endif(DOXYGEN_FOUND)
 endif()
 
+if(USE_BUNDLED_OPENSSL)
+    hunter_add_package_safe(OpenSSL)
+endif()
+find_package(OpenSSL 1.1.0 REQUIRED)
+
 #
 ## coeurl
 #
@@ -539,10 +544,6 @@ set(SRC_FILES
 
 include(FeatureSummary)
 
-if(USE_BUNDLED_OPENSSL)
-    hunter_add_package_safe(OpenSSL)
-endif()
-find_package(OpenSSL 1.1.0 REQUIRED)
 if(USE_BUNDLED_OLM)
     include(FetchContent)
     FetchContent_Declare(


### PR DESCRIPTION
On a clean Windows checkout, CMake configure fails with:

  Could NOT find OpenSSL (missing: OPENSSL_LIBRARIES OPENSSL_INCLUDE_DIR)
  Call Stack:
    LibeventConfig.cmake:47 (find_dependency)
    CMakeLists.txt:165 (find_package)

This happens even with -DUSE_BUNDLED_OPENSSL=ON.

Cause is ordering. Libevent's config file calls find_dependency(OpenSSL),
and that is reached from CMakeLists.txt:165. hunter_add_package_safe(OpenSSL)
does not run until line 542. Since CMake processes the file top to bottom,
hunter has not set up OpenSSL yet when Libevent asks for it, so Libevent
falls back to looking for a system OpenSSL, which is not present on a clean
machine.

This patch moves the OpenSSL block above the Libevent lookup. It is a no-op
anywhere a system OpenSSL already exists, which is probably why it does not
reproduce on the GitLab Windows runner.

Verified on a clean GitHub Actions windows-latest runner: with this change
build.bat completes and produces a working nheko.exe. Without it, configure
fails as above, but build.bat continues past the failure and exits 0, so the
run reports success and nheko_win_64.zip ends up containing only
qtjdenticon.dll.